### PR TITLE
docs: point stale #31 refs at their new public issues

### DIFF
--- a/docs/developer/architecture-internals.md
+++ b/docs/developer/architecture-internals.md
@@ -105,7 +105,7 @@ All user files are written via `secure_io::write_user_only` — an atomic `tempf
 
 `Scheduler` holds seven `tokio::sync::Mutex` fields (settings, pause_state, timers, stats, screen_time, profiles, active_profile_name) plus one `std::sync::Mutex<Option<BreakEvent>>` for the renderer-bound `current_break` slot. The struct is `Clone` — each clone bumps the inner `Arc`s, no deep copy.
 
-Most handlers acquire several locks in sequence. **There's no documented lock order yet** (see [#31](https://github.com/drmowinckels/entracte/issues/31)). The convention in practice:
+Most handlers acquire several locks in sequence. **There's no documented lock order yet** (see [#14](https://github.com/drmowinckels/entracte/issues/14)). The convention in practice:
 
 1. `settings` first (cloned out immediately so it's not held across awaits).
 2. `pause_state` and the AtomicBools (`camera_active`, `video_active`, `auto_suppressed`, `hook_dialog_busy`) next.
@@ -152,7 +152,5 @@ The backend → renderer / tray surface is just Tauri events. The renderer subsc
 
 What's _not_ covered yet:
 
-- Integration test driving `run_loop` with a frozen clock.
-- Serde roundtrip parity between the Rust `Settings` and the TS `SchedulerSettings`.
-
-Both are tracked in [#31](https://github.com/drmowinckels/entracte/issues/31).
+- Integration test driving `run_loop` with a frozen clock — tracked in [#10](https://github.com/drmowinckels/entracte/issues/10).
+- Serde roundtrip parity between the Rust `Settings` and the TS `SchedulerSettings` — tracked in [#13](https://github.com/drmowinckels/entracte/issues/13).

--- a/docs/developer/contributing.md
+++ b/docs/developer/contributing.md
@@ -74,7 +74,7 @@ See the [IPC contract](./ipc) for the existing surface.
 3. Render a control on the relevant tab under `src/views/settings/tabs/`.
 4. If you're adding a new field that the scheduler should react to, wire it into `run_loop.rs` and add a test.
 
-The serde defaults make missing fields harmless on older `settings.json` files, but the TS type drift is not enforced by anything yet (see [#31](https://github.com/drmowinckels/entracte/issues/31) for the parity-test idea).
+The serde defaults make missing fields harmless on older `settings.json` files, but the TS type drift is not enforced by anything yet (see [#13](https://github.com/drmowinckels/entracte/issues/13) for the parity-test idea).
 
 ## Adding a break suppression / guard
 


### PR DESCRIPTION
## What changed

Three developer-docs links pointed at \`issues/31\` in the pre-public repo and didn't resolve under \`drmowinckels/entracte\`. The old #31 was a bundle issue covering three separate concerns; each now points at the right destination:

- TS/Rust settings parity test → new issue [#13](https://github.com/drmowinckels/entracte/issues/13)
- Documented Scheduler lock-ordering convention → new issue [#14](https://github.com/drmowinckels/entracte/issues/14)
- Integration test driving \`run_loop\` with a frozen clock → existing issue [#10](https://github.com/drmowinckels/entracte/issues/10) (the Tauri test rig already covers this)

Files touched:

- [docs/developer/contributing.md:77](docs/developer/contributing.md) — parity-test ref → #13
- [docs/developer/architecture-internals.md:108](docs/developer/architecture-internals.md) — lock-order ref → #14
- [docs/developer/architecture-internals.md:158](docs/developer/architecture-internals.md) — the "Both are tracked in #31" line is split inline so each item carries its own link

## Verification

- \`grep -rn "/issues/3[0-9]" docs/ README.md CONTRIBUTING.md .github/\` returns nothing.
- \`cd docs && npm run build\` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)