### PR TITLE
docs: rename sched → scheduler in lock-ordering example for cspell

### DIFF
--- a/docs/developer/architecture-internals.md
+++ b/docs/developer/architecture-internals.md
@@ -112,17 +112,17 @@ All user files are written via `secure_io::write_user_only` — an atomic `tempf
 The pattern in code:
 
 ```rust
-let s = sched.settings.lock().await.clone();      // released at `;`
-let name = sched.active_profile_name.lock().await.clone();
-let mut profiles = sched.profiles.lock().await;   // safe — others released
+let s = scheduler.settings.lock().await.clone();      // released at `;`
+let name = scheduler.active_profile_name.lock().await.clone();
+let mut profiles = scheduler.profiles.lock().await;   // safe — others released
 ```
 
 Following this rule, deadlock becomes structurally impossible — the classic "A holds X waiting for Y, B holds Y waiting for X" cycle cannot form if guards never overlap on `.await`.
 
 **What it rules out:**
 
-- `let s = sched.settings.lock().await; let p = sched.profiles.lock().await;` (holding `settings` across the `profiles` acquisition).
-- `let g = sched.timers.lock().await; some_async_fn(&sched).await;` (holding any guard across a call that may itself lock the same scheduler).
+- `let s = scheduler.settings.lock().await; let p = scheduler.profiles.lock().await;` (holding `settings` across the `profiles` acquisition).
+- `let g = scheduler.timers.lock().await; some_async_fn(&scheduler).await;` (holding any guard across a call that may itself lock the same scheduler).
 
 **What it allows:**
 


### PR DESCRIPTION
Hotfix for main. PR #28 squash-merged before the cspell follow-up commit landed, so main shipped \`sched\` in the lock-ordering code example. Every downstream PR's \`audit\` job is now failing on cspell:

> docs/developer/architecture-internals.md:115:9 - Unknown word (sched)

Rename to \`scheduler\` (matches the real variable name used in the worked \`commands::hooks::set_hooks\` example a few lines below).

After merge, PRs #26, #27, #29 will need a rebase / merge of main to clear their \`audit\` checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)