### PR TITLE
test(a11y): lock overlay ARIA contract (refs #8)

### DIFF
--- a/src/views/break-overlay.test.tsx
+++ b/src/views/break-overlay.test.tsx
@@ -1,6 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { act, fireEvent, render, waitFor, within } from "@testing-library/react";
+import { announceBreak, dialogLabel, remainingAriaLabel } from "../lib/a11y";
 import { DEFAULT_OVERLAY_SETTINGS } from "./break-overlay/types";
+import type { AnnouncedKind } from "../lib/a11y";
 import type { BreakEvent } from "./break-overlay/types";
 
 type Handler = (event: { payload: unknown }) => void;
@@ -220,4 +222,64 @@ describe("BreakOverlay action handlers", () => {
     fireEvent.keyDown(window, { key: "Escape" });
     expect(invokeMock).toHaveBeenCalledWith("end_break", { reason: "dismissed" });
   });
+});
+
+describe("BreakOverlay ARIA contract", () => {
+  afterEach(() => {
+    listeners.clear();
+    currentBreak = null;
+  });
+
+  it("non-strict mode exposes a dialog and no alert region", async () => {
+    const { getByRole, queryByRole, getByLabelText } = await startBreak(false);
+    getByRole("dialog", { name: dialogLabel("micro") });
+    expect(queryByRole("alert")).toBeNull();
+    getByLabelText(remainingAriaLabel(sampleBreak.duration_secs));
+  });
+
+  it("strict mode exposes an assertive alert region and no dialog", async () => {
+    const { getByRole, queryByRole } = await startBreak(true, {
+      enforceable: true,
+      postpone_available: false,
+    });
+    expect(queryByRole("dialog")).toBeNull();
+    const alert = getByRole("alert");
+    expect(alert.textContent).toBe(
+      announceBreak("micro", sampleBreak.duration_secs),
+    );
+    expect(alert.getAttribute("aria-live")).toBe("assertive");
+  });
+
+  const kinds: ReadonlyArray<{
+    kind: AnnouncedKind;
+    duration: number;
+  }> = [
+    { kind: "micro", duration: 30 },
+    { kind: "long", duration: 300 },
+    { kind: "sleep", duration: 600 },
+  ];
+
+  it.each(kinds)(
+    "non-strict dialog name matches dialogLabel($kind)",
+    async ({ kind, duration }) => {
+      const { getByRole } = await startBreak(false, {
+        kind,
+        duration_secs: duration,
+      });
+      getByRole("dialog", { name: dialogLabel(kind) });
+    },
+  );
+
+  it.each(kinds)(
+    "strict alert text matches announceBreak($kind, $duration) exactly",
+    async ({ kind, duration }) => {
+      const { getByRole } = await startBreak(true, {
+        kind,
+        duration_secs: duration,
+        enforceable: true,
+        postpone_available: false,
+      });
+      expect(getByRole("alert").textContent).toBe(announceBreak(kind, duration));
+    },
+  );
 });


### PR DESCRIPTION
## Summary

Adds a regression rail for the screen-reader-relevant ARIA exposure on the break overlay so a future rename or strict-mode swap breaks a test instead of silently dropping the AT contract. Implements only the *Automated, today* bullet from #8.

New `describe("BreakOverlay ARIA contract", ...)` block in `src/views/break-overlay.test.tsx`:

- **Non-strict micro**: dialog reachable by accessible name, no `role=alert` element, countdown reachable via `getByLabelText(remainingAriaLabel(30))`.
- **Strict micro**: no dialog, the `role=alert` element's text equals `announceBreak("micro", 30)` exactly, `aria-live="assertive"` locked on the alert (the issue's open question about VO actually interrupting hinges on this attribute, so we lock it explicitly).
- **Kind variants (table-driven)**: dialog accessible name matches `dialogLabel(kind)` for `micro` / `long` / `sleep` in non-strict mode.
- **Live-region text contract**: alert text equals `announceBreak(kind, durationSecs)` exactly across the same kinds in strict mode.

Tests import `dialogLabel` / `announceBreak` / `remainingAriaLabel` from `src/lib/a11y.ts` rather than hard-coding strings — the helper unit tests in `src/lib/a11y.test.ts` already own the string shape, so this file only catches drift between the component and the helper. Queries use `@testing-library/react`'s ARIA-tree API (`getByRole`, `queryByRole`, `getByLabelText`) so the test is driven by the same tree screen readers see, not by class names or test ids.

## What stays open in #8

- Manual VoiceOver / NVDA / Orca audit pass.
- Per-OS defect issues filed off the manual pass.
- Developer-facing AT-contract doc in `docs/developer/`.
- Playwright accessibility-tree snapshots (`page.accessibility.snapshot()`) as a coarser net than axe.

Refs #8.

## Test plan

- [x] `npm test -- src/views/break-overlay.test.tsx` (22 tests, was 14)
- [x] `npm test` (362 tests, all green)
- [x] `npm run typecheck` clean
- [x] No changes to `src/views/break-overlay.tsx`, `src/lib/a11y.ts`, or `scripts/audit-a11y.mjs`

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>