### PR TITLE
docs(developer): lead-priority pass + why-sentences in contributing

### DIFF
--- a/docs/developer/architecture-internals.md
+++ b/docs/developer/architecture-internals.md
@@ -1,6 +1,6 @@
 # Architecture internals
 
-The user-facing [Architecture overview](../architecture/) covers the shape from outside; this page is what you'd want before editing the code.
+The 1Hz async loop in [`scheduler::run_loop`](#the-1hz-run-loop) is the heart of Entracte: every second it walks a fixed decision tree — paused, bedtime, suppressed, overdue, fire — and the rest of the code exists to feed it state or react to its events. This page maps the modules that surround it, the on-disk state it persists, the concurrency rules every command obeys, and the events the renderer subscribes to. The user-facing [Architecture overview](../architecture/) covers the shape from outside; this page is what you'd want before editing the code.
 
 ## Module map
 

--- a/docs/developer/contributing.md
+++ b/docs/developer/contributing.md
@@ -1,5 +1,7 @@
 # Contributing
 
+The fastest path from `git clone` to a passing PR: install the prerequisites below, run `npm run tauri dev` to confirm the app builds, then read [Architecture internals](./architecture-internals) for the module map and the 1Hz run-loop walkthrough. When you're ready to make a change, the patterns lower on this page — adding a Tauri command, adding a setting, adding a suppression guard — are the seams the codebase is built around.
+
 ## Layout
 
 - `src-tauri/` — the Rust backend (Tauri 2 + Tokio).
@@ -42,12 +44,13 @@ npm run audit:a11y
 CI enforces all four. Run them locally before pushing:
 
 ```sh
-cargo fmt   --manifest-path src-tauri/Cargo.toml --check
+cargo fmt    --manifest-path src-tauri/Cargo.toml --check
 cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings
+RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path src-tauri/Cargo.toml --no-deps
 npx tsc --noEmit
 ```
 
-The cargo step also runs `cargo doc --no-deps` with `-D warnings` so broken intra-doc links fail the build.
+The `cargo doc` step rejects broken intra-doc links — a renamed module that's still referenced from a `[link]` somewhere will fail the build, even when nothing else has drifted.
 
 ## Branch / PR workflow
 
@@ -61,28 +64,26 @@ The cargo step also runs `cargo doc --no-deps` with `-D warnings` so broken intr
 Every IPC entry-point is a `#[tauri::command]` somewhere under `src-tauri/src/scheduler/commands/`. The pattern:
 
 1. Add the function to the right submodule (`settings.rs`, `breaks.rs`, `profiles.rs`, etc.).
-2. Add a `///` doc comment — at minimum: what it does, what events it emits, what errors it returns.
-3. Register it in `lib.rs` inside the `tauri::generate_handler![...]` macro.
-4. If the renderer needs to call it, add a wrapper in the relevant `views/settings/hooks/use-*.ts` so the call stays out of components.
+2. Add a `///` doc comment — at minimum: what it does, what events it emits, what errors it returns. This is what surfaces in the generated [Rust API reference](./rust-api), and CI fails the build if intra-doc links break.
+3. Register it in `lib.rs` inside the `tauri::generate_handler![...]` macro. Tauri's capability layer authorises commands per-name; a function tagged `#[tauri::command]` that's not in the macro is silently unreachable from the renderer.
+4. If the renderer needs to call it, add a wrapper in the relevant `views/settings/hooks/use-*.ts` so the call stays out of components. The hooks layer is where shape drift gets caught — the `invoke` boundary itself is untyped (see [#13](https://github.com/drmowinckels/entracte/issues/13)).
 
 See the [IPC contract](./ipc) for the existing surface.
 
 ## Adding a setting
 
-1. Add the field to the Rust `Settings` struct in `src-tauri/src/scheduler/settings.rs`, with a sensible default in the `Default` impl.
-2. Add the matching field to the TS `SchedulerSettings` type in `src/views/settings/types.ts`.
+1. Add the field to the Rust `Settings` struct in `src-tauri/src/scheduler/settings.rs`, with a sensible default in the `Default` impl. The default is what older installs get when their `settings.json` lacks the field — the `#[serde(default)]` and `#[serde(alias = ...)]` pattern in the same file is how settings migrate forward without a schema version bump.
+2. Add the matching field to the TS `SchedulerSettings` type in `src/views/settings/types.ts`. The two types are mirrored by hand — no parity test yet ([#13](https://github.com/drmowinckels/entracte/issues/13)) — so skipping this step turns into a renderer runtime crash, not a compile error.
 3. Render a control on the relevant tab under `src/views/settings/tabs/`.
-4. If you're adding a new field that the scheduler should react to, wire it into `run_loop.rs` and add a test.
-
-The serde defaults make missing fields harmless on older `settings.json` files, but the TS type drift is not enforced by anything yet (see [#13](https://github.com/drmowinckels/entracte/issues/13) for the parity-test idea).
+4. If the scheduler should react to the field at runtime, wire it into `run_loop.rs` and add a test. Settings that only affect rendering (overlay theme, hints, etc.) don't need this step — the run-loop only reads the fields it cares about each tick.
 
 ## Adding a break suppression / guard
 
 The 1Hz loop in `src-tauri/src/scheduler/run_loop.rs` consults each guard in order. To add one:
 
-1. Add the detection module (e.g. `dnd.rs`, `camera.rs`, `video.rs`) or extend an existing one.
-2. Add the `GuardReason` variant in `src-tauri/src/stats.rs`.
-3. Hook the check into `run_loop` before the fire-decision; if active, reset the per-kind timers, log via `log_suppressions`, and `continue`.
+1. Add the detection module (e.g. `dnd.rs`, `camera.rs`, `video.rs`) or extend an existing one. Per-OS branches live inside the module; the public surface is a single boolean check the run-loop can call cheaply on every tick.
+2. Add the `GuardReason` variant in `src-tauri/src/stats.rs`. This is what shows up in the Insights tab's "Breaks suppressed by" breakdown — without a variant, the suppression is invisible to the user even though the break didn't fire.
+3. Hook the check into `run_loop` before the fire-decision; if active, reset the per-kind timers, log via `log_suppressions`, and `continue`. Order matters — earlier guards in the chain win when several would trigger on the same tick, so place the new guard wherever the precedence ought to fall.
 4. Add a setting that gates it (see "Adding a setting" above) and surface it on the Quiet tab.
 
 ## Filing issues

--- a/docs/developer/index.md
+++ b/docs/developer/index.md
@@ -1,19 +1,7 @@
 # Developer guide
 
-Resources for contributing to Entracte or understanding how it's built. The user-facing [Architecture](../architecture/) section covers the high-level "how Entracte works"; this section is what you'd want before opening a PR.
+If you've never touched the code, **[Architecture internals](./architecture-internals)** is where to start — it covers the module map, the 1Hz run-loop walkthrough, on-disk persistence, and the concurrency model. From there, **[IPC contract](./ipc)** lists every Tauri command the renderer can call and the events the backend emits, and **[Contributing](./contributing)** is the quick reference for branch workflow, the test suites, and what CI checks.
 
-## What's here
+The user-facing [Architecture](../architecture/) section covers the high-level "how Entracte works" — useful as a refresher but not where to start when you're editing the code.
 
-- **[Contributing](./contributing)** — branch and PR workflow, how to run the dev server, what the test suites cover, what CI checks.
-- **[Architecture internals](./architecture-internals)** — the actual module map, the 1Hz run-loop walkthrough, on-disk persistence, the concurrency model.
-- **[IPC contract](./ipc)** — every Tauri command the renderer can call, plus the events the backend emits.
-- **[Releases](./releases)** — how the tag-triggered pipeline cuts and signs bundles, and where the in-app updater fits in.
-- **API references** — generated code navigation for [Rust](./rust-api) (`rustdoc` over the Tauri crate, with private items) and [TypeScript](./ts-api) (`typedoc` over the React frontend).
-
-## Reading order
-
-If you've never touched the code, start with **Architecture internals** to get the module map and the run-loop shape, then dip into **IPC contract** to see what the renderer can ask of the backend. **Contributing** is a quick reference once you're ready to send a PR.
-
-The **API references** are flat browsers over every symbol in the source tree with the same one-line summaries that appear in IDE hovers — useful when you remember a name but not where it lives.
-
-For how releases are cut and signed, see [Releases](./releases).
+**[Releases](./releases)** describes the tag-triggered pipeline that cuts and signs bundles, and where the in-app updater fits in. The **API references** ([Rust](./rust-api) via `rustdoc` over the Tauri crate with private items, [TypeScript](./ts-api) via `typedoc` over the React frontend) are flat browsers over every symbol in the source tree with the same one-line summaries that appear in IDE hovers — useful when you remember a name but not where it lives.


### PR DESCRIPTION
## Summary

Five small changes informed by a codex-voice review of the developer guide section:

- **`developer/index.md`** — cut the *"Resources for contributing"* definition lead and the redundant trailing pointer to releases.md; the reading-order paragraph is the new lead. The standalone *What's here* / *Reading order* headings collapse into the opening because the page is short and the VitePress sidebar already handles top-level navigation.
- **`developer/contributing.md`** — open with a one-paragraph framing sentence so the reader knows what the page solves before hitting `## Layout`.
- **`developer/contributing.md`** — fix *"CI enforces all four"* (the block listed three commands and named `cargo doc` only in the trailing note). Add `cargo doc` to the block so the count matches what CI actually runs.
- **`developer/contributing.md`** — add one *why*-sentence per step in the three *Adding a X* recipes (Tauri command, setting, suppression guard). These were recipes without rationale; the new lines name the hidden constraint that makes each step load-bearing (Tauri capability layer, hand-mirrored Settings types, GuardReason → Insights tab, etc.).
- **`developer/architecture-internals.md`** — lead with the 1Hz loop (the load-bearing concept) instead of the structural pointer to the user-facing overview.

No content was removed.

## Verification

- `cd docs && npm run build` — green, no broken links, all six pages render.
- All inline links spot-checked (the new `#the-1hz-run-loop` anchor lands on the existing `## The 1Hz run loop` heading).