### PR TITLE
ci(cspell): allow Mermaid keywords (autonumber, Sched)

### DIFF
--- a/.github/audit/cspell/project-words.txt
+++ b/.github/audit/cspell/project-words.txt
@@ -33,6 +33,9 @@ cargo-deny
 knip
 cspell
 lychee
+mermaid
+autonumber
+Sched
 size-limit
 Codecov
 codecov


### PR DESCRIPTION
## Summary

PR #44 added Mermaid sequence diagrams in [docs/developer/ipc.md](docs/developer/ipc.md) and [docs/architecture/](docs/architecture/). cspell flags:

- `autonumber` — Mermaid sequence-diagram keyword
- `Sched` — participant alias for the scheduler
- `mermaid` — added defensively for the code-fence label / text contexts

Currently blocking the `audit` check on every open PR (e.g. #43).

## Test plan

- [ ] CI: `audit` check passes on this PR
- [ ] After merge, rebase #43 → audit goes green there too

🤖 Generated with [Claude Code](https://claude.com/claude-code)