### PR TITLE
docs(install): add official-release section + SignPath Foundation mention

### DIFF
--- a/docs/guide/install.md
+++ b/docs/guide/install.md
@@ -15,6 +15,8 @@ Tagged releases appear on the [Releases page](https://github.com/drmowinckels/en
 
 Both `.dmg` builds are code-signed and notarised with an Apple Developer ID certificate, so macOS Gatekeeper opens them without the "unidentified developer" warning. Mount the disk image, drag **Entracte** into Applications, eject.
 
+A [Homebrew Cask](https://brew.sh/) is also planned — once submitted and accepted by `homebrew-cask`, you'll be able to install via `brew install --cask entracte` and let Homebrew handle upgrades.
+
 ### Windows
 
 - `Entracte_<version>_x64-setup.exe` — NSIS installer

--- a/docs/guide/install.md
+++ b/docs/guide/install.md
@@ -1,8 +1,36 @@
 # Install
 
 ::: tip Pre-release
-Entracte does not yet have official binary releases. For now, run from source. The release pipeline is in place — signed bundles will land here as soon as the first `v*` tag is cut.
+Entracte does not yet have official binary releases. The release pipeline is in place — signed bundles will land here as soon as the first `v*` tag is cut. Until then, [build from source](#build-from-source).
 :::
+
+## Download official builds
+
+Tagged releases appear on the [Releases page](https://github.com/drmowinckels/entracte/releases) with signed installers for every supported platform. Pick the artefact that matches your OS and architecture.
+
+### macOS
+
+- `Entracte_<version>_aarch64.dmg` — Apple Silicon (M-series)
+- `Entracte_<version>_x64.dmg` — Intel
+
+Both `.dmg` builds are code-signed and notarised with an Apple Developer ID certificate, so macOS Gatekeeper opens them without the "unidentified developer" warning. Mount the disk image, drag **Entracte** into Applications, eject.
+
+### Windows
+
+- `Entracte_<version>_x64-setup.exe` — NSIS installer
+- `Entracte_<version>_x64_en-US.msi` — MSI for managed deployment
+
+Windows installers are code-signed by the [SignPath Foundation](https://signpath.org/) under their free open-source code-signing programme, with certificate issuance and signing infrastructure provided by [SignPath.io](https://signpath.io/). SmartScreen recognises the publisher and lets the installer run without the "unrecognised publisher" warning.
+
+Double-click the installer; the standard Windows installation wizard takes over.
+
+### Linux
+
+- `entracte_<version>_amd64.AppImage` — portable, single binary
+- `entracte_<version>_amd64.deb` — Debian, Ubuntu, and derivatives
+- `entracte-<version>-1.x86_64.rpm` — Fedora, openSUSE, and derivatives
+
+AppImage: `chmod +x entracte_*.AppImage && ./entracte_*.AppImage`. For `.deb` / `.rpm`, install via your package manager (e.g. `sudo apt install ./entracte_*.deb`). Linux builds aren't per-binary code-signed — the ecosystem relies on repository signatures instead.
 
 ## Build from source
 
@@ -30,7 +58,3 @@ npm run tauri build
 The bundle ends up in `src-tauri/target/release/bundle/` — platform-specific subdirectories for `.dmg`, `.msi`, `.AppImage`, `.deb`, etc.
 
 Without signing secrets, macOS and Windows will warn about the unsigned binary. That's expected.
-
-## When binaries land
-
-Watch the [releases page](https://github.com/drmowinckels/entracte/releases) — once tagged builds start shipping, they'll appear there with installers for macOS (Intel + Apple Silicon), Windows, and Linux.


### PR DESCRIPTION
## Summary

- Add per-platform download instructions for tagged releases to [docs/guide/install.md](docs/guide/install.md): macOS `.dmg` (Apple Silicon + Intel), Windows `.exe` / `.msi`, Linux AppImage / `.deb` / `.rpm`.
- Document that Windows installers are code-signed by the [SignPath Foundation](https://signpath.org/) under their free open-source code-signing programme, with infrastructure from [SignPath.io](https://signpath.io/). This acknowledgement on the download URL is a SignPath Foundation approval requirement.
- Keep "build from source" intact; tighten the pre-release tip so it cross-links to the build section.

The new content describes what users will find on the [Releases page](https://github.com/drmowinckels/entracte/releases) once the first `v*` tag is cut — so the page is ready when SignPath onboarding completes.

## Test plan

- [ ] `docs/guide/install.md` renders correctly in VitePress (headings, lists, intra-page anchor `#build-from-source`).
- [ ] SignPath Foundation and SignPath.io links resolve.
- [ ] No remaining references to the old "When binaries land" footer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)