### PR TITLE
docs: refresh landing page feature cards + add screenshot and pre-release notice

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -30,20 +30,28 @@ features:
     linkText: Why each kind matters
   - icon: 🤫
     title: Knows when to stay quiet
-    details: Skips when Do Not Disturb is on, your camera is in use, you've gone idle, or you're outside your work hours.
-  - icon: ⏸
-    title: Pause from the tray
-    details: One-click pause for 15m, 30m, 1h, 2h, 4h, until tomorrow 6am, or indefinitely.
-  - icon: 🖥
-    title: Multi-monitor aware
-    details: One borderless overlay per display, no Space-hopping fullscreen tricks.
-  - icon: 🔔
-    title: Pre-break heads-up
-    details: Optional notification a configurable number of seconds before each break, so the overlay never surprises you.
+    details: Skips when Do Not Disturb is on, your camera is in use, you've gone idle, or you're outside your work hours. One borderless overlay per monitor when it does fire.
+  - icon: 👤
+    title: Profiles for every mode
+    details: Switch from the tray between "Deep work", "Meetings", "Weekend"… each carries its own intervals, hint pool, and sound. Inherit-from-active when you create a new one.
+  - icon: 💭
+    title: Wellness hints, not nag screens
+    details: Each break shows one of a rotating pool of prompts — physical stretches, breathing cues, social nudges. Edit the pool, mix the categories, swap in your own.
+  - icon: 📊
+    title: Insights you can actually use
+    details: 84-day heatmap, time-of-day distribution, suppression-reason breakdown, daily screen-time budget with reminders. Export to CSV when you want it elsewhere.
   - icon: 🦀
     title: Native and lightweight
-    details: Rust + Tauri 2 core. Small binary, low idle CPU, no Electron.
+    details: Rust + Tauri 2 core. Small binary, low idle CPU, no Electron. Local-only — no telemetry, no cloud sync, no account.
 ---
+
+<div style="text-align: center; margin: 3rem 0 1rem;">
+  <img src="/screenshots/break-overlay-active.png" alt="A micro break overlay: countdown ring at 10 seconds with the prompt 'Sip some water.' and Postpone / Skip buttons" style="max-width: 720px; width: 100%; border-radius: 8px; box-shadow: 0 4px 20px rgba(0,0,0,0.15);" />
+</div>
+
+::: warning Pre-release
+No tagged binaries yet — installing currently means [building from source](/guide/install). The release pipeline is in place; the first `v0.1.0` will land on the [Releases page](https://github.com/drmowinckels/entracte/releases) once it's cut.
+:::
 
 <div style="text-align: center; margin-top: 2rem;">
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,18 +31,28 @@ features:
   - icon: 🤫
     title: Knows when to stay quiet
     details: Skips when Do Not Disturb is on, your camera is in use, you've gone idle, or you're outside your work hours. One borderless overlay per monitor when it does fire.
+    link: /guide/settings#quiet-times
+    linkText: How the guards work
   - icon: 👤
     title: Settings profiles
     details: Save multiple named profiles and swap between them from the tray. Each carries its own intervals, hints, and sound.
+    link: /guide/settings#profiles
+    linkText: Profiles overview
   - icon: 💭
     title: Wellness hints, not nag screens
     details: Each break shows one of a curated pool of prompts — physical stretches, breathing cues, social nudges. Mix the categories or rotate between them on a cadence you set.
+    link: /guide/settings#breaks
+    linkText: Tune the hint mix
   - icon: 📊
     title: Insights you can actually use
     details: 84-day heatmap, time-of-day distribution, suppression-reason breakdown, daily screen-time budget with reminders. Export to CSV when you want it elsewhere.
+    link: /guide/settings#insights
+    linkText: What Insights tracks
   - icon: 🦀
     title: Native and lightweight
     details: Rust + Tauri 2 core. Small binary, low idle CPU, no Electron. Local-only — no telemetry, no cloud sync, no account.
+    link: /architecture/
+    linkText: How it's built
 ---
 
 <div style="text-align: center; margin: 3rem 0 1rem;">

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,11 +32,11 @@ features:
     title: Knows when to stay quiet
     details: Skips when Do Not Disturb is on, your camera is in use, you've gone idle, or you're outside your work hours. One borderless overlay per monitor when it does fire.
   - icon: 👤
-    title: Profiles for every mode
-    details: Switch from the tray between "Deep work", "Meetings", "Weekend"… each carries its own intervals, hint pool, and sound. Inherit-from-active when you create a new one.
+    title: Settings profiles
+    details: Save multiple named profiles and swap between them from the tray. Each carries its own intervals, hints, and sound.
   - icon: 💭
     title: Wellness hints, not nag screens
-    details: Each break shows one of a rotating pool of prompts — physical stretches, breathing cues, social nudges. Edit the pool, mix the categories, swap in your own.
+    details: Each break shows one of a curated pool of prompts — physical stretches, breathing cues, social nudges. Mix the categories or rotate between them on a cadence you set.
   - icon: 📊
     title: Insights you can actually use
     details: 84-day heatmap, time-of-day distribution, suppression-reason breakdown, daily screen-time budget with reminders. Export to CSV when you want it elsewhere.


### PR DESCRIPTION
## What changed

[docs/index.md](docs/index.md) — three discrete improvements layered into one PR since they all share the same edit and the same review surface.

### 1. Feature cards refreshed

The previous 6 cards were heavy on infrastructure differentiators that the Architecture docs already cover better. Swapped three out for user-facing features that landed since but were missing from the landing entirely.

| Was | Now |
|---|---|
| 🎭 Three kinds of break | 🎭 *(kept)* |
| 🤫 Knows when to stay quiet | 🤫 *(kept, multi-monitor folded in)* |
| ⏸ Pause from the tray | 👤 **Profiles for every mode** |
| 🖥 Multi-monitor aware | 💭 **Wellness hints, not nag screens** |
| 🔔 Pre-break heads-up | 📊 **Insights you can actually use** |
| 🦀 Native and lightweight | 🦀 *(kept, local-only stance folded in)* |

Pause-from-tray and pre-break heads-up are operational details, better placed in the guide than burning a headline slot.

### 2. Inline screenshot

Visitors could only see a break overlay by clicking through to Getting Started or the README. Now there's one on the landing page itself ([docs/screenshots/break-overlay-active.png](docs/screenshots/break-overlay-active.png), the same asset the README uses), centred and shadowed.

### 3. Pre-release warning callout

\`::: warning Pre-release\` block pointing at the Install guide and the empty Releases page. Sets the expectation that "Install" currently means build from source rather than letting someone hit the empty release listing first.

## Verification

- \`cd docs && npm run build\` succeeds.
- Once merged, the Netlify preview URL on this PR shows the new layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)