### PR TITLE
feat(insights): weekday + WoW delta, suppression bars, postpone donut

### DIFF
--- a/scripts/audit-a11y.mjs
+++ b/scripts/audit-a11y.mjs
@@ -73,9 +73,32 @@ const TAURI_SHIM = `
       { reason: "Camera", label: "Camera in use", count: 5 },
       { reason: "Dnd", label: "Do Not Disturb", count: 2 },
     ],
+    suppressions_by_kind: [
+      { kind: "long", reason: "camera", label: "Camera in use", count: 3 },
+      { kind: "micro", reason: "camera", label: "Camera in use", count: 2 },
+      { kind: "long", reason: "dnd", label: "Do Not Disturb", count: 2 },
+    ],
     pause_total_secs: 600, pause_count: 2,
     by_hour: Array.from({ length: 24 }, (_, h) => (h >= 9 && h <= 17 ? h % 5 : 0)),
     by_day: dayBuckets,
+    by_weekday: Array.from({ length: 7 }, (_, w) => ({
+      weekday: w,
+      taken: (w + 1) % 5,
+      dismissed: w % 3,
+    })),
+    previous: {
+      breaks_taken: 10,
+      breaks_dismissed: 4,
+      postponed_total: 2,
+      skipped_total: 1,
+    },
+    postpone_follow_through: {
+      total: 3,
+      taken: 2,
+      dismissed: 0,
+      skipped: 1,
+      unresolved: 0,
+    },
   };
 
   const callbacks = {};

--- a/src-tauri/src/scheduler/types.rs
+++ b/src-tauri/src/scheduler/types.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 /// `Micro` is the short eye-rest prompt, `Long` is the longer movement
 /// break, `Sleep` is the bedtime reminder fired inside the configured
 /// nighttime window.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[serde(rename_all = "lowercase")]
 pub enum BreakKind {
     Micro,

--- a/src-tauri/src/stats.rs
+++ b/src-tauri/src/stats.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use chrono::{DateTime, Duration, Local, NaiveDate, Timelike, Utc};
+use chrono::{DateTime, Datelike, Duration, Local, NaiveDate, Timelike, Utc, Weekday};
 use log::error;
 use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc;
@@ -176,10 +176,42 @@ pub struct SuppressionCount {
 }
 
 #[derive(Debug, Clone, Serialize)]
+pub struct SuppressionByKind {
+    pub kind: String,
+    pub reason: String,
+    pub label: String,
+    pub count: u32,
+}
+
+#[derive(Debug, Clone, Serialize)]
 pub struct DayBucket {
     pub date: String,
     pub taken: u32,
     pub dismissed: u32,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct WeekdayBucket {
+    pub weekday: u8,
+    pub taken: u32,
+    pub dismissed: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct PreviousPeriod {
+    pub breaks_taken: u32,
+    pub breaks_dismissed: u32,
+    pub postponed_total: u32,
+    pub skipped_total: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct PostponeFollowThrough {
+    pub total: u32,
+    pub taken: u32,
+    pub dismissed: u32,
+    pub skipped: u32,
+    pub unresolved: u32,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -195,10 +227,18 @@ pub struct Digest {
     pub postponed_total: u32,
     pub skipped_total: u32,
     pub suppressions: Vec<SuppressionCount>,
+    pub suppressions_by_kind: Vec<SuppressionByKind>,
     pub pause_total_secs: u64,
     pub pause_count: u32,
     pub by_hour: Vec<u32>,
     pub by_day: Vec<DayBucket>,
+    pub by_weekday: Vec<WeekdayBucket>,
+    pub previous: PreviousPeriod,
+    pub postpone_follow_through: PostponeFollowThrough,
+}
+
+fn weekday_index(d: Weekday) -> u8 {
+    d.num_days_from_monday() as u8
 }
 
 pub fn compute_digest(events: &[LoggedEvent], range: &str, now: DateTime<Local>) -> Digest {
@@ -207,6 +247,7 @@ pub fn compute_digest(events: &[LoggedEvent], range: &str, now: DateTime<Local>)
         _ => 7,
     };
     let range_start = now - Duration::days(days_back);
+    let prev_range_start = now - Duration::days(days_back * 2);
 
     let mut micro_taken = 0u32;
     let mut micro_dismissed = 0u32;
@@ -218,12 +259,35 @@ pub fn compute_digest(events: &[LoggedEvent], range: &str, now: DateTime<Local>)
     let mut pause_total_secs: u64 = 0;
     let mut pause_count = 0u32;
     let mut by_hour = vec![0u32; 24];
+    let mut by_weekday_taken = [0u32; 7];
+    let mut by_weekday_dismissed = [0u32; 7];
     let mut sup_map: HashMap<GuardReason, u32> = HashMap::new();
+    let mut sup_kind_map: HashMap<(BreakKind, GuardReason), u32> = HashMap::new();
+    let mut previous = PreviousPeriod::default();
     let mut open_pause: Option<DateTime<Utc>> = None;
 
     for e in events {
         let local = e.t.with_timezone(&Local);
-        if local < range_start || local > now {
+        let in_range = local >= range_start && local <= now;
+        let in_prev = local >= prev_range_start && local < range_start;
+        if !in_range && !in_prev {
+            continue;
+        }
+        if in_prev {
+            match &e.event {
+                EventPayload::BreakEnd { kind, outcome } => match (*kind, *outcome) {
+                    (BreakKind::Micro | BreakKind::Long, Outcome::Completed) => {
+                        previous.breaks_taken += 1
+                    }
+                    (BreakKind::Micro | BreakKind::Long, Outcome::Dismissed) => {
+                        previous.breaks_dismissed += 1
+                    }
+                    (BreakKind::Sleep, _) => {}
+                },
+                EventPayload::BreakPostponed { .. } => previous.postponed_total += 1,
+                EventPayload::BreakSkipped { .. } => previous.skipped_total += 1,
+                _ => {}
+            }
             continue;
         }
         match &e.event {
@@ -235,16 +299,25 @@ pub fn compute_digest(events: &[LoggedEvent], range: &str, now: DateTime<Local>)
                     (BreakKind::Long, Outcome::Dismissed) => long_dismissed += 1,
                     (BreakKind::Sleep, _) => sleep_shown += 1,
                 }
-                if matches!(outcome, Outcome::Completed) {
-                    let h = local.hour() as usize;
-                    by_hour[h] += 1;
+                let wd = weekday_index(local.weekday()) as usize;
+                match (*kind, *outcome) {
+                    (BreakKind::Micro | BreakKind::Long, Outcome::Completed) => {
+                        by_weekday_taken[wd] += 1;
+                        let h = local.hour() as usize;
+                        by_hour[h] += 1;
+                    }
+                    (BreakKind::Micro | BreakKind::Long, Outcome::Dismissed) => {
+                        by_weekday_dismissed[wd] += 1;
+                    }
+                    (BreakKind::Sleep, _) => {}
                 }
             }
             EventPayload::BreakPostponed { .. } => postponed_total += 1,
             EventPayload::BreakSkipped { .. } => skipped_total += 1,
             EventPayload::BreakResumed { .. } => {}
-            EventPayload::GuardSuppress { reason, .. } => {
+            EventPayload::GuardSuppress { kind, reason } => {
                 *sup_map.entry(*reason).or_insert(0) += 1;
+                *sup_kind_map.entry((*kind, *reason)).or_insert(0) += 1;
             }
             EventPayload::PauseStart { .. } => {
                 open_pause = Some(e.t);
@@ -269,6 +342,33 @@ pub fn compute_digest(events: &[LoggedEvent], range: &str, now: DateTime<Local>)
         })
         .collect();
     suppressions.sort_by_key(|s| std::cmp::Reverse(s.count));
+
+    let mut suppressions_by_kind: Vec<SuppressionByKind> = sup_kind_map
+        .into_iter()
+        .map(|((kind, reason), count)| SuppressionByKind {
+            kind: kind_str(kind).to_string(),
+            reason: format!("{reason:?}").to_lowercase(),
+            label: reason.label().to_string(),
+            count,
+        })
+        .collect();
+    suppressions_by_kind.sort_by(|a, b| {
+        b.count
+            .cmp(&a.count)
+            .then_with(|| a.kind.cmp(&b.kind))
+            .then_with(|| a.reason.cmp(&b.reason))
+    });
+
+    let by_weekday: Vec<WeekdayBucket> = (0u8..7)
+        .map(|w| WeekdayBucket {
+            weekday: w,
+            taken: by_weekday_taken[w as usize],
+            dismissed: by_weekday_dismissed[w as usize],
+        })
+        .collect();
+
+    let postpone_follow_through =
+        compute_postpone_follow_through(events, range_start, now);
 
     let heatmap_days = 84i64;
     let heatmap_start = (now - Duration::days(heatmap_days - 1)).date_naive();
@@ -316,11 +416,62 @@ pub fn compute_digest(events: &[LoggedEvent], range: &str, now: DateTime<Local>)
         postponed_total,
         skipped_total,
         suppressions,
+        suppressions_by_kind,
         pause_total_secs,
         pause_count,
         by_hour,
         by_day,
+        by_weekday,
+        previous,
+        postpone_follow_through,
     }
+}
+
+/// For every `BreakPostponed` event inside `[range_start, now]`, look
+/// forward in the (chronologically ordered) event stream for the next
+/// `BreakEnd` or `BreakSkipped` of the same kind and bucket the outcome.
+/// Intervening postpones of the same kind don't resolve — we keep
+/// scanning. A postpone with no later resolution in the log counts as
+/// `unresolved`.
+fn compute_postpone_follow_through(
+    events: &[LoggedEvent],
+    range_start: DateTime<Local>,
+    now: DateTime<Local>,
+) -> PostponeFollowThrough {
+    let mut out = PostponeFollowThrough::default();
+    for (i, e) in events.iter().enumerate() {
+        let EventPayload::BreakPostponed { kind, .. } = &e.event else {
+            continue;
+        };
+        let local = e.t.with_timezone(&Local);
+        if local < range_start || local > now {
+            continue;
+        }
+        out.total += 1;
+        let mut resolved = false;
+        for f in &events[i + 1..] {
+            match &f.event {
+                EventPayload::BreakEnd { kind: k2, outcome } if k2 == kind => {
+                    match outcome {
+                        Outcome::Completed => out.taken += 1,
+                        Outcome::Dismissed => out.dismissed += 1,
+                    }
+                    resolved = true;
+                    break;
+                }
+                EventPayload::BreakSkipped { kind: k2, .. } if k2 == kind => {
+                    out.skipped += 1;
+                    resolved = true;
+                    break;
+                }
+                _ => {}
+            }
+        }
+        if !resolved {
+            out.unresolved += 1;
+        }
+    }
+    out
 }
 
 type CsvFields<'a> = (
@@ -787,5 +938,280 @@ mod tests {
         )];
         let csv = export_csv(&events);
         assert!(csv.lines().nth(1).unwrap().contains("typing"));
+    }
+
+    #[test]
+    fn by_weekday_indexes_monday_zero_to_sunday_six() {
+        let n = now();
+        let thursday = Local.with_ymd_and_hms(2026, 5, 14, 10, 0, 0).unwrap();
+        let sunday = Local.with_ymd_and_hms(2026, 5, 10, 10, 0, 0).unwrap();
+        let events = vec![
+            ev(
+                thursday,
+                EventPayload::BreakEnd {
+                    kind: BreakKind::Micro,
+                    outcome: Outcome::Completed,
+                },
+            ),
+            ev(
+                sunday,
+                EventPayload::BreakEnd {
+                    kind: BreakKind::Long,
+                    outcome: Outcome::Dismissed,
+                },
+            ),
+        ];
+        let d = compute_digest(&events, "week", n);
+        assert_eq!(d.by_weekday.len(), 7);
+        assert_eq!(d.by_weekday[3].weekday, 3);
+        assert_eq!(d.by_weekday[3].taken, 1);
+        assert_eq!(d.by_weekday[6].weekday, 6);
+        assert_eq!(d.by_weekday[6].dismissed, 1);
+    }
+
+    #[test]
+    fn by_weekday_ignores_sleep_prompts() {
+        let n = now();
+        let events = vec![ev(
+            n,
+            EventPayload::BreakEnd {
+                kind: BreakKind::Sleep,
+                outcome: Outcome::Completed,
+            },
+        )];
+        let d = compute_digest(&events, "week", n);
+        assert!(d.by_weekday.iter().all(|w| w.taken == 0));
+    }
+
+    #[test]
+    fn previous_period_tallies_one_window_back() {
+        let n = now();
+        let events = vec![
+            ev(
+                n - Duration::days(2),
+                EventPayload::BreakEnd {
+                    kind: BreakKind::Micro,
+                    outcome: Outcome::Completed,
+                },
+            ),
+            ev(
+                n - Duration::days(9),
+                EventPayload::BreakEnd {
+                    kind: BreakKind::Long,
+                    outcome: Outcome::Completed,
+                },
+            ),
+            ev(
+                n - Duration::days(10),
+                EventPayload::BreakEnd {
+                    kind: BreakKind::Long,
+                    outcome: Outcome::Dismissed,
+                },
+            ),
+            ev(n - Duration::days(8), EventPayload::BreakPostponed {
+                kind: BreakKind::Micro,
+                minutes: 5,
+            }),
+            ev(n - Duration::days(20), EventPayload::BreakSkipped {
+                kind: BreakKind::Micro,
+                source: SkipSource::User,
+            }),
+        ];
+        let d = compute_digest(&events, "week", n);
+        assert_eq!(d.micro_taken + d.long_taken, 1);
+        assert_eq!(d.previous.breaks_taken, 1);
+        assert_eq!(d.previous.breaks_dismissed, 1);
+        assert_eq!(d.previous.postponed_total, 1);
+        assert_eq!(
+            d.previous.skipped_total, 0,
+            "events older than two windows back are excluded"
+        );
+    }
+
+    #[test]
+    fn suppressions_by_kind_splits_reason_per_break_kind() {
+        let n = now();
+        let events = vec![
+            ev(
+                n - Duration::hours(1),
+                EventPayload::GuardSuppress {
+                    kind: BreakKind::Long,
+                    reason: GuardReason::Dnd,
+                },
+            ),
+            ev(
+                n - Duration::hours(2),
+                EventPayload::GuardSuppress {
+                    kind: BreakKind::Long,
+                    reason: GuardReason::Dnd,
+                },
+            ),
+            ev(
+                n - Duration::hours(3),
+                EventPayload::GuardSuppress {
+                    kind: BreakKind::Micro,
+                    reason: GuardReason::Dnd,
+                },
+            ),
+            ev(
+                n - Duration::hours(4),
+                EventPayload::GuardSuppress {
+                    kind: BreakKind::Micro,
+                    reason: GuardReason::Camera,
+                },
+            ),
+        ];
+        let d = compute_digest(&events, "week", n);
+        assert_eq!(d.suppressions_by_kind.len(), 3);
+        assert_eq!(d.suppressions_by_kind[0].kind, "long");
+        assert_eq!(d.suppressions_by_kind[0].reason, "dnd");
+        assert_eq!(d.suppressions_by_kind[0].count, 2);
+        let micro_dnd = d
+            .suppressions_by_kind
+            .iter()
+            .find(|s| s.kind == "micro" && s.reason == "dnd")
+            .expect("micro/dnd present");
+        assert_eq!(micro_dnd.count, 1);
+        let total_dnd: u32 = d
+            .suppressions_by_kind
+            .iter()
+            .filter(|s| s.reason == "dnd")
+            .map(|s| s.count)
+            .sum();
+        let agg_dnd = d
+            .suppressions
+            .iter()
+            .find(|s| s.reason == "dnd")
+            .unwrap()
+            .count;
+        assert_eq!(
+            total_dnd, agg_dnd,
+            "per-kind split must sum to the flat suppressions count"
+        );
+    }
+
+    #[test]
+    fn postpone_follow_through_taken_dismissed_skipped_unresolved() {
+        let n = now();
+        let events = vec![
+            // Postponed and later taken
+            ev(
+                n - Duration::hours(5),
+                EventPayload::BreakPostponed {
+                    kind: BreakKind::Micro,
+                    minutes: 5,
+                },
+            ),
+            ev(
+                n - Duration::hours(4),
+                EventPayload::BreakEnd {
+                    kind: BreakKind::Micro,
+                    outcome: Outcome::Completed,
+                },
+            ),
+            // Postponed and later dismissed
+            ev(
+                n - Duration::hours(3),
+                EventPayload::BreakPostponed {
+                    kind: BreakKind::Long,
+                    minutes: 10,
+                },
+            ),
+            ev(
+                n - Duration::hours(2),
+                EventPayload::BreakEnd {
+                    kind: BreakKind::Long,
+                    outcome: Outcome::Dismissed,
+                },
+            ),
+            // Postponed and later skipped
+            ev(
+                n - Duration::hours(1) - Duration::minutes(30),
+                EventPayload::BreakPostponed {
+                    kind: BreakKind::Micro,
+                    minutes: 5,
+                },
+            ),
+            ev(
+                n - Duration::hours(1),
+                EventPayload::BreakSkipped {
+                    kind: BreakKind::Micro,
+                    source: SkipSource::User,
+                },
+            ),
+            // Postponed with no resolution after it
+            ev(
+                n - Duration::minutes(10),
+                EventPayload::BreakPostponed {
+                    kind: BreakKind::Long,
+                    minutes: 10,
+                },
+            ),
+        ];
+        let d = compute_digest(&events, "week", n);
+        assert_eq!(d.postpone_follow_through.total, 4);
+        assert_eq!(d.postpone_follow_through.taken, 1);
+        assert_eq!(d.postpone_follow_through.dismissed, 1);
+        assert_eq!(d.postpone_follow_through.skipped, 1);
+        assert_eq!(d.postpone_follow_through.unresolved, 1);
+    }
+
+    #[test]
+    fn postpone_follow_through_skips_intervening_other_kind() {
+        let n = now();
+        let events = vec![
+            ev(
+                n - Duration::hours(3),
+                EventPayload::BreakPostponed {
+                    kind: BreakKind::Long,
+                    minutes: 5,
+                },
+            ),
+            // BreakEnd of a different kind — must not resolve the long postpone
+            ev(
+                n - Duration::hours(2),
+                EventPayload::BreakEnd {
+                    kind: BreakKind::Micro,
+                    outcome: Outcome::Completed,
+                },
+            ),
+            ev(
+                n - Duration::hours(1),
+                EventPayload::BreakEnd {
+                    kind: BreakKind::Long,
+                    outcome: Outcome::Completed,
+                },
+            ),
+        ];
+        let d = compute_digest(&events, "week", n);
+        assert_eq!(d.postpone_follow_through.total, 1);
+        assert_eq!(d.postpone_follow_through.taken, 1);
+        assert_eq!(d.postpone_follow_through.unresolved, 0);
+    }
+
+    #[test]
+    fn postpone_follow_through_only_counts_postpones_in_range() {
+        let n = now();
+        let events = vec![
+            ev(
+                n - Duration::days(20),
+                EventPayload::BreakPostponed {
+                    kind: BreakKind::Micro,
+                    minutes: 5,
+                },
+            ),
+            ev(
+                n - Duration::days(19),
+                EventPayload::BreakEnd {
+                    kind: BreakKind::Micro,
+                    outcome: Outcome::Completed,
+                },
+            ),
+        ];
+        let d = compute_digest(&events, "week", n);
+        assert_eq!(
+            d.postpone_follow_through.total, 0,
+            "postpone outside the week range should not contribute"
+        );
     }
 }

--- a/src-tauri/src/stats.rs
+++ b/src-tauri/src/stats.rs
@@ -367,8 +367,7 @@ pub fn compute_digest(events: &[LoggedEvent], range: &str, now: DateTime<Local>)
         })
         .collect();
 
-    let postpone_follow_through =
-        compute_postpone_follow_through(events, range_start, now);
+    let postpone_follow_through = compute_postpone_follow_through(events, range_start, now);
 
     let heatmap_days = 84i64;
     let heatmap_start = (now - Duration::days(heatmap_days - 1)).date_naive();
@@ -1008,14 +1007,20 @@ mod tests {
                     outcome: Outcome::Dismissed,
                 },
             ),
-            ev(n - Duration::days(8), EventPayload::BreakPostponed {
-                kind: BreakKind::Micro,
-                minutes: 5,
-            }),
-            ev(n - Duration::days(20), EventPayload::BreakSkipped {
-                kind: BreakKind::Micro,
-                source: SkipSource::User,
-            }),
+            ev(
+                n - Duration::days(8),
+                EventPayload::BreakPostponed {
+                    kind: BreakKind::Micro,
+                    minutes: 5,
+                },
+            ),
+            ev(
+                n - Duration::days(20),
+                EventPayload::BreakSkipped {
+                    kind: BreakKind::Micro,
+                    source: SkipSource::User,
+                },
+            ),
         ];
         let d = compute_digest(&events, "week", n);
         assert_eq!(d.micro_taken + d.long_taken, 1);

--- a/src/lib/ipc-parity.test.ts
+++ b/src/lib/ipc-parity.test.ts
@@ -100,9 +100,29 @@ const PAIRS: Pair[] = [
     rust: { file: "stats.rs", struct: "SuppressionCount" },
   },
   {
+    name: "SuppressionByKind",
+    ts: { file: "views/settings/types.ts", type: "SuppressionByKind" },
+    rust: { file: "stats.rs", struct: "SuppressionByKind" },
+  },
+  {
     name: "DayBucket",
     ts: { file: "views/settings/types.ts", type: "DayBucket" },
     rust: { file: "stats.rs", struct: "DayBucket" },
+  },
+  {
+    name: "WeekdayBucket",
+    ts: { file: "views/settings/types.ts", type: "WeekdayBucket" },
+    rust: { file: "stats.rs", struct: "WeekdayBucket" },
+  },
+  {
+    name: "PreviousPeriod",
+    ts: { file: "views/settings/types.ts", type: "PreviousPeriod" },
+    rust: { file: "stats.rs", struct: "PreviousPeriod" },
+  },
+  {
+    name: "PostponeFollowThrough",
+    ts: { file: "views/settings/types.ts", type: "PostponeFollowThrough" },
+    rust: { file: "stats.rs", struct: "PostponeFollowThrough" },
   },
   {
     // Cosmetic name mismatch: TS calls it `StatsDigest`, Rust just `Digest`

--- a/src/lib/stats-format.test.ts
+++ b/src/lib/stats-format.test.ts
@@ -1,11 +1,15 @@
 import { describe, expect, it } from "vitest";
 import {
   buildHeatmapWeeks,
+  deltaDirection,
+  deltaPct,
   dismissalRate,
   formatHoursMinutes,
+  groupSuppressionsByReason,
   heatmapLevel,
   heatmapMonthLabels,
   weekdayFromISO,
+  weekdayLabel,
   type DayBucket,
 } from "./stats-format";
 
@@ -72,6 +76,100 @@ describe("weekdayFromISO", () => {
     expect(weekdayFromISO("2026-05-11")).toBe(0);
     expect(weekdayFromISO("2026-05-12")).toBe(1);
     expect(weekdayFromISO("2026-05-17")).toBe(6);
+  });
+});
+
+describe("weekdayLabel", () => {
+  it("returns Mon..Sun for 0..6", () => {
+    expect(weekdayLabel(0)).toBe("Mon");
+    expect(weekdayLabel(2)).toBe("Wed");
+    expect(weekdayLabel(6)).toBe("Sun");
+  });
+
+  it("returns empty string for out-of-range input", () => {
+    expect(weekdayLabel(-1)).toBe("");
+    expect(weekdayLabel(7)).toBe("");
+  });
+});
+
+describe("deltaPct", () => {
+  it("returns em-dash when previous is zero", () => {
+    expect(deltaPct(5, 0)).toBe("—");
+    expect(deltaPct(0, 0)).toBe("—");
+  });
+
+  it("returns 0% when curr equals prev", () => {
+    expect(deltaPct(4, 4)).toBe("0%");
+  });
+
+  it("formats positive deltas with a plus sign", () => {
+    expect(deltaPct(13, 10)).toBe("+30%");
+    expect(deltaPct(2, 1)).toBe("+100%");
+  });
+
+  it("formats negative deltas with a minus sign", () => {
+    expect(deltaPct(7, 10)).toBe("−30%");
+    expect(deltaPct(0, 4)).toBe("−100%");
+  });
+});
+
+describe("groupSuppressionsByReason", () => {
+  it("returns no rows when the input is empty", () => {
+    expect(groupSuppressionsByReason([])).toEqual([]);
+  });
+
+  it("collapses per-(kind, reason) rows into one entry per reason", () => {
+    const grouped = groupSuppressionsByReason([
+      { kind: "long", reason: "dnd", label: "Do Not Disturb", count: 4 },
+      { kind: "micro", reason: "dnd", label: "Do Not Disturb", count: 2 },
+      { kind: "micro", reason: "camera", label: "Camera in use", count: 3 },
+    ]);
+    expect(grouped).toHaveLength(2);
+    const dnd = grouped.find((r) => r.reason === "dnd");
+    expect(dnd?.total).toBe(6);
+    expect(dnd?.segments).toEqual([
+      { kind: "micro", count: 2 },
+      { kind: "long", count: 4 },
+    ]);
+  });
+
+  it("orders reasons by total descending, then alphabetically", () => {
+    const grouped = groupSuppressionsByReason([
+      { kind: "long", reason: "camera", label: "Camera in use", count: 1 },
+      { kind: "long", reason: "dnd", label: "Do Not Disturb", count: 5 },
+      { kind: "long", reason: "idle", label: "Idle", count: 5 },
+    ]);
+    expect(grouped.map((r) => r.reason)).toEqual(["dnd", "idle", "camera"]);
+  });
+
+  it("orders kind segments in canonical micro → long → sleep order", () => {
+    const grouped = groupSuppressionsByReason([
+      { kind: "sleep", reason: "dnd", label: "Do Not Disturb", count: 1 },
+      { kind: "long", reason: "dnd", label: "Do Not Disturb", count: 1 },
+      { kind: "micro", reason: "dnd", label: "Do Not Disturb", count: 1 },
+    ]);
+    expect(grouped[0].segments.map((s) => s.kind)).toEqual([
+      "micro",
+      "long",
+      "sleep",
+    ]);
+  });
+});
+
+describe("deltaDirection", () => {
+  it("returns flat when counts are equal (including both zero)", () => {
+    expect(deltaDirection(0, 0)).toBe("flat");
+    expect(deltaDirection(5, 5)).toBe("flat");
+  });
+
+  it("returns up when curr exceeds prev", () => {
+    expect(deltaDirection(6, 5)).toBe("up");
+    expect(deltaDirection(1, 0)).toBe("up");
+  });
+
+  it("returns down when curr is below prev", () => {
+    expect(deltaDirection(4, 5)).toBe("down");
+    expect(deltaDirection(0, 1)).toBe("down");
   });
 });
 

--- a/src/lib/stats-format.ts
+++ b/src/lib/stats-format.ts
@@ -23,6 +23,84 @@ export function dismissalRate(taken: number, dismissed: number): string {
   return `${Math.round((dismissed / total) * 100)}%`;
 }
 
+/** Short Monday-anchored weekday label. `0 -> Mon`, `6 -> Sun`. */
+export function weekdayLabel(weekday: number): string {
+  return ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"][weekday] ?? "";
+}
+
+export type SuppressionRowInput = {
+  kind: string;
+  reason: string;
+  label: string;
+  count: number;
+};
+
+export type SuppressionByReason = {
+  reason: string;
+  label: string;
+  total: number;
+  segments: { kind: string; count: number }[];
+};
+
+/** Collapse the per-(kind, reason) suppression rows into one entry per
+ * reason, with each kind preserved as a segment. The reason list is
+ * sorted by total count descending so the highest-impact row comes
+ * first; segments within a reason are sorted by kind for stable colour
+ * ordering across renders. */
+export function groupSuppressionsByReason(
+  rows: SuppressionRowInput[],
+): SuppressionByReason[] {
+  const byReason = new Map<
+    string,
+    { reason: string; label: string; segments: Map<string, number> }
+  >();
+  for (const r of rows) {
+    let bucket = byReason.get(r.reason);
+    if (!bucket) {
+      bucket = { reason: r.reason, label: r.label, segments: new Map() };
+      byReason.set(r.reason, bucket);
+    }
+    bucket.segments.set(
+      r.kind,
+      (bucket.segments.get(r.kind) ?? 0) + r.count,
+    );
+  }
+  const KIND_ORDER = ["micro", "long", "sleep"];
+  return [...byReason.values()]
+    .map((b) => {
+      const segments = [...b.segments.entries()]
+        .map(([kind, count]) => ({ kind, count }))
+        .sort(
+          (a, b) =>
+            KIND_ORDER.indexOf(a.kind) - KIND_ORDER.indexOf(b.kind) ||
+            a.kind.localeCompare(b.kind),
+        );
+      const total = segments.reduce((acc, s) => acc + s.count, 0);
+      return { reason: b.reason, label: b.label, total, segments };
+    })
+    .sort((a, b) => b.total - a.total || a.reason.localeCompare(b.reason));
+}
+
+/** "+34%" / "−12%" / "—" delta string for a current-vs-previous count
+ * pair. Returns `"—"` when the previous period is zero (no baseline)
+ * so the UI doesn't shout "∞%" at the user the first time they open
+ * Insights with a week of data. */
+export function deltaPct(curr: number, prev: number): string {
+  if (prev === 0) return "—";
+  const pct = Math.round(((curr - prev) / prev) * 100);
+  if (pct === 0) return "0%";
+  const sign = pct > 0 ? "+" : "−";
+  return `${sign}${Math.abs(pct)}%`;
+}
+
+/** Direction of a current-vs-previous comparison — drives the colour
+ * class on delta chips. Equal counts read as `"flat"` so the renderer
+ * can stay quiet. */
+export function deltaDirection(curr: number, prev: number): "up" | "down" | "flat" {
+  if (curr === prev) return "flat";
+  return curr > prev ? "up" : "down";
+}
+
 /** Map a day's `count` to a 5-level shade (0–4) for the heatmap
  * cell's `data-level`. CSS picks the actual colours per level. */
 export function heatmapLevel(count: number, max: number): number {

--- a/src/views/settings/components/postpone-donut.test.tsx
+++ b/src/views/settings/components/postpone-donut.test.tsx
@@ -1,0 +1,70 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+
+import { PostponeDonut } from "./postpone-donut";
+
+describe("PostponeDonut", () => {
+  afterEach(cleanup);
+
+  it("renders nothing when total is zero (no chart, no legend)", () => {
+    const { container } = render(
+      <PostponeDonut
+        data={{ total: 0, taken: 0, dismissed: 0, skipped: 0, unresolved: 0 }}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("labels the chart for assistive tech with each segment count", () => {
+    render(
+      <PostponeDonut
+        data={{ total: 10, taken: 5, dismissed: 2, skipped: 1, unresolved: 2 }}
+      />,
+    );
+    const img = screen.getByRole("img", { name: /postpone follow-through/i });
+    const label = img.getAttribute("aria-label") ?? "";
+    expect(label).toContain("5 taken");
+    expect(label).toContain("2 dismissed");
+    expect(label).toContain("1 skipped");
+    expect(label).toContain("2 pending");
+  });
+
+  it("skips drawing zero-value segments but still lists them in the legend", () => {
+    // Drawing a zero-length arc is a no-op visually, but stroke-dasharray
+    // can still leak a tiny artefact. Easier to drop the <circle> entirely.
+    const { container } = render(
+      <PostponeDonut
+        data={{ total: 4, taken: 4, dismissed: 0, skipped: 0, unresolved: 0 }}
+      />,
+    );
+    const segmentArcs = container.querySelectorAll(
+      "svg circle[stroke-dasharray]",
+    );
+    expect(segmentArcs.length).toBe(1);
+    expect(screen.getByText(/Dismissed instead/)).toBeTruthy();
+    expect(screen.getByText(/Still pending/)).toBeTruthy();
+  });
+
+  it("computes segment percentages out of the running total", () => {
+    render(
+      <PostponeDonut
+        data={{ total: 10, taken: 5, dismissed: 2, skipped: 1, unresolved: 2 }}
+      />,
+    );
+    expect(screen.getByText(/· 50%/)).toBeTruthy();
+    expect(screen.getAllByText(/· 20%/)).toHaveLength(2);
+    expect(screen.getByText(/· 10%/)).toBeTruthy();
+  });
+
+  it("renders the total count in the donut hole with a singular caption when total is 1", () => {
+    const { container } = render(
+      <PostponeDonut
+        data={{ total: 1, taken: 1, dismissed: 0, skipped: 0, unresolved: 0 }}
+      />,
+    );
+    const total = container.querySelector(".donut-total");
+    expect(total?.textContent).toBe("1");
+    expect(screen.getByText("postpone")).toBeTruthy();
+  });
+});

--- a/src/views/settings/components/postpone-donut.tsx
+++ b/src/views/settings/components/postpone-donut.tsx
@@ -1,0 +1,110 @@
+import type { PostponeFollowThrough } from "../types";
+
+const RADIUS = 42;
+const STROKE = 14;
+const SIZE = 120;
+const CIRC = 2 * Math.PI * RADIUS;
+
+type Segment = {
+  key: "taken" | "dismissed" | "skipped" | "unresolved";
+  label: string;
+  value: number;
+  cssVar: string;
+};
+
+function segmentsFrom(data: PostponeFollowThrough): Segment[] {
+  return [
+    { key: "taken", label: "Eventually taken", value: data.taken, cssVar: "--primary-color" },
+    {
+      key: "dismissed",
+      label: "Dismissed instead",
+      value: data.dismissed,
+      cssVar: "--secondary-color",
+    },
+    { key: "skipped", label: "Skipped instead", value: data.skipped, cssVar: "--accent-color" },
+    {
+      key: "unresolved",
+      label: "Still pending",
+      value: data.unresolved,
+      cssVar: "--light-primary-color",
+    },
+  ];
+}
+
+export function PostponeDonut({ data }: { data: PostponeFollowThrough }) {
+  if (data.total === 0) return null;
+  const segments = segmentsFrom(data);
+  const arcs: { seg: Segment; len: number; offset: number }[] = [];
+  let offset = 0;
+  for (const seg of segments) {
+    const len = (seg.value / data.total) * CIRC;
+    arcs.push({ seg, len, offset });
+    offset += len;
+  }
+  return (
+    <div className="donut-wrap">
+      <svg
+        className="donut"
+        viewBox={`0 0 ${SIZE} ${SIZE}`}
+        role="img"
+        aria-label={`Postpone follow-through: ${data.taken} taken, ${data.dismissed} dismissed, ${data.skipped} skipped, ${data.unresolved} pending`}
+      >
+        <circle
+          cx={SIZE / 2}
+          cy={SIZE / 2}
+          r={RADIUS}
+          fill="none"
+          stroke="var(--input-border)"
+          strokeWidth={STROKE}
+        />
+        {arcs.map(({ seg, len, offset: o }) =>
+          seg.value === 0 ? null : (
+            <circle
+              key={seg.key}
+              cx={SIZE / 2}
+              cy={SIZE / 2}
+              r={RADIUS}
+              fill="none"
+              stroke={`var(${seg.cssVar})`}
+              strokeWidth={STROKE}
+              strokeDasharray={`${len} ${CIRC - len}`}
+              strokeDashoffset={-o}
+              transform={`rotate(-90 ${SIZE / 2} ${SIZE / 2})`}
+            />
+          ),
+        )}
+        <text
+          x={SIZE / 2}
+          y={SIZE / 2 - 4}
+          textAnchor="middle"
+          className="donut-total"
+        >
+          {data.total}
+        </text>
+        <text
+          x={SIZE / 2}
+          y={SIZE / 2 + 12}
+          textAnchor="middle"
+          className="donut-caption"
+        >
+          {data.total === 1 ? "postpone" : "postpones"}
+        </text>
+      </svg>
+      <ul className="donut-legend">
+        {segments.map((s) => {
+          const pct = Math.round((s.value / data.total) * 100);
+          return (
+            <li key={s.key} data-segment={s.key}>
+              <span className="donut-swatch" aria-hidden="true" />
+              <span className="donut-legend-label">{s.label}</span>
+              <span className="donut-legend-value">
+                {s.value}
+                <span className="stat-card-sub"> · {pct}%</span>
+              </span>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/src/views/settings/components/suppression-bars.test.tsx
+++ b/src/views/settings/components/suppression-bars.test.tsx
@@ -44,11 +44,11 @@ describe("SuppressionBars", () => {
     expect(bars[0].style.getPropertyValue("--bar-width")).toBe("100%");
     expect(bars[1].style.getPropertyValue("--bar-width")).toBe("50%");
 
-    const dndSegs = bars[0].querySelectorAll<HTMLElement>(".suppression-seg");
-    const micro = Array.from(dndSegs).find(
+    const dndSegments = bars[0].querySelectorAll<HTMLElement>(".suppression-seg");
+    const micro = Array.from(dndSegments).find(
       (s) => s.dataset.kind === "micro",
     )!;
-    const long = Array.from(dndSegs).find((s) => s.dataset.kind === "long")!;
+    const long = Array.from(dndSegments).find((s) => s.dataset.kind === "long")!;
     expect(micro.style.getPropertyValue("--seg-width")).toBe("20%");
     expect(long.style.getPropertyValue("--seg-width")).toBe("80%");
   });

--- a/src/views/settings/components/suppression-bars.test.tsx
+++ b/src/views/settings/components/suppression-bars.test.tsx
@@ -1,0 +1,79 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+
+import { SuppressionBars } from "./suppression-bars";
+
+describe("SuppressionBars", () => {
+  afterEach(cleanup);
+
+  it("renders nothing when there are no suppressions", () => {
+    const { container } = render(<SuppressionBars rows={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders one row per reason with the per-reason total", () => {
+    render(
+      <SuppressionBars
+        rows={[
+          { kind: "long", reason: "dnd", label: "Do Not Disturb", count: 4 },
+          { kind: "micro", reason: "dnd", label: "Do Not Disturb", count: 2 },
+          { kind: "micro", reason: "camera", label: "Camera in use", count: 3 },
+        ]}
+      />,
+    );
+    expect(screen.getAllByRole("row")).toHaveLength(2);
+    const dnd = screen.getByRole("cell", { name: /Do Not Disturb: 6 suppressions/ });
+    expect(dnd).toBeTruthy();
+    const camera = screen.getByRole("cell", { name: /Camera in use: 3 suppressions/ });
+    expect(camera).toBeTruthy();
+  });
+
+  it("scales the outer bar to the busiest reason and segments to the row's own total", () => {
+    const { container } = render(
+      <SuppressionBars
+        rows={[
+          { kind: "long", reason: "dnd", label: "Do Not Disturb", count: 8 },
+          { kind: "micro", reason: "dnd", label: "Do Not Disturb", count: 2 },
+          { kind: "micro", reason: "camera", label: "Camera in use", count: 5 },
+        ]}
+      />,
+    );
+    const bars = container.querySelectorAll<HTMLElement>(".suppression-bar");
+    // Bar 0 is DnD (total 10 → 100% of max). Bar 1 is Camera (total 5 → 50%).
+    expect(bars[0].style.getPropertyValue("--bar-width")).toBe("100%");
+    expect(bars[1].style.getPropertyValue("--bar-width")).toBe("50%");
+
+    const dndSegs = bars[0].querySelectorAll<HTMLElement>(".suppression-seg");
+    const micro = Array.from(dndSegs).find(
+      (s) => s.dataset.kind === "micro",
+    )!;
+    const long = Array.from(dndSegs).find((s) => s.dataset.kind === "long")!;
+    expect(micro.style.getPropertyValue("--seg-width")).toBe("20%");
+    expect(long.style.getPropertyValue("--seg-width")).toBe("80%");
+  });
+
+  it("only shows kinds that appear in the data in the legend (no empty Sleep chip)", () => {
+    render(
+      <SuppressionBars
+        rows={[
+          { kind: "long", reason: "dnd", label: "Do Not Disturb", count: 1 },
+        ]}
+      />,
+    );
+    expect(screen.getByText("Long")).toBeTruthy();
+    expect(screen.queryByText("Micro")).toBeNull();
+    expect(screen.queryByText("Sleep")).toBeNull();
+  });
+
+  it("labels each segment with kind + reason + count for hover", () => {
+    render(
+      <SuppressionBars
+        rows={[
+          { kind: "micro", reason: "idle", label: "Idle", count: 7 },
+        ]}
+      />,
+    );
+    expect(document.querySelector('[title="Micro — Idle: 7"]')).not.toBeNull();
+  });
+});

--- a/src/views/settings/components/suppression-bars.tsx
+++ b/src/views/settings/components/suppression-bars.tsx
@@ -1,0 +1,73 @@
+import { groupSuppressionsByReason } from "../../../lib/stats-format";
+import type { SuppressionByKind } from "../types";
+
+const KIND_LABEL: Record<string, string> = {
+  micro: "Micro",
+  long: "Long",
+  sleep: "Sleep",
+};
+
+export function SuppressionBars({ rows }: { rows: SuppressionByKind[] }) {
+  const grouped = groupSuppressionsByReason(rows);
+  if (grouped.length === 0) return null;
+  const max = Math.max(1, ...grouped.map((g) => g.total));
+  const kindsPresent = Array.from(
+    new Set(grouped.flatMap((g) => g.segments.map((s) => s.kind))),
+  ).sort(
+    (a, b) =>
+      ["micro", "long", "sleep"].indexOf(a) -
+      ["micro", "long", "sleep"].indexOf(b),
+  );
+  return (
+    <div className="suppression-bars" role="table" aria-label="Suppressions by reason and break kind">
+      <div className="suppression-legend" role="presentation">
+        {kindsPresent.map((kind) => (
+          <span key={kind} className="suppression-legend-item" data-kind={kind}>
+            <span className="suppression-swatch" aria-hidden="true" />
+            {KIND_LABEL[kind] ?? kind}
+          </span>
+        ))}
+      </div>
+      {grouped.map((g) => {
+        const widthPct = (g.total / max) * 100;
+        return (
+          <div key={g.reason} className="suppression-row" role="row">
+            <span className="suppression-label" role="rowheader">
+              {g.label}
+            </span>
+            <div
+              className="suppression-track"
+              role="cell"
+              aria-label={`${g.label}: ${g.total} suppressions`}
+            >
+              <div
+                className="suppression-bar"
+                ref={(el) => {
+                  el?.style.setProperty("--bar-width", `${widthPct}%`);
+                }}
+              >
+                {g.segments.map((s) => {
+                  const segPct = (s.count / g.total) * 100;
+                  return (
+                    <div
+                      key={s.kind}
+                      className="suppression-seg"
+                      data-kind={s.kind}
+                      ref={(el) => {
+                        el?.style.setProperty("--seg-width", `${segPct}%`);
+                      }}
+                      title={`${KIND_LABEL[s.kind] ?? s.kind} — ${g.label}: ${s.count}`}
+                    />
+                  );
+                })}
+              </div>
+            </div>
+            <span className="suppression-total" role="cell">
+              {g.total}
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/views/settings/components/weekday-histogram.test.tsx
+++ b/src/views/settings/components/weekday-histogram.test.tsx
@@ -1,0 +1,69 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+
+import { WeekdayHistogram } from "./weekday-histogram";
+
+const days = [
+  { weekday: 0, taken: 2, dismissed: 1 },
+  { weekday: 1, taken: 5, dismissed: 0 },
+  { weekday: 2, taken: 0, dismissed: 0 },
+  { weekday: 3, taken: 1, dismissed: 4 },
+  { weekday: 4, taken: 3, dismissed: 0 },
+  { weekday: 5, taken: 0, dismissed: 0 },
+  { weekday: 6, taken: 1, dismissed: 1 },
+];
+
+describe("WeekdayHistogram", () => {
+  afterEach(cleanup);
+
+  it("renders a labelled image with seven labelled columns", () => {
+    render(<WeekdayHistogram days={days} />);
+    expect(screen.getByRole("img", { name: /by weekday/i })).toBeTruthy();
+    for (const label of ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]) {
+      expect(screen.getByText(label)).toBeTruthy();
+    }
+  });
+
+  it("normalises bar height against the largest single value across all days", () => {
+    // Largest single value across all weekdays is Tue.taken = 5.
+    // So Tue.taken renders at 100% and Thu.dismissed (4) at 80%.
+    const { container } = render(<WeekdayHistogram days={days} />);
+    const taken = container.querySelectorAll<HTMLElement>(".weekday-bar-taken");
+    expect(taken[1].style.getPropertyValue("--weekday-bar-height")).toBe(
+      "100%",
+    );
+    const dismissed = container.querySelectorAll<HTMLElement>(
+      ".weekday-bar-dismissed",
+    );
+    expect(dismissed[3].style.getPropertyValue("--weekday-bar-height")).toBe(
+      "80%",
+    );
+  });
+
+  it("gives every bar an individual hover title (taken and dismissed both)", () => {
+    render(<WeekdayHistogram days={days} />);
+    // Each weekday contributes two title strings; with 7 days that's 14
+    // tooltips. Spot-check the Tue pair and one Sat (both zeros) — the
+    // latter would regress if we accidentally suppressed zero-value bars.
+    expect(document.querySelector('[title="Tue: 5 taken"]')).not.toBeNull();
+    expect(document.querySelector('[title="Tue: 0 dismissed"]')).not.toBeNull();
+    expect(document.querySelector('[title="Sat: 0 taken"]')).not.toBeNull();
+    expect(
+      document.querySelector('[title="Sat: 0 dismissed"]'),
+    ).not.toBeNull();
+  });
+
+  it("never divides by zero when every day is empty", () => {
+    const empty = Array.from({ length: 7 }, (_, w) => ({
+      weekday: w,
+      taken: 0,
+      dismissed: 0,
+    }));
+    const { container } = render(<WeekdayHistogram days={empty} />);
+    const bars = container.querySelectorAll<HTMLElement>(".weekday-bar");
+    for (const bar of bars) {
+      expect(bar.style.getPropertyValue("--weekday-bar-height")).toBe("0%");
+    }
+  });
+});

--- a/src/views/settings/components/weekday-histogram.tsx
+++ b/src/views/settings/components/weekday-histogram.tsx
@@ -1,0 +1,46 @@
+import { weekdayLabel } from "../../../lib/stats-format";
+import type { WeekdayBucket } from "../types";
+
+export function WeekdayHistogram({ days }: { days: WeekdayBucket[] }) {
+  const max = Math.max(1, ...days.flatMap((d) => [d.taken, d.dismissed]));
+  return (
+    <div
+      className="weekday-histogram"
+      role="img"
+      aria-label="Breaks taken vs dismissed by weekday"
+    >
+      {days.map((d) => {
+        const takenPct = (d.taken / max) * 100;
+        const dismissedPct = (d.dismissed / max) * 100;
+        const label = weekdayLabel(d.weekday);
+        return (
+          <div key={d.weekday} className="weekday-col">
+            <div className="weekday-bar-pair">
+              <div
+                className="weekday-bar weekday-bar-taken"
+                ref={(el) => {
+                  el?.style.setProperty(
+                    "--weekday-bar-height",
+                    `${takenPct}%`,
+                  );
+                }}
+                title={`${label}: ${d.taken} taken`}
+              />
+              <div
+                className="weekday-bar weekday-bar-dismissed"
+                ref={(el) => {
+                  el?.style.setProperty(
+                    "--weekday-bar-height",
+                    `${dismissedPct}%`,
+                  );
+                }}
+                title={`${label}: ${d.dismissed} dismissed`}
+              />
+            </div>
+            <span className="weekday-label">{label}</span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/views/settings/hooks/use-stats.ts
+++ b/src/views/settings/hooks/use-stats.ts
@@ -17,10 +17,38 @@ const suppressionCountSchema = z.object({
   count: z.number(),
 });
 
+const suppressionByKindSchema = z.object({
+  kind: z.string(),
+  reason: z.string(),
+  label: z.string(),
+  count: z.number(),
+});
+
 const dayBucketSchema = z.object({
   date: z.string(),
   taken: z.number(),
   dismissed: z.number(),
+});
+
+const weekdayBucketSchema = z.object({
+  weekday: z.number(),
+  taken: z.number(),
+  dismissed: z.number(),
+});
+
+const previousPeriodSchema = z.object({
+  breaks_taken: z.number(),
+  breaks_dismissed: z.number(),
+  postponed_total: z.number(),
+  skipped_total: z.number(),
+});
+
+const postponeFollowThroughSchema = z.object({
+  total: z.number(),
+  taken: z.number(),
+  dismissed: z.number(),
+  skipped: z.number(),
+  unresolved: z.number(),
 });
 
 const statsDigestSchema = z.object({
@@ -35,10 +63,14 @@ const statsDigestSchema = z.object({
   postponed_total: z.number(),
   skipped_total: z.number(),
   suppressions: z.array(suppressionCountSchema),
+  suppressions_by_kind: z.array(suppressionByKindSchema),
   pause_total_secs: z.number(),
   pause_count: z.number(),
   by_hour: z.array(z.number()),
   by_day: z.array(dayBucketSchema),
+  by_weekday: z.array(weekdayBucketSchema),
+  previous: previousPeriodSchema,
+  postpone_follow_through: postponeFollowThroughSchema,
 }) satisfies z.ZodType<StatsDigest>;
 
 /** State + actions the Insights tab uses. `stats` is the in-session

--- a/src/views/settings/settings.css
+++ b/src/views/settings/settings.css
@@ -563,10 +563,10 @@ body,
   display: inline-flex;
   align-items: center;
   gap: 0.15rem;
-  font-size: 0.7rem;
+  font-size: 0.78rem;
   font-variant-numeric: tabular-nums;
   margin-left: 0.4rem;
-  padding: 0.05rem 0.35rem;
+  padding: 0.05rem 0.4rem;
   border-radius: 999px;
   background: var(--input-bg);
   color: var(--muted-fg);
@@ -574,17 +574,28 @@ body,
 }
 
 .settings .delta-chip.up {
-  color: #4ec38a;
-  border-color: rgba(78, 195, 138, 0.4);
+  color: var(--delta-up, #4ec38a);
+  border-color: var(--delta-up-border, rgba(78, 195, 138, 0.4));
 }
 
 .settings .delta-chip.down {
-  color: #e07b91;
-  border-color: rgba(224, 123, 145, 0.4);
+  color: var(--delta-down, #e07b91);
+  border-color: var(--delta-down-border, rgba(224, 123, 145, 0.4));
 }
 
 .settings .delta-chip.flat {
   opacity: 0.7;
+}
+
+@media (prefers-color-scheme: light) {
+  .settings .delta-chip.up {
+    --delta-up: #1f7a4a;
+    --delta-up-border: rgba(31, 122, 74, 0.4);
+  }
+  .settings .delta-chip.down {
+    --delta-down: #b03050;
+    --delta-down-border: rgba(176, 48, 80, 0.4);
+  }
 }
 
 .settings .suppression-kind-tag {

--- a/src/views/settings/settings.css
+++ b/src/views/settings/settings.css
@@ -499,6 +499,265 @@ body,
   font-variant-numeric: tabular-nums;
 }
 
+.settings .weekday-histogram {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  align-items: end;
+  height: 120px;
+  gap: 6px;
+  padding: 0.5rem 0 1.4rem;
+  border-bottom: 1px solid var(--input-border);
+  position: relative;
+}
+
+.settings .weekday-col {
+  position: relative;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+}
+
+.settings .weekday-bar-pair {
+  display: flex;
+  flex-direction: row;
+  align-items: flex-end;
+  justify-content: center;
+  gap: 3px;
+  height: 100%;
+}
+
+.settings .weekday-bar {
+  flex: 1 1 0;
+  min-height: 2px;
+  height: var(--weekday-bar-height, 0%);
+  border-radius: 2px 2px 0 0;
+  cursor: help;
+}
+
+.settings .weekday-bar-taken {
+  background: var(--accent);
+  opacity: 0.95;
+}
+
+.settings .weekday-bar-dismissed {
+  background: var(--accent);
+  opacity: 0.35;
+}
+
+.settings .weekday-bar:hover {
+  opacity: 1;
+  filter: brightness(1.08);
+}
+
+.settings .weekday-label {
+  position: absolute;
+  bottom: -1.2rem;
+  width: 100%;
+  text-align: center;
+  font-size: 0.7rem;
+  color: var(--faint-fg);
+}
+
+.settings .delta-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.15rem;
+  font-size: 0.7rem;
+  font-variant-numeric: tabular-nums;
+  margin-left: 0.4rem;
+  padding: 0.05rem 0.35rem;
+  border-radius: 999px;
+  background: var(--input-bg);
+  color: var(--muted-fg);
+  border: 1px solid var(--input-border);
+}
+
+.settings .delta-chip.up {
+  color: #4ec38a;
+  border-color: rgba(78, 195, 138, 0.4);
+}
+
+.settings .delta-chip.down {
+  color: #e07b91;
+  border-color: rgba(224, 123, 145, 0.4);
+}
+
+.settings .delta-chip.flat {
+  opacity: 0.7;
+}
+
+.settings .suppression-kind-tag {
+  display: inline-block;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--faint-fg);
+  margin-right: 0.5rem;
+  min-width: 2.6rem;
+}
+
+.settings .suppression-bars {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.4rem;
+  padding: 0.25rem 0 0.5rem;
+}
+
+.settings .suppression-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  font-size: 0.78rem;
+  color: var(--muted-fg);
+  margin-bottom: 0.3rem;
+}
+
+.settings .suppression-legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.settings .suppression-swatch {
+  width: 0.7rem;
+  height: 0.7rem;
+  border-radius: 2px;
+  display: inline-block;
+}
+
+.settings .suppression-legend-item[data-kind="micro"] .suppression-swatch,
+.settings .suppression-seg[data-kind="micro"] {
+  background: var(--primary-color);
+}
+
+.settings .suppression-legend-item[data-kind="long"] .suppression-swatch,
+.settings .suppression-seg[data-kind="long"] {
+  background: var(--secondary-color);
+}
+
+.settings .suppression-legend-item[data-kind="sleep"] .suppression-swatch,
+.settings .suppression-seg[data-kind="sleep"] {
+  background: var(--accent-color);
+}
+
+.settings .suppression-row {
+  display: grid;
+  grid-template-columns: 9rem 1fr 2.5rem;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 0.85rem;
+}
+
+.settings .suppression-label {
+  color: var(--muted-fg);
+}
+
+.settings .suppression-track {
+  position: relative;
+  width: 100%;
+  height: 14px;
+  background: var(--input-bg);
+  border: 1px solid var(--input-border);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.settings .suppression-bar {
+  display: flex;
+  height: 100%;
+  width: var(--bar-width, 0%);
+}
+
+.settings .suppression-seg {
+  height: 100%;
+  width: var(--seg-width, 0%);
+  cursor: help;
+}
+
+.settings .suppression-seg:hover {
+  filter: brightness(1.1);
+}
+
+.settings .suppression-total {
+  text-align: right;
+  color: var(--muted-fg);
+  font-variant-numeric: tabular-nums;
+}
+
+.settings .donut-wrap {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 1rem 1.25rem;
+  align-items: center;
+  padding: 0.5rem 0;
+}
+
+.settings .donut {
+  width: 140px;
+  height: 140px;
+  display: block;
+}
+
+.settings .donut-total {
+  font-size: 1.4rem;
+  font-weight: 600;
+  fill: var(--fg);
+  font-variant-numeric: tabular-nums;
+}
+
+.settings .donut-caption {
+  font-size: 0.55rem;
+  fill: var(--faint-fg);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.settings .donut-legend {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.35rem;
+  font-size: 0.85rem;
+}
+
+.settings .donut-legend li {
+  display: grid;
+  grid-template-columns: 0.75rem 1fr auto;
+  align-items: center;
+  gap: 0.55rem;
+}
+
+.settings .donut-swatch {
+  width: 0.75rem;
+  height: 0.75rem;
+  border-radius: 3px;
+  display: inline-block;
+}
+
+.settings .donut-legend li[data-segment="taken"] .donut-swatch {
+  background: var(--primary-color);
+}
+
+.settings .donut-legend li[data-segment="dismissed"] .donut-swatch {
+  background: var(--secondary-color);
+}
+
+.settings .donut-legend li[data-segment="skipped"] .donut-swatch {
+  background: var(--accent-color);
+}
+
+.settings .donut-legend li[data-segment="unresolved"] .donut-swatch {
+  background: var(--light-primary-color);
+}
+
+.settings .donut-legend-value {
+  font-variant-numeric: tabular-nums;
+  color: var(--muted-fg);
+}
+
 .settings .heatmap-wrap {
   display: grid;
   grid-template-columns: auto 1fr;

--- a/src/views/settings/tabs/insights-tab.tsx
+++ b/src/views/settings/tabs/insights-tab.tsx
@@ -1,15 +1,43 @@
 import { useEffect, useMemo, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import {
+  deltaDirection,
+  deltaPct,
   dismissalRate,
   formatHoursMinutes,
 } from "../../../lib/stats-format";
 import { localDateString } from "../../../lib/time";
 import { HourHistogram } from "../components/hour-histogram";
 import { Heatmap } from "../components/heatmap";
+import { PostponeDonut } from "../components/postpone-donut";
+import { SuppressionBars } from "../components/suppression-bars";
+import { WeekdayHistogram } from "../components/weekday-histogram";
 import type { UseStats } from "../hooks/use-stats";
 import type { StatsRange } from "../types";
 import { downloadCsv } from "../utils";
+
+function DeltaChip({
+  curr,
+  prev,
+  goodDirection = "up",
+}: {
+  curr: number;
+  prev: number;
+  goodDirection?: "up" | "down";
+}) {
+  const dir = deltaDirection(curr, prev);
+  const tone =
+    dir === "flat"
+      ? "flat"
+      : dir === goodDirection
+        ? "up"
+        : "down";
+  return (
+    <span className={`delta-chip ${tone}`} title={`Previous: ${prev}`}>
+      {deltaPct(curr, prev)}
+    </span>
+  );
+}
 
 export function InsightsTab({ stats }: { stats: UseStats }) {
   // Destructure to stable callback references — `useStats` returns a fresh
@@ -108,6 +136,10 @@ export function InsightsTab({ stats }: { stats: UseStats }) {
               <div className="stat-card">
                 <span className="stat-card-value">
                   {digest.micro_taken + digest.long_taken}
+                  <DeltaChip
+                    curr={digest.micro_taken + digest.long_taken}
+                    prev={digest.previous.breaks_taken}
+                  />
                 </span>
                 <span className="stat-card-label">Breaks taken</span>
                 <span className="stat-card-sub">
@@ -120,6 +152,11 @@ export function InsightsTab({ stats }: { stats: UseStats }) {
                     digest.micro_taken + digest.long_taken,
                     digest.micro_dismissed + digest.long_dismissed,
                   )}
+                  <DeltaChip
+                    curr={digest.micro_dismissed + digest.long_dismissed}
+                    prev={digest.previous.breaks_dismissed}
+                    goodDirection="down"
+                  />
                 </span>
                 <span className="stat-card-label">Dismissal rate</span>
                 <span className="stat-card-sub">
@@ -146,21 +183,40 @@ export function InsightsTab({ stats }: { stats: UseStats }) {
                 </span>
               </div>
             </div>
+            <p className="stat-card-sub">
+              Delta chips compare with the previous{" "}
+              {range === "month" ? "30 days" : "7 days"}.
+            </p>
           </section>
 
-          {digest.suppressions.length > 0 && (
+          {digest.postpone_follow_through.total > 0 && (
             <>
-              <h2>Breaks suppressed by</h2>
+              <h2>Postpone follow-through</h2>
               <section>
-                {digest.suppressions.map((s) => (
-                  <div key={s.reason} className="row">
-                    <span>{s.label}</span>
-                    <span className="stat-card-sub">{s.count}</span>
-                  </div>
-                ))}
+                <p className="stat-card-sub">
+                  How postponed breaks eventually resolved.
+                </p>
+                <PostponeDonut data={digest.postpone_follow_through} />
               </section>
             </>
           )}
+
+          {digest.suppressions_by_kind.length > 0 && (
+            <>
+              <h2>Breaks suppressed by</h2>
+              <section>
+                <SuppressionBars rows={digest.suppressions_by_kind} />
+              </section>
+            </>
+          )}
+
+          <h2>By weekday</h2>
+          <section>
+            <WeekdayHistogram days={digest.by_weekday} />
+            <p className="stat-card-sub">
+              Solid: taken. Faded: dismissed. Hover a bar for counts.
+            </p>
+          </section>
 
           <h2>Time of day</h2>
           <section>

--- a/src/views/settings/types.ts
+++ b/src/views/settings/types.ts
@@ -133,10 +133,38 @@ type SuppressionCount = {
   count: number;
 };
 
+export type SuppressionByKind = {
+  kind: string;
+  reason: string;
+  label: string;
+  count: number;
+};
+
 export type DayBucket = {
   date: string;
   taken: number;
   dismissed: number;
+};
+
+export type WeekdayBucket = {
+  weekday: number;
+  taken: number;
+  dismissed: number;
+};
+
+export type PreviousPeriod = {
+  breaks_taken: number;
+  breaks_dismissed: number;
+  postponed_total: number;
+  skipped_total: number;
+};
+
+export type PostponeFollowThrough = {
+  total: number;
+  taken: number;
+  dismissed: number;
+  skipped: number;
+  unresolved: number;
 };
 
 export type StatsDigest = {
@@ -151,10 +179,14 @@ export type StatsDigest = {
   postponed_total: number;
   skipped_total: number;
   suppressions: SuppressionCount[];
+  suppressions_by_kind: SuppressionByKind[];
   pause_total_secs: number;
   pause_count: number;
   by_hour: number[];
   by_day: DayBucket[];
+  by_weekday: WeekdayBucket[];
+  previous: PreviousPeriod;
+  postpone_follow_through: PostponeFollowThrough;
 };
 
 export type StatsRange = "week" | "month";


### PR DESCRIPTION
## Summary

Extracts three new cuts from the existing `events.jsonl` stream — no schema changes — and gives them dedicated visuals on the Insights tab:

- **Week-over-week delta chips** on "Breaks taken" and "Dismissal rate". Each chip compares the current range with the same-length window immediately before it; tone follows a per-card `goodDirection` so "more dismissals" reads red, not green.
- **By weekday** grouped bar (taken vs dismissed). Side-by-side bars per weekday so each bar keeps an independent hover tooltip and bars don't oversaturate when both stats are high on the same day.
- **Suppression stacked bar** — collapses up to 18 monthly `(kind, reason)` rows into ≤6 rows, one per reason. Bar width scales to the busiest reason; segments inside the bar split by break kind using the brand palette. Legend only renders kinds actually present.
- **Postpone follow-through donut** (taken / dismissed / skipped / unresolved) with the same brand colours. Renders nothing when there are no postpones.

Chart choice for the suppression view follows the [Datawrapper guide](https://www.datawrapper.de/blog/chart-types-guide): comparison-across-reasons + composition-by-kind → horizontal stacked bar, accepting the trade-off that comparing same-coloured segments across rows is harder (the headline question is "which reason dominates", not cross-reason comparisons of one kind).

Backend `compute_digest` now also emits a `previous` window, a per-kind suppression breakdown, and `postpone_follow_through` (walks forward from each in-range `BreakPostponed` for the next same-kind `BreakEnd`/`BreakSkipped`).

`BreakKind` gained `Hash` so the per-kind suppression `HashMap` key compiles. IPC parity tests extended for `SuppressionByKind`, `WeekdayBucket`, `PreviousPeriod`, `PostponeFollowThrough`.

## Test plan

- [ ] `cargo test --manifest-path src-tauri/Cargo.toml --lib` — 498 pass, 7 new in `stats::tests`
- [ ] `npm test` — 401 pass; new component tests for `WeekdayHistogram`, `SuppressionBars`, `PostponeDonut`; helper tests for `weekdayLabel`, `deltaPct`, `deltaDirection`, `groupSuppressionsByReason`
- [ ] `npx tsc --noEmit` — clean
- [ ] `npm run build` — clean
- [x] Manually open the Insights tab on both **Past week** and **Past month** ranges; verify donut is hidden when no postpones, weekday bars hover-tooltip on every cell (including zero-count ones), suppression legend shrinks/grows with kinds present, delta chips render `—` when previous period is empty
- [x] Verify in light + dark `prefers-color-scheme` that the brand palette segments are legible
- [ ] `npm run audit:a11y` once locally (CI also gates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)