### PR TITLE
fix: scheduler doc link points at the old single-file path

### DIFF
--- a/docs/architecture/scheduler.md
+++ b/docs/architecture/scheduler.md
@@ -1,6 +1,6 @@
 # Scheduler
 
-The scheduler is a 1 Hz Tokio loop in [scheduler.rs](https://github.com/drmowinckels/entracte/blob/main/src-tauri/src/scheduler.rs). Every second it walks a priority cascade. First match wins; all other timers reset.
+The scheduler is a 1 Hz Tokio loop in [scheduler/run_loop.rs](https://github.com/drmowinckels/entracte/blob/main/src-tauri/src/scheduler/run_loop.rs), part of the [scheduler module](https://github.com/drmowinckels/entracte/tree/main/src-tauri/src/scheduler). Every second it walks a priority cascade. First match wins; all other timers reset.
 
 ## The cascade
 


### PR DESCRIPTION
## What changed

[docs/architecture/scheduler.md](docs/architecture/scheduler.md) linked to \`src-tauri/src/scheduler.rs\`, which 404s — the file was split into \`scheduler/{mod,run_loop,settings,timers,pause,…}.rs\` during an earlier refactor. The lychee link-check job flagged it on PR #16.

Updated to:

- **Primary link**: \`scheduler/run_loop.rs\` — that's where the 1Hz loop actually lives now.
- **Secondary link**: the [scheduler module directory](https://github.com/drmowinckels/entracte/tree/main/src-tauri/src/scheduler) so a reader can browse the rest of the split.

## Verification

- \`grep "src-tauri/src/scheduler\\.rs" docs/\` returns nothing outside \`.vitepress/dist/\` (which is a build artifact).
- \`gh api repos/drmowinckels/entracte/contents/src-tauri/src/scheduler/run_loop.rs\` returns 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)