### PR TITLE
chore: add CNAME for entracte.drmowinckels.io

### DIFF
--- a/docs/public/CNAME
+++ b/docs/public/CNAME
@@ -1,0 +1,1 @@
+entracte.drmowinckels.io


### PR DESCRIPTION
## What changed

[docs/public/CNAME](docs/public/CNAME) → \`entracte.drmowinckels.io\`. VitePress copies \`public/*\` into \`dist/\`, so the CNAME ends up at the root where GitHub Pages reads it.

## What you need to do on the registrar side

Add **one DNS record** in drmowinckels.io's DNS:

| Type | Name | Value | TTL |
|---|---|---|---|
| \`CNAME\` | \`entracte\` | \`drmowinckels.github.io\` | default (often 3600) |

Some registrars (Cloudflare, Namecheap) don't allow CNAMEs on subdomains that share zone with a non-A record — if so, use the A/AAAA quad instead:

| Type | Name | Value |
|---|---|---|
| \`A\` | \`entracte\` | \`185.199.108.153\` |
| \`A\` | \`entracte\` | \`185.199.109.153\` |
| \`A\` | \`entracte\` | \`185.199.110.153\` |
| \`A\` | \`entracte\` | \`185.199.111.153\` |
| \`AAAA\` | \`entracte\` | \`2606:50c0:8000::153\` |
| \`AAAA\` | \`entracte\` | \`2606:50c0:8001::153\` |
| \`AAAA\` | \`entracte\` | \`2606:50c0:8002::153\` |
| \`AAAA\` | \`entracte\` | \`2606:50c0:8003::153\` |

CNAME is simpler if your registrar allows it.

## Order of operations — safe to land this PR anytime

The CNAME file alone is harmless without DNS. GH Pages keeps serving at \`drmowinckels.github.io/entracte\` until the DNS lookup resolves, and surfaces a "DNS check failed" yellow banner in Settings → Pages until then. Once DNS resolves:

1. GH Pages auto-detects the new domain on the next deploy and updates Settings → Pages.
2. Let's Encrypt cert provisions automatically (~5-10 min).
3. \`drmowinckels.github.io/entracte\` starts 301-redirecting to \`entracte.drmowinckels.io\`.

## Follow-up (not in this PR)

The site will be reachable at \`entracte.drmowinckels.io/entracte/...\` because VitePress is still configured with \`base: "/entracte/"\`. Once DNS is verified, a small follow-up PR can switch \`base\` to \`/\` so the path component drops — that's gated on confirming the custom domain serves correctly first, because otherwise we lose the GH Pages production URL during the transition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)