### PR TITLE
chore(spell): allow "NSIS" used in install.md

### DIFF
--- a/.github/audit/cspell/project-words.txt
+++ b/.github/audit/cspell/project-words.txt
@@ -42,6 +42,7 @@ notarization
 codesigned
 SignPath
 signpath
+NSIS
 TEAMID
 Bootswatch
 proscenium


### PR DESCRIPTION
## Summary
- Adds `NSIS` to `cspell/project-words.txt` so the audit job stops failing on `docs/guide/install.md:22`.
- Collateral from #35 which introduced the term but did not update the dictionary.

Unblocks audit on #32 and #38 once they rebase.

## Test plan
- [ ] audit job passes (cspell finds 0 issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)