### PR TITLE
ci(lychee): promote to merge-blocking + VitePress-aware resolution

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -163,16 +163,16 @@ Audits run in CI but every one is invokable locally. Configs live in [.github/au
 | JS bundle size budget                    | `npm run audit:size`           | size-limit           | hard                   |
 | Accessibility (axe + console-error gate) | `npm run audit:a11y`           | puppeteer + axe-core | hard                   |
 | Rust licenses + CVEs + dupes             | `npm run audit:rust`           | cargo-deny           | advisory               |
-| Broken links in `*.md`                   | `npm run audit:links`          | lychee               | advisory               |
+| Broken links in `*.md`                   | `npm run audit:links`          | lychee               | hard                   |
 | npm CVEs                                 | `npm audit --audit-level=high` | npm                  | advisory               |
 
-The `audit` CI job runs the hard-fail ones; the `advisory` job runs the rest with `continue-on-error: true` and aggregates findings into a sticky PR comment via `marocchino/sticky-pull-request-comment`.
+The `audit` CI job runs the always-hard-fail ones (knip / cspell / size-limit / a11y). The `advisory` job runs cargo-deny + lychee + npm audit with `continue-on-error: true` per-step so all three reports reach the sticky PR comment via `marocchino/sticky-pull-request-comment` — but a final step re-surfaces the lychee outcome as a job failure, so lychee breakage blocks merges.
 
 **knip warnings vs errors:** unused exports / types / duplicates are configured as `warn` (reported but exit-0) since legitimate API surface and parity-test-referenced types would otherwise force noisy ignores. Genuinely unused dependencies are still hard-fail.
 
 **cspell project dictionary:** [`.github/audit/cspell/project-words.txt`](audit/cspell/project-words.txt) — add new words alphabetically-ish under a relevant comment if you can.
 
-**lychee 404 expectations:** GitHub `blob/tree/issues/` URLs to this repo only resolve after a commit lands on `main`; treat first-run lychee failures as transient.
+**lychee scope:** in-repo GitHub URLs (`github.com/drmowinckels/entracte/{blob,tree,issues,pull,commit}/…`) are excluded in [`.github/audit/lychee.toml`](audit/lychee.toml) because they only resolve after the referencing commit lands on `main` — checking them on PR runs would 404 every time the PR adds a link to the repo. Broken in-repo links surface as 404s in the rendered docs anyway.
 
 ## CI / deployment
 
@@ -182,7 +182,7 @@ Three workflows in [.github/workflows/](workflows/):
   - **frontend** (ubuntu): `tsc --noEmit`, `npm run coverage`, `npm run build`, `audit:a11y`. Uploads `coverage/lcov.info` to Codecov with flag `frontend`.
   - **rust** (macOS + ubuntu + windows matrix): `cargo fmt --check`, `cargo clippy -D warnings`, `cargo test`. Ubuntu also runs `cargo llvm-cov` and uploads `src-tauri/lcov.info` to Codecov with flag `rust`, plus `cargo doc -D warnings` (catches broken intra-doc links).
   - **audit** (ubuntu, hard-fail): knip + cspell + size-limit.
-  - **advisory** (ubuntu, `continue-on-error: true`): cargo-deny + lychee + npm audit, results posted as a sticky PR comment.
+  - **advisory** (ubuntu): cargo-deny + lychee + npm audit, results posted as a sticky PR comment. Step-level `continue-on-error: true` keeps the comment posting even when an audit fails; a final step re-fails the job on lychee breakage so broken links block merges.
 - **[docs.yml](workflows/docs.yml)** — runs on push to `main` when `docs/**`, `src/**`, `src-tauri/**`, or `.config/typedoc/**` change. Builds the VitePress site + rustdoc + TypeDoc, deploys to GitHub Pages.
 - **[docs-preview.yml](workflows/docs-preview.yml)** — runs on `pull_request` against the same path set. Mirrors the production docs build and pushes the result to Netlify as a per-PR preview, then sticky-comments the URL on the PR. Requires `NETLIFY_AUTH_TOKEN` (user token) and `NETLIFY_SITE_ID` (per-site) repo secrets. Skips fork PRs (no secret access). Production deploys stay on GitHub Pages via `docs.yml` — Netlify is preview-only.
 - **[release.yml](workflows/release.yml)** — runs on `v*` tag push (or `workflow_dispatch`). Full bundle via `tauri-action` across all platforms, creates a draft GitHub release.

--- a/.github/audit/lychee.toml
+++ b/.github/audit/lychee.toml
@@ -19,6 +19,20 @@ exclude = [
   # rustdoc / TypeDoc output: generated into the built site at /api/{rust,ts}/,
   # not present in source.
   '/api/(rust|ts)/',
+  # In-repo GitHub URLs (blob/tree/issues/pull/commit). These only
+  # resolve after the referencing commit lands on main, so on PR runs
+  # they 404 even when the link is correct. The lychee gate is now
+  # merge-blocking, so excluding them avoids spurious failures —
+  # broken in-repo links surface as 404s in the rendered docs anyway.
+  '^https?://github\.com/drmowinckels/entracte/(blob|tree|issues|pull|commit)/',
+  # VitePress mounts `docs/public/` at the site root, so `/audio/...`
+  # and similar public-mounted assets don't exist under `docs/` — they
+  # live under `docs/public/`. The `--root-dir docs` invocation handles
+  # everything else, but the public-mounted prefixes need an URL-form
+  # exclude (lychee resolves them to `file:///…/docs/audio/…` before
+  # matching against this list). Add new public asset dirs here as they
+  # appear.
+  'file://.*?/docs/audio/',
 ]
 
 exclude_path = [

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,8 +123,10 @@ jobs:
 
   # Advisory audits: surface signal without blocking merges.
   # cargo-deny covers licenses + CVEs + duplicate-version checks.
-  # lychee + npm audit are externally-validated and can flap, so they're
-  # advisory; promote to hard-fail once stable.
+  # npm audit is externally-validated and can flap, so it stays advisory.
+  # lychee is now merge-blocking — its step keeps `continue-on-error`
+  # so cargo-deny / npm-audit / the sticky-comment all still run, but
+  # the job's final step exits non-zero if lychee flagged any link.
   # Findings are aggregated into one sticky PR comment.
   advisory:
     runs-on: ubuntu-22.04
@@ -162,7 +164,7 @@ jobs:
         continue-on-error: true
         uses: lycheeverse/lychee-action@v2
         with:
-          args: --config .github/audit/lychee.toml --no-progress "**/*.md"
+          args: --config .github/audit/lychee.toml --root-dir "${{ github.workspace }}/docs" --no-progress "**/*.md"
           output: audit-reports/lychee.md
           fail: true
         env:
@@ -231,3 +233,16 @@ jobs:
         with:
           header: advisory-audit
           path: advisory-comment.md
+
+      # lychee is the only audit in this job that blocks merges. Keeping
+      # the step-level `continue-on-error: true` lets cargo-deny, npm
+      # audit, and the sticky comment all run to completion; this final
+      # step then re-surfaces the lychee outcome as a job failure so the
+      # `advisory` check goes red.
+      - name: Fail if lychee found broken links
+        if: always()
+        run: |
+          if [ "${{ steps.lychee.outcome }}" = "failure" ]; then
+            echo "::error::lychee found broken links — see the sticky PR comment above for details"
+            exit 1
+          fi

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "audit:knip": "knip --config .github/audit/knip.json",
     "audit:spell": "cspell --no-progress --config .github/audit/cspell.json \"**/*.{md,ts,tsx}\"",
     "audit:size": "npm run build && size-limit",
-    "audit:links": "lychee --config .github/audit/lychee.toml \"**/*.md\"",
+    "audit:links": "lychee --config .github/audit/lychee.toml --root-dir \"$PWD/docs\" \"**/*.md\"",
     "audit:rust": "cd src-tauri && cargo deny check",
     "doc": "typedoc --options .config/typedoc/typedoc.json",
     "tauri": "tauri"


### PR DESCRIPTION
## Summary

Lychee was advisory because it flapped on two known cases:

1. In-repo GitHub URLs (\`github.com/drmowinckels/entracte/{blob,tree,issues,pull,commit}/…\`) only resolve after the referencing commit lands on \`main\`, so PR runs 404 on any new link to the repo.
2. VitePress root-relative paths (\`/audio/…\`, \`/guide/install\`) — lychee can't resolve them against the filesystem because content lives in \`docs/\` and assets live in \`docs/public/\`.

Both are now handled, and the lychee step is wired to block merges.

## Changes

- **[\`.github/audit/lychee.toml\`](.github/audit/lychee.toml)**:
  - Exclude in-repo GitHub URLs (transient on PRs; broken in-repo links surface as 404s in the rendered docs anyway).
  - Exclude the \`file://…/docs/audio/\` prefix that VitePress mounts from \`docs/public/\` (lychee resolves \`/audio/…\` against \`--root-dir\` before applying excludes, hence the resolved-URL form).
- **[\`package.json\`](package.json) + [\`.github/workflows/ci.yml\`](.github/workflows/ci.yml)**: pass \`--root-dir docs\` so root-relative routes like \`/guide/install\` resolve against the content tree. The existing \`fallback_extensions = [\"md\", \"html\"]\` picks up the \`.md\` source.
- **[\`.github/workflows/ci.yml\`](.github/workflows/ci.yml)**: keep \`continue-on-error: true\` on the lychee step so cargo-deny, npm audit, and the sticky comment all still run on a lychee failure; add a final \`Fail if lychee found broken links\` step that re-surfaces the lychee outcome as a job failure. The \`advisory\` check now goes red on broken links.
- **[\`.github/AGENTS.md\`](.github/AGENTS.md)**: lychee row in the audit table flips from \`advisory\` to \`hard\`; the workflow description and the transient-failure note are rewritten.

## Test plan

- [x] \`npm run audit:links\` is clean locally on this branch (246 links, 43 excluded, 0 errors).
- [ ] CI on this PR shows the \`advisory\` check passing (lychee + cargo-deny + npm-audit all clean, sticky comment posted).
- [ ] Verify by introducing a deliberate broken link in a follow-up PR that the \`advisory\` check goes red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)