### PR TITLE
docs: add pronunciation note (ahn-TRAHKT, not en-tract)

### DIFF
--- a/.github/audit/cspell/project-words.txt
+++ b/.github/audit/cspell/project-words.txt
@@ -150,3 +150,4 @@ TEAMID
 TRAHKT
 trahkt
 ahn
+tʁakt

--- a/.github/audit/cspell/project-words.txt
+++ b/.github/audit/cspell/project-words.txt
@@ -147,3 +147,6 @@ shinephoenixstormcrow
 Daitokuji
 codesigned
 TEAMID
+TRAHKT
+trahkt
+ahn

--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 <h1 align="center">Entracte</h1>
 
 <p align="center">
+  <em>Pronounced "ahn-TRAHKT" (French <em>entracte</em>, IPA /ɑ̃.tʁakt/) — not "en-tract".</em>
+</p>
+
+<p align="center">
   A cross-platform break reminder app for macOS, Windows, and Linux —<br/>
   named after the theatre interval between acts.
 </p>

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -1,5 +1,9 @@
 # Getting started
 
+::: tip Pronounced "ahn-TRAHKT"
+**Entracte** is French for the interval between acts of a play — IPA `/ɑ̃.tʁakt/`. "En-tract" with a hard _t_ is the common-but-incorrect English reading; we say it the French way.
+:::
+
 Entracte runs as a menu bar / tray app. After launching it, you'll see a small stage-arch icon in the system tray — that's the only entry point. There is no Dock icon on macOS, by design.
 
 ## First minute

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ layout: home
 hero:
   name: Entracte
   text: Breaks that respect your flow.
-  tagline: A cross-platform break reminder app, named after the theatre interval between acts.
+  tagline: A cross-platform break reminder app, named after the theatre interval between acts. Pronounced "ahn-TRAHKT", not "en-tract".
   image:
     src: /logo_gradient.svg
     alt: Entracte logo


### PR DESCRIPTION
## What changed

Pronunciation lands in three places — wherever a new user actually shows up:

- [README.md](README.md) — italic line directly under the H1, before the rest of the hero copy.
- [docs/index.md](docs/index.md) — extends the VitePress hero \`tagline\`.
- [docs/guide/getting-started.md](docs/guide/getting-started.md) — \`::: tip\` callout at the top of the first guide page.

All three carry the same phrasing: "ahn-TRAHKT" as the English-friendly respelling, IPA \`/ɑ̃.tʁakt/\` for the curious, and "en-tract" called out explicitly so readers can pattern-match their own mispronunciation.

[.github/audit/cspell/project-words.txt](.github/audit/cspell/project-words.txt) gets "TRAHKT", "trahkt", and "ahn" allowlisted so the audit job doesn't reject the respelling.

## Out of scope

The narrower problem — VoiceOver and other screen readers reading the word wrong — needs a different fix (an \`aria-label\` override on user-facing instances of the product name, or a phonetic SSML hint). That decision belongs in [#8](https://github.com/drmowinckels/entracte/issues/8) (the broader VoiceOver audit) so the trade-offs around "spoken vs visible text" can be considered together.

## Verification

- \`cd docs && npm run build\` succeeds.
- The new strings appear once each on rendered \`/\` and \`/guide/getting-started\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)