### PR TITLE
docs: genericize supporter-pack notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Full command reference, IPC details, and tips in [docs/guide/cli.md](docs/guide/
 
 Entracte is free, cross-platform, and open source under Apache 2.0. Every scheduling, suppression, profile, hooks, stats, accessibility, and CLI feature is available to everyone.
 
-If you'd like to support development, a **Supporter pack** unlocks personalisation extras — custom overlay colour, theme rotation, editable break hints, custom sounds — through a one-off Lemon Squeezy license key. The unlock check lives in plain source: it's an honour-system thank-you, not a DRM scheme. See [docs/guide/supporter.md](docs/guide/supporter.md).
+A **Supporter pack** is in the works as a way to back development — personalisation extras like custom overlay colour, theme rotation, editable break hints, and custom sounds will unlock through a one-off purchase once the infrastructure is in place. The unlock check lives in plain source: it's an honour-system thank-you, not a DRM scheme. See [docs/guide/supporter.md](docs/guide/supporter.md).
 
 ## Stack
 

--- a/docs/guide/settings.md
+++ b/docs/guide/settings.md
@@ -123,10 +123,10 @@ The overlay tries to be friendly to a range of needs.
 ## Supporter pack
 
 ::: warning Coming soon — work in progress
-Purchase and license activation are temporarily hidden in **About → Supporter** while the Lemon Squeezy store is under review (~10 days). All the gated features below are in the codebase; only the storefront is missing. See the [Supporter pack page](./supporter) for the full status.
+Purchase and license activation are temporarily hidden in **About → Supporter** while we set up the storefront infrastructure. All the gated features below are in the codebase; only the storefront is missing. See the [Supporter pack page](./supporter) for the full status.
 :::
 
-Entracte is free and open source. A small set of personalisation extras is gated behind the supporter pack — a one-time Lemon Squeezy purchase that funds continued development. Nothing in the scheduling, suppression, profile, hooks, stats, accessibility, or CLI surface is gated; the defaults remain usable forever.
+Entracte is free and open source. A small set of personalisation extras will be gated behind the supporter pack — a one-time purchase that funds continued development, once the infrastructure is in place. Nothing in the scheduling, suppression, profile, hooks, stats, accessibility, or CLI surface is gated; the defaults remain usable forever.
 
 | Tab                  | Setting             | What it unlocks                                                                                                                                     |
 | -------------------- | ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -136,4 +136,4 @@ Entracte is free and open source. A small set of personalisation extras is gated
 | Breaks → Custom CSS  | **Stylesheet**      | Freeform CSS injected into the settings window and the break overlay for full visual customisation.                                                 |
 | Schedule → Sound     | **Custom file…**    | Point each break kind at your own audio file (end-chime or looping ambient).                                                                        |
 
-Activation lives in **About → Supporter** in Preferences. The key is machine-bound, validated against Lemon Squeezy once a day, and tolerates 30 days offline before it re-locks. See [Supporter pack](./supporter) for the full purchase, activation, and on-disk-storage details.
+Activation lives in **About → Supporter** in Preferences. The key is machine-bound, revalidated once a day, and tolerates 30 days offline before it re-locks. See [Supporter pack](./supporter) for the full purchase, activation, and on-disk-storage details.

--- a/docs/guide/settings.md
+++ b/docs/guide/settings.md
@@ -8,7 +8,7 @@ Settings persist automatically as plain JSON in the platform app-data directory 
 Most non-obvious settings carry a small ⓘ icon next to the label — hover or focus it for a short explanation. Power-user options are tucked behind a **Show advanced** disclosure in each section.
 :::
 
-A small handful of personalisation extras are part of the [Supporter pack](./supporter) — flagged inline below and consolidated in the [Supporter pack](#supporter-pack) section at the end.
+A small handful of personalisation extras are part of the [Supporter pack](./supporter) and flagged inline below.
 
 ## Schedule
 
@@ -36,9 +36,9 @@ Bedtime (Sleep) is hard-coded to full-screen Overlay and ignores this setting.
 
 The Breaks tab covers what breaks look and sound like, and the escape hatches.
 
-- **Overlay** — transparency, text size, theme (Dark / Midnight / Forest / Rose / Sunset — plus Rotate and Custom in the [Supporter pack](#supporter-pack)), wellness hints toggle, current time toggle. Advanced disclosure adds **monitor placement**, **high contrast**, and the **break-health vignette** that intensifies as you skip more breaks. (Whether a break renders full-screen or windowed is part of the per-kind **Mode** dropdown in the Schedule tab — see [Break mode](#break-mode-per-kind) below.)
+- **Overlay** — transparency, text size, theme (Dark / Midnight / Forest / Rose / Sunset — plus Rotate and Custom in the [Supporter pack](./supporter)), wellness hints toggle, current time toggle. Advanced disclosure adds **monitor placement**, **high contrast**, and the **break-health vignette** that intensifies as you skip more breaks. (Whether a break renders full-screen or windowed is part of the per-kind **Mode** dropdown in the Schedule tab — see [Break mode](#break-mode-per-kind) below.)
 - **Sound** — chime theme and volume, with a Preview button.
-- **Break ideas** — optional rotation toggle (off by default — one idea is picked per break and stays on screen; turn on to cycle through the pool every N seconds), plus a **Mix** selector for Micro (Physical / Psychological / Both) and Long (Solo / Social / Both — Social prompts you to call someone, walk with a colleague, or share a coffee). The curated default pools cover every category out of the box; editing the pool text is a [Supporter pack](#supporter-pack) feature.
+- **Break ideas** — optional rotation toggle (off by default — one idea is picked per break and stays on screen; turn on to cycle through the pool every N seconds), plus a **Mix** selector for Micro (Physical / Psychological / Both) and Long (Solo / Social / Both — Social prompts you to call someone, walk with a colleague, or share a coffee). The curated default pools cover every category out of the box; editing the pool text is a [Supporter pack](./supporter) feature.
 - **Skip & postpone** — Strict mode (no skip, no postpone, all breaks enforced), postpone toggle and minutes, optional postpone escalation (each postpone of the same break adds extra delay), and one-shot **Skip next micro / Skip next long** buttons.
 
 ### Monitor placement
@@ -105,7 +105,7 @@ These controls live under **Breaks → Overlay**. The overlay is always dark (it
 
 </div>
 
-The **Theme** dropdown ships with five presets — Dark, Midnight, Forest, Rose, Sunset — available to everyone. Two additional entries, **Rotate** and **Custom…**, are part of the [Supporter pack](#supporter-pack).
+The **Theme** dropdown ships with five presets — Dark, Midnight, Forest, Rose, Sunset — available to everyone. Two additional entries, **Rotate** and **Custom…**, are part of the [Supporter pack](./supporter).
 
 ## Accessibility
 
@@ -119,21 +119,3 @@ The overlay tries to be friendly to a range of needs.
 - **Screen readers** get a `role="dialog"` overlay with an `aria-live="polite"` announcement when each break starts ("Long break started. 10 minutes remaining."). The countdown timer carries an `aria-label` that reads as e.g. "9 minutes 30 seconds remaining" so navigating to it via screen-reader cursor speaks something meaningful.
 - **Keyboard** — `Esc` skips the break. Postpone, Skip, and "I'm back" reach focus in DOM order; the high-contrast theme adds a yellow focus ring for visibility.
 - **Font size** — the **Text size** slider under **Breaks → Overlay** scales every text element in the overlay from 80% to 160%, so users who prefer larger text don't have to squint at hint or countdown.
-
-## Supporter pack
-
-::: warning Coming soon — work in progress
-Purchase and license activation are temporarily hidden in **About → Supporter** while we set up the storefront infrastructure. All the gated features below are in the codebase; only the storefront is missing. See the [Supporter pack page](./supporter) for the full status.
-:::
-
-Entracte is free and open source. A small set of personalisation extras will be gated behind the supporter pack — a one-time purchase that funds continued development, once the infrastructure is in place. Nothing in the scheduling, suppression, profile, hooks, stats, accessibility, or CLI surface is gated; the defaults remain usable forever.
-
-| Tab                  | Setting             | What it unlocks                                                                                                                                     |
-| -------------------- | ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Breaks → Overlay     | **Theme = Custom…** | Pick any colour via hex input or the native colour picker (with synchronised controls and an auto-darken cap so the overlay still dims the screen). |
-| Breaks → Overlay     | **Theme = Rotate**  | A different preset per break, never the same one twice in a row.                                                                                    |
-| Breaks → Break ideas | **Edit hint pools** | Add / remove / rewrite the prompts shown during a break. Mix selectors and rotation cadence remain free.                                            |
-| Breaks → Custom CSS  | **Stylesheet**      | Freeform CSS injected into the settings window and the break overlay for full visual customisation.                                                 |
-| Schedule → Sound     | **Custom file…**    | Point each break kind at your own audio file (end-chime or looping ambient).                                                                        |
-
-Activation lives in **About → Supporter** in Preferences. The key is machine-bound, revalidated once a day, and tolerates 30 days offline before it re-locks. See [Supporter pack](./supporter) for the full purchase, activation, and on-disk-storage details.

--- a/docs/guide/supporter.md
+++ b/docs/guide/supporter.md
@@ -12,13 +12,15 @@ It's intentionally light: nothing core depends on it. Every scheduling, suppress
 
 ## What's in it
 
-- **Custom overlay colour** — pick any hex or use the colour picker, on top of the built-in themes.
-- **Theme rotation** — the `Rotate` option shuffles between your preset palettes break to break.
-- **Editable break hints** — customise the prompts shown during a break, or rotate your own list.
-- **Custom sounds** — point each break kind at your own audio file (end-chime or looping ambient).
-- **Custom CSS** — freeform stylesheet injected into the settings window and the break overlay for full visual customisation.
+| Tab                  | Setting             | What it unlocks                                                                                                                                     |
+| -------------------- | ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Breaks → Overlay     | **Theme = Custom…** | Pick any colour via hex input or the native colour picker (with synchronised controls and an auto-darken cap so the overlay still dims the screen). |
+| Breaks → Overlay     | **Theme = Rotate**  | A different preset per break, never the same one twice in a row.                                                                                    |
+| Breaks → Break ideas | **Edit hint pools** | Add / remove / rewrite the prompts shown during a break. Mix selectors and rotation cadence remain free.                                            |
+| Breaks → Custom CSS  | **Stylesheet**      | Freeform CSS injected into the settings window and the break overlay for full visual customisation.                                                 |
+| Schedule → Sound     | **Custom file…**    | Point each break kind at your own audio file (end-chime or looping ambient).                                                                        |
 
-The defaults remain available even after your key expires, so you'll never lose access to a break you've configured — only the ability to edit personalisation while the key is inactive.
+Nothing in the scheduling, suppression, profile, hooks, stats, accessibility, or CLI surface is gated; the defaults remain usable forever. If your key later goes inactive you'll never lose access to a break you've configured — only the ability to edit personalisation while the key is inactive.
 
 ## How to get one
 

--- a/docs/guide/supporter.md
+++ b/docs/guide/supporter.md
@@ -1,7 +1,7 @@
 # Supporter pack
 
 ::: warning Coming soon — work in progress
-The supporter pack itself is wired end-to-end in the app, but the [Lemon Squeezy](https://lemonsqueezy.com/) storefront is still under review. **Purchase and license activation are temporarily hidden** in the **About → Supporter** tab while we wait for approval — expected within ~10 days from this note.
+The supporter pack itself is wired end-to-end in the app, but the storefront infrastructure is still being set up. **Purchase and license activation are temporarily hidden** in the **About → Supporter** tab while we get the payment flow in place.
 
 In the meantime the pack ships as source-only: every gated feature is in the codebase and unlocks for anyone running a build with a valid record, but there's no way to buy a key yet. Nothing in the free experience is affected.
 :::
@@ -23,15 +23,15 @@ The defaults remain available even after your key expires, so you'll never lose 
 ## How to get one
 
 1. Open Entracte → tray menu → **About** → **Supporter** → **Become a supporter →**.
-2. Pay through Lemon Squeezy. They're the merchant of record, so they handle VAT and sales tax wherever you are.
-3. The receipt email contains your license key.
+2. Complete checkout through the payment partner. They'll act as merchant of record, handling VAT and sales tax wherever you are.
+3. The receipt email will contain your license key.
 4. Back in **About → Supporter**, paste the key and click **Verify**.
 
 The key is bound to the machine you activate it on. You can remove it from one machine and activate it on another at any time.
 
 ## How the key is stored and validated
 
-Activation calls the [Lemon Squeezy License API](https://docs.lemonsqueezy.com/api/license-keys) and stores a small `supporter.json` in Entracte's app-data directory:
+Activation calls the license API and stores a small `supporter.json` in Entracte's app-data directory:
 
 - **macOS** — `~/Library/Application Support/app.entracte/supporter.json`
 - **Windows** — `%APPDATA%\app.entracte\supporter.json`

--- a/src/views/settings/tabs/about-tab.tsx
+++ b/src/views/settings/tabs/about-tab.tsx
@@ -102,9 +102,9 @@ export function AboutTab({ supporter }: { supporter: UseSupporter }) {
               break hints — is unlocked by becoming a supporter once, forever.
             </p>
             <p className="about-meta">
-              <strong>Coming soon.</strong> The Lemon Squeezy store is still
-              under review; purchase and license activation will go live once
-              the storefront is approved. Until then, the pack ships as
+              <strong>Coming soon.</strong> The storefront infrastructure is
+              still being set up; purchase and license activation will go live
+              once the payment flow is in place. Until then, the pack ships as
               source-only.
             </p>
           </>


### PR DESCRIPTION
## Summary

- Reword the user-facing supporter-pack notice in `README.md`, `docs/guide/supporter.md`, `docs/guide/settings.md`, and the About tab to a generic "storefront infrastructure being set up" framing.
- Drop direct mentions of the payment processor from user-facing prose — the storefront isn't live yet and the specifics shouldn't be baked into the docs.
- Backend code comments and the API constant in `src-tauri/src/supporter.rs` are left as-is (implementation, not user-facing copy).

## Test plan

- [ ] `docs/guide/supporter.md` and `docs/guide/settings.md` render correctly in VitePress preview.
- [ ] About → Supporter tab in Settings shows the reworded "Coming soon" notice for non-supporters.
- [ ] No remaining "Lemon Squeezy" references in `README.md`, `docs/`, or `src/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)