### PR TITLE
feat(packaging): prep for Homebrew + RPM, rename bundle id

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -8,7 +8,7 @@ Cross-platform break reminder app named after the theatre interval between acts.
 - **Backend**: Rust + Tauri 2 + Tokio, lives in [src-tauri](../src-tauri/).
 - **Notable deps**: `chrono` (local time), `user-idle` (cross-platform idle), `tauri-plugin-notification`, `tauri-plugin-opener`. Windows-only: `winreg`, `windows-sys`.
 - **License**: Apache-2.0.
-- **Bundle id**: `app.entracte`. Lib crate: `entracte_lib`. (Previously `dev.mowinckel.entracte` — old installs keep their data dir under the old id until the user migrates it manually.)
+- **Bundle id**: `io.drmowinckels.entracte`. Lib crate: `entracte_lib`. (History: `dev.mowinckel.entracte` → `app.entracte` → `io.drmowinckels.entracte`, the last rename happened pre-v0.0.1 in preparation for Homebrew submission. Pre-rename dev installs keep their data dir under the old id until the user migrates it manually.)
 
 ## Layout
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -70,9 +70,9 @@ body:
 
         Entracte writes to `entracte.log` in the OS-standard app log directory:
 
-        - **macOS**: `~/Library/Logs/app.entracte/entracte.log`
-        - **Linux**: `~/.local/share/app.entracte/logs/entracte.log` (XDG, may vary)
-        - **Windows**: `%LOCALAPPDATA%\app.entracte\logs\entracte.log`
+        - **macOS**: `~/Library/Logs/io.drmowinckels.entracte/entracte.log`
+        - **Linux**: `~/.local/share/io.drmowinckels.entracte/logs/entracte.log` (XDG, may vary)
+        - **Windows**: `%LOCALAPPDATA%\io.drmowinckels.entracte\logs\entracte.log`
 
         The last few rotated files (`entracte.log.1`, `.2`, …) live in the same directory if the bug pre-dates the most recent restart.
 

--- a/.github/workflows/bump-cask.yml
+++ b/.github/workflows/bump-cask.yml
@@ -1,0 +1,127 @@
+name: Bump Homebrew cask
+
+# Opens a same-repo PR bumping Casks/entracte.rb (version + both sha256
+# lines) whenever a new non-prerelease GitHub release is published.
+# Uses the default GITHUB_TOKEN — no PAT required because the cask
+# lives in this repo (users tap with `brew tap drmowinckels/entracte
+# https://github.com/drmowinckels/entracte`).
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to bump from (e.g. v0.1.2)"
+        required: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: bump-cask-${{ github.event.release.tag_name || inputs.tag }}
+  cancel-in-progress: false
+
+jobs:
+  bump-cask:
+    if: github.event_name == 'workflow_dispatch' || !github.event.release.prerelease
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve tag and version
+        id: meta
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            tag="${{ github.event.release.tag_name }}"
+          else
+            tag="${{ inputs.tag }}"
+          fi
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+          echo "version=${tag#v}" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/checkout@v6
+
+      - name: Fetch SHA256SUMS.txt
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release download "${{ steps.meta.outputs.tag }}" \
+            --repo "${{ github.repository }}" \
+            --pattern "SHA256SUMS.txt"
+
+      - name: Extract DMG checksums
+        id: shas
+        run: |
+          version="${{ steps.meta.outputs.version }}"
+          arm_file="Entracte_${version}_aarch64.dmg"
+          intel_file="Entracte_${version}_x64.dmg"
+
+          arm=$(awk -v f="$arm_file"     '$2 == f { print $1 }' SHA256SUMS.txt)
+          intel=$(awk -v f="$intel_file" '$2 == f { print $1 }' SHA256SUMS.txt)
+
+          if [ -z "$arm" ] || [ -z "$intel" ]; then
+            echo "::error::missing DMG checksum(s) — looked for ${arm_file} and ${intel_file}"
+            echo "SHA256SUMS.txt contents:"
+            cat SHA256SUMS.txt
+            exit 1
+          fi
+
+          echo "arm=$arm" >> "$GITHUB_OUTPUT"
+          echo "intel=$intel" >> "$GITHUB_OUTPUT"
+
+      - name: Bump cask
+        run: |
+          cask=Casks/entracte.rb
+          version="${{ steps.meta.outputs.version }}"
+          arm="${{ steps.shas.outputs.arm }}"
+          intel="${{ steps.shas.outputs.intel }}"
+
+          sed -i -E "s/^(  version) \"[^\"]+\"/\1 \"${version}\"/" "$cask"
+          sed -i -E "s|^(  sha256 arm:[[:space:]]+\")[0-9a-f]{64}(\")|\1${arm}\2|" "$cask"
+          sed -i -E "s|^(         intel:[[:space:]]+\")[0-9a-f]{64}(\")|\1${intel}\2|" "$cask"
+
+          grep -q "version \"${version}\"" "$cask" \
+            || { echo "::error::version line not updated"; exit 1; }
+          grep -q "${arm}" "$cask" \
+            || { echo "::error::arm sha not updated"; exit 1; }
+          grep -q "${intel}" "$cask" \
+            || { echo "::error::intel sha not updated"; exit 1; }
+
+          grep -E '^(  version|  sha256|         intel:)' "$cask"
+
+      - name: Commit, push, open PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          version="${{ steps.meta.outputs.version }}"
+          branch="bump-cask/${version}"
+
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          if git diff --quiet Casks/entracte.rb; then
+            echo "Cask already at ${version} — nothing to bump."
+            exit 0
+          fi
+
+          git checkout -b "$branch"
+          git add Casks/entracte.rb
+          git commit -m "Bump cask to ${version}"
+          git push --force-with-lease origin "$branch"
+
+          # Idempotent: reuse an open PR for this version if one exists.
+          if gh pr view "$branch" --json number --jq .number >/dev/null 2>&1; then
+            echo "PR for $branch already exists — branch updated in place."
+          else
+            gh pr create \
+              --base main \
+              --head "$branch" \
+              --title "Bump cask to ${version}" \
+              --body "Automated cask bump triggered by [\`${{ steps.meta.outputs.tag }}\`](https://github.com/${{ github.repository }}/releases/tag/${{ steps.meta.outputs.tag }}).
+
+          - version → \`${version}\`
+          - sha256 arm → \`${{ steps.shas.outputs.arm }}\`
+          - sha256 intel → \`${{ steps.shas.outputs.intel }}\`
+
+          Once merged, \`brew upgrade --cask entracte\` picks up the new version."
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
         if: matrix.platform == 'ubuntu-22.04'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libxss-dev
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libxss-dev rpm
 
       - uses: actions/setup-node@v6
         with:
@@ -53,8 +53,6 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
-          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
           projectPath: .
           tagName: ${{ github.ref_name }}
@@ -127,3 +125,83 @@ jobs:
           draft: true
           tag_name: ${{ github.ref_name }}
           files: signed/*
+
+  # Aggregate SHA256 checksums for every artifact on the draft release into
+  # SHA256SUMS.txt (uploaded as an asset) and a markdown table appended to
+  # the release body. The table sits between HTML markers so re-runs replace
+  # the section instead of stacking duplicates. Needed by the Homebrew cask
+  # bump and any other downstream packagers that pin by sha256.
+  checksums:
+    needs: [build-unix, sign-windows]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download all release assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p assets
+          gh release download "${{ github.ref_name }}" \
+            --repo "${{ github.repository }}" \
+            --dir assets \
+            --pattern '*'
+
+      - name: Compute SHA256SUMS.txt
+        run: |
+          cd assets
+          # Checksum every artifact except updater signatures and any
+          # pre-existing checksum files from a prior re-run.
+          mapfile -t files < <(ls -1 | grep -vE '\.(sig|sha256)$|^SHA256SUMS')
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "::error::no artifacts found on draft release"
+            exit 1
+          fi
+          shasum -a 256 "${files[@]}" | tee ../SHA256SUMS.txt
+
+      - name: Upload SHA256SUMS.txt as a release asset
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "${{ github.ref_name }}" SHA256SUMS.txt \
+            --repo "${{ github.repository }}" \
+            --clobber
+
+      - name: Splice checksum table into release notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          START='<!-- checksums:start -->'
+          END='<!-- checksums:end -->'
+
+          {
+            echo "## Checksums"
+            echo ""
+            echo "| File | SHA256 |"
+            echo "| --- | --- |"
+            while read -r sum file; do
+              echo "| \`${file}\` | \`${sum}\` |"
+            done < SHA256SUMS.txt
+          } > checksums.md
+
+          gh release view "${{ github.ref_name }}" \
+            --repo "${{ github.repository }}" \
+            --json body --jq '.body // ""' > current.md
+
+          # Strip any previous checksums block (markers + content between them).
+          awk -v s="$START" -v e="$END" '
+            $0 == s { skip = 1; next }
+            $0 == e { skip = 0; next }
+            !skip   { print }
+          ' current.md > stripped.md
+
+          {
+            cat stripped.md
+            printf '\n%s\n' "$START"
+            cat checksums.md
+            printf '%s\n' "$END"
+          } > combined.md
+
+          gh release edit "${{ github.ref_name }}" \
+            --repo "${{ github.repository }}" \
+            --notes-file combined.md

--- a/Casks/entracte.rb
+++ b/Casks/entracte.rb
@@ -1,0 +1,32 @@
+cask "entracte" do
+  arch arm: "aarch64", intel: "x64"
+
+  version "0.0.1"
+  sha256 arm:   "0000000000000000000000000000000000000000000000000000000000000000",
+         intel: "0000000000000000000000000000000000000000000000000000000000000000"
+
+  url "https://github.com/drmowinckels/entracte/releases/download/v#{version}/Entracte_#{version}_#{arch}.dmg",
+      verified: "github.com/drmowinckels/entracte/"
+
+  name "Entracte"
+  desc "Cross-platform break reminder named after the theatre interval between acts"
+  homepage "https://github.com/drmowinckels/entracte"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on macos: ">= :big_sur"
+
+  app "Entracte.app"
+
+  zap trash: [
+    "~/Library/Application Support/io.drmowinckels.entracte",
+    "~/Library/Caches/io.drmowinckels.entracte",
+    "~/Library/Logs/io.drmowinckels.entracte",
+    "~/Library/Preferences/io.drmowinckels.entracte.plist",
+    "~/Library/LaunchAgents/io.drmowinckels.entracte.plist",
+    "~/Library/Saved Application State/io.drmowinckels.entracte.savedState",
+  ]
+end

--- a/README.md
+++ b/README.md
@@ -67,6 +67,17 @@ Entracte keeps a local history of breaks taken, dismissed, and suppressed, with 
   <img src="docs/screenshots/stats-heatmap.png" alt="Stats charts: time-of-day distribution and 12-week heatmap" width="480" />
 </p>
 
+## Install
+
+**macOS** — via Homebrew (the cask lives in this repo, so tap from URL):
+
+```sh
+brew tap drmowinckels/entracte https://github.com/drmowinckels/entracte
+brew install --cask drmowinckels/entracte/entracte
+```
+
+**Linux / Windows** — download the `.deb`, `.rpm`, `.AppImage`, `.msi`, or `.exe` from the [latest release](https://github.com/drmowinckels/entracte/releases/latest).
+
 ## Command line
 
 The same `entracte` binary doubles as a small CLI for scripting / hotkey wiring. Action commands forward to the running tray app:
@@ -158,6 +169,6 @@ Functional and usable day-to-day on macOS. Windows and Linux build and run; some
 
 Settings persist to a JSON file in the OS app-config dir:
 
-- **macOS** — `~/Library/Application Support/app.entracte/`
-- **Windows** — `%APPDATA%\app.entracte\`
-- **Linux** — `~/.config/app.entracte/`
+- **macOS** — `~/Library/Application Support/io.drmowinckels.entracte/`
+- **Windows** — `%APPDATA%\io.drmowinckels.entracte\`
+- **Linux** — `~/.config/io.drmowinckels.entracte/`

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -91,9 +91,9 @@ Prints the entracte log file from disk and follows new entries as they're writte
 
 The log lives at:
 
-- macOS: `~/Library/Logs/app.entracte/entracte.log`
-- Linux: `$XDG_STATE_HOME/app.entracte/logs/entracte.log` (defaults to `~/.local/state/...`)
-- Windows: `%LOCALAPPDATA%\app.entracte\logs\entracte.log`
+- macOS: `~/Library/Logs/io.drmowinckels.entracte/entracte.log`
+- Linux: `$XDG_STATE_HOME/io.drmowinckels.entracte/logs/entracte.log` (defaults to `~/.local/state/...`)
+- Windows: `%LOCALAPPDATA%\io.drmowinckels.entracte\logs\entracte.log`
 
 ### `help`
 
@@ -123,7 +123,7 @@ Flags can be combined freely; profile is applied first, colour after. Unknown va
 The CLI uses two channels depending on the command:
 
 - **Action commands** (`pause`, `resume`, `trigger`, `skip`) ship to the running instance through the OS's single-instance channel. They're fire-and-forget — no return value. If no instance is running, the binary boots the tray app and the action is ignored.
-- **Query / mutation commands** (`status`, `profile`, `settings`) talk to the running app over a localhost-only TCP socket. The running app writes its port to `~/Library/Application Support/app.entracte/ipc-port` (or the platform equivalent) at startup; the CLI reads that file and connects. These commands require the app to be running and print their response to your terminal.
+- **Query / mutation commands** (`status`, `profile`, `settings`) talk to the running app over a localhost-only TCP socket. The running app writes its port to `~/Library/Application Support/io.drmowinckels.entracte/ipc-port` (or the platform equivalent) at startup; the CLI reads that file and connects. These commands require the app to be running and print their response to your terminal.
 - **Local commands** (`log`, `help`) never touch the running app and always print to the calling terminal.
 
 ## Tips

--- a/docs/guide/supporter.md
+++ b/docs/guide/supporter.md
@@ -42,9 +42,9 @@ The key is bound to the machine you activate it on. You can remove it from one m
 
 Activation calls the license API and stores a small `supporter.json` in Entracte's app-data directory:
 
-- **macOS** — `~/Library/Application Support/app.entracte/supporter.json`
-- **Windows** — `%APPDATA%\app.entracte\supporter.json`
-- **Linux** — `~/.config/app.entracte/supporter.json`
+- **macOS** — `~/Library/Application Support/io.drmowinckels.entracte/supporter.json`
+- **Windows** — `%APPDATA%\io.drmowinckels.entracte\supporter.json`
+- **Linux** — `~/.config/io.drmowinckels.entracte/supporter.json`
 
 It's deliberately _not_ in `settings.json` — that file is often synced through dotfile managers, and a supporter key is machine-bound by design.
 

--- a/src-tauri/src/cli.rs
+++ b/src-tauri/src/cli.rs
@@ -240,7 +240,7 @@ pub fn help_text() -> &'static str {
 
 pub fn log_path() -> Option<std::path::PathBuf> {
     use std::path::PathBuf;
-    const BUNDLE: &str = "app.entracte";
+    const BUNDLE: &str = "io.drmowinckels.entracte";
     const FILE: &str = "entracte.log";
     #[cfg(target_os = "macos")]
     {
@@ -727,7 +727,10 @@ mod tests {
     fn log_path_uses_bundle_subdir() {
         let p = log_path().expect("log_path resolves on the test platform");
         let s = p.to_string_lossy();
-        assert!(s.contains("app.entracte"), "missing bundle id in {s}");
+        assert!(
+            s.contains("io.drmowinckels.entracte"),
+            "missing bundle id in {s}"
+        );
         assert!(s.ends_with("entracte.log"), "wrong filename in {s}");
     }
 }

--- a/src-tauri/src/ipc.rs
+++ b/src-tauri/src/ipc.rs
@@ -347,7 +347,7 @@ pub fn call(req: &IpcRequest, data_dir: &Path) -> Result<IpcResponse, String> {
 }
 
 pub fn ipc_data_dir() -> Option<PathBuf> {
-    const BUNDLE: &str = "app.entracte";
+    const BUNDLE: &str = "io.drmowinckels.entracte";
     #[cfg(target_os = "macos")]
     {
         std::env::var_os("HOME").map(|h| {
@@ -747,7 +747,7 @@ mod tests {
     #[test]
     fn ipc_data_dir_contains_bundle_id() {
         let d = ipc_data_dir().expect("resolves on test platform");
-        assert!(d.to_string_lossy().contains("app.entracte"));
+        assert!(d.to_string_lossy().contains("io.drmowinckels.entracte"));
     }
 
     #[test]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Entracte",
   "version": "0.0.1",
-  "identifier": "app.entracte",
+  "identifier": "io.drmowinckels.entracte",
   "build": {
     "beforeDevCommand": "npm run dev",
     "devUrl": "http://localhost:1420",


### PR DESCRIPTION
## Summary

- Drafts a Homebrew cask at [`Casks/entracte.rb`](Casks/entracte.rb) and an auto-bump workflow that opens a same-repo PR on release publish — no separate `homebrew-entracte` tap, no PAT.
- Adds `rpm` to the Linux release build so Tauri bundles `.rpm` alongside `.deb` / `.AppImage`; new `checksums` job uploads `SHA256SUMS.txt` and splices a checksum table into the release notes between markers (idempotent on re-runs).
- Renames bundle id `app.entracte` → `io.drmowinckels.entracte` (matches `drmowinckels.io`, proper reverse-DNS; nothing shipped yet so no migration).
- Strips `TAURI_SIGNING_*` env refs from `release.yml` — they'll return alongside the updater-plugin PR.

## How users will install once v0.0.1 ships

```sh
brew tap drmowinckels/entracte https://github.com/drmowinckels/entracte
brew install --cask drmowinckels/entracte/entracte
```

## Test plan

- [x] `cargo test --lib cli:: ipc::` — 45 tests pass with new bundle id constant + assertions
- [x] `python3 -m yaml` validates both `release.yml` and `bump-cask.yml`
- [x] `ruby -c Casks/entracte.rb` — cask syntax OK
- [x] Sed substitutions in `bump-cask.yml` dry-run against the placeholder cask — version + both shas update, formatting preserved
- [ ] First signed v0.0.1 tag — verify DMG filenames match the cask `url` template (`Entracte_\${version}_aarch64.dmg`, `Entracte_\${version}_x64.dmg`)
- [ ] First release publish — confirm `bump-cask` workflow opens a PR with real SHAs
- [ ] `brew install --cask` on a clean macOS box — confirm app launches, `~/Library/Application Support/io.drmowinckels.entracte/` is created, `brew uninstall --zap` clears all six zap paths

## Follow-ups (not in this PR)

- Updater plugin wiring (separate worktree) — will re-introduce the two `TAURI_SIGNING_*` env entries and add `plugins.updater.pubkey` to `tauri.conf.json`.
- Apple secrets sanity check before tagging: cert type must be "Developer ID Application"; `APPLE_PASSWORD` must be an app-specific password.

🤖 Generated with [Claude Code](https://claude.com/claude-code)