### PR TITLE
ci: update workflow actions to latest major versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - run: npx tsc --noEmit
       - run: npm run coverage
       - name: Upload frontend coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: drmowinckels/entracte
@@ -66,7 +66,7 @@ jobs:
         run: cargo llvm-cov --manifest-path src-tauri/Cargo.toml --lib --lcov --output-path src-tauri/lcov.info
       - name: Upload Rust coverage to Codecov
         if: matrix.platform == 'ubuntu-22.04'
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: drmowinckels/entracte
@@ -206,7 +206,7 @@ jobs:
 
       - name: Post / update sticky PR comment
         if: always() && github.event_name == 'pull_request'
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@v3
         with:
           header: advisory-audit
           path: advisory-comment.md


### PR DESCRIPTION
## Summary
- Bump `codecov/codecov-action` v5 → v6 (both upload steps in [ci.yml](.github/workflows/ci.yml))
- Bump `marocchino/sticky-pull-request-comment` v2 → v3 ([ci.yml](.github/workflows/ci.yml))

Both major bumps are node24 runtime updates with no API changes. All other actions across `ci.yml`, `docs.yml`, and `release.yml` were already current.

## Test plan
- [x] CI runs successfully on this PR
- [x] Codecov uploads (frontend + rust) succeed
- [x] Advisory sticky comment posts/updates on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)