### PR TITLE
chore(ci): skip Checks workflow on pure-docs / pure-meta PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,30 @@
 name: Checks
 
+# Skip the app test matrix on changes that can't break the app:
+# pure docs, READMEs, contributor guides, issue templates, and the
+# adjacent workflow files. A mixed PR (e.g. docs + a code tweak) still
+# triggers — paths-ignore only skips when every changed file is ignored.
+#
+# `workflow_dispatch` ignores path filters, so a manual rerun always
+# runs the full suite if needed.
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
+      - ".github/ISSUE_TEMPLATE/**"
+      - ".github/workflows/docs.yml"
+      - ".github/workflows/docs-preview.yml"
+      - ".github/workflows/release.yml"
   pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
+      - ".github/ISSUE_TEMPLATE/**"
+      - ".github/workflows/docs.yml"
+      - ".github/workflows/docs-preview.yml"
+      - ".github/workflows/release.yml"
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## What changed

The \`Checks\` workflow ([.github/workflows/ci.yml](.github/workflows/ci.yml)) now skips the frontend + Rust + audit matrix when a PR only touches files that can't break the app: \`docs/**\`, any \`*.md\`, \`.github/ISSUE_TEMPLATE/**\`, and the sibling workflow files (\`docs.yml\`, \`docs-preview.yml\`, \`release.yml\`).

A mixed PR (e.g. docs + a code tweak) still triggers, because \`paths-ignore\` only skips when **every** changed file is in the ignore list.

## Design notes

- **\`paths-ignore\` instead of \`paths\`.** Negative filter so we don't have to maintain a positive allow-list of every config file at root or under \`.github/audit/**\`. New build-relevant files trigger CI by default, which is the safer direction to lean.
- **\`workflow_dispatch\` ignores path filters.** A manual rerun via the Actions UI always runs the full suite — no need to fake a code change to trigger a recheck.
- **No branch-protection conflict.** \`gh api .../branches/main/protection\` confirms no required status checks are configured, so a "skipped" run doesn't block merge.

## Verification

- \`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"\` parses.
- This PR touches only \`.github/workflows/ci.yml\` (a file NOT in the ignore list), so it should itself trigger the full Checks matrix as a sanity check that the workflow still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)