### PR TITLE
ci: split audit + advisory into their own workflow (no paths-ignore)

### DIFF
--- a/.github/audit/cspell/project-words.txt
+++ b/.github/audit/cspell/project-words.txt
@@ -33,6 +33,9 @@ cargo-deny
 knip
 cspell
 lychee
+mermaid
+autonumber
+Sched
 size-limit
 Codecov
 codecov

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,164 @@
+name: Audit
+
+# Audit / advisory checks that target documentation as much as code
+# (cspell, lychee). They MUST NOT carry a `paths-ignore` filter — a
+# docs-only PR can still introduce unknown words or broken links that
+# the next non-docs PR would otherwise inherit as silent main rot.
+#
+# Frontend / Rust build-and-test jobs stay in ci.yml with their docs
+# paths-ignore, because they don't gain signal from a docs-only diff.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: audit-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # Hard-fail audits: enforce correctness on every PR.
+  audit:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: lts/*
+          cache: npm
+          cache-dependency-path: package-lock.json
+      - run: npm ci
+      - name: knip (unused exports / deps)
+        run: npm run audit:knip
+      - name: cspell (spell check)
+        run: npm run audit:spell
+      - name: size-limit (bundle budget)
+        run: npm run audit:size
+
+  # Advisory audits: surface signal without blocking merges.
+  # cargo-deny covers licenses + CVEs + duplicate-version checks.
+  # npm audit is externally-validated and can flap, so it stays advisory.
+  # lychee is now merge-blocking — its step keeps `continue-on-error`
+  # so cargo-deny / npm-audit / the sticky-comment all still run, but
+  # the job's final step exits non-zero if lychee flagged any link.
+  # Findings are aggregated into one sticky PR comment.
+  advisory:
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: lts/*
+          cache: npm
+          cache-dependency-path: package-lock.json
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+      - run: mkdir -p audit-reports
+
+      - name: Install cargo-deny
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-deny
+
+      - name: cargo-deny
+        id: deny
+        continue-on-error: true
+        working-directory: src-tauri
+        run: |
+          cargo deny check 2>&1 | tee ../audit-reports/cargo-deny.txt
+          echo "exit=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
+
+      - name: lychee (broken links)
+        id: lychee
+        continue-on-error: true
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: --config .github/audit/lychee.toml --root-dir "${{ github.workspace }}/docs" --no-progress "**/*.md"
+          output: audit-reports/lychee.md
+          fail: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - run: npm ci
+
+      - name: npm audit
+        id: npm_audit
+        continue-on-error: true
+        run: |
+          npm audit --audit-level=high 2>&1 | tee audit-reports/npm-audit.txt
+          echo "exit=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
+
+      - name: Assemble advisory report
+        if: always() && github.event_name == 'pull_request'
+        run: |
+          {
+            echo "## 🔍 Advisory audit report"
+            echo ""
+            echo "These checks don't block merges — they surface drift in dependencies, licensing, and external links."
+            echo ""
+
+            echo "### cargo-deny"
+            if [ "${{ steps.deny.outputs.exit }}" = "0" ]; then
+              echo "✅ clean (advisories, bans, licenses, sources)"
+            else
+              echo "<details><summary>⚠️ findings</summary>"
+              echo ""
+              echo '```'
+              tail -200 audit-reports/cargo-deny.txt
+              echo '```'
+              echo "</details>"
+            fi
+            echo ""
+
+            echo "### lychee (broken links)"
+            if [ "${{ steps.lychee.outcome }}" = "success" ]; then
+              echo "✅ all links resolve"
+            elif [ -s audit-reports/lychee.md ]; then
+              echo "<details><summary>⚠️ findings</summary>"
+              echo ""
+              cat audit-reports/lychee.md
+              echo "</details>"
+            else
+              echo "⚠️ lychee step failed (no report produced)"
+            fi
+            echo ""
+
+            echo "### npm audit"
+            if [ "${{ steps.npm_audit.outputs.exit }}" = "0" ]; then
+              echo "✅ no high-severity vulnerabilities"
+            else
+              echo "<details><summary>⚠️ findings</summary>"
+              echo ""
+              echo '```'
+              tail -100 audit-reports/npm-audit.txt
+              echo '```'
+              echo "</details>"
+            fi
+          } > advisory-comment.md
+
+      - name: Post / update sticky PR comment
+        if: always() && github.event_name == 'pull_request'
+        uses: marocchino/sticky-pull-request-comment@v3
+        with:
+          header: advisory-audit
+          path: advisory-comment.md
+
+      # lychee is the only audit in this job that blocks merges. Keeping
+      # the step-level `continue-on-error: true` lets cargo-deny, npm
+      # audit, and the sticky comment all run to completion; this final
+      # step then re-surfaces the lychee outcome as a job failure so the
+      # `advisory` check goes red.
+      - name: Fail if lychee found broken links
+        if: always()
+        run: |
+          if [ "${{ steps.lychee.outcome }}" = "failure" ]; then
+            echo "::error::lychee found broken links — see the sticky PR comment above for details"
+            exit 1
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,12 @@
 name: Checks
 
-# Skip the app test matrix on changes that can't break the app:
-# pure docs, READMEs, contributor guides, issue templates, and the
+# Skip the frontend + rust test matrix on changes that can't break the
+# app: pure docs, READMEs, contributor guides, issue templates, and the
 # adjacent workflow files. A mixed PR (e.g. docs + a code tweak) still
 # triggers — paths-ignore only skips when every changed file is ignored.
+#
+# Spell-check / link-check / dependency audits live in audit.yml with
+# NO paths-ignore filter, so docs-only PRs still get those gates.
 #
 # `workflow_dispatch` ignores path filters, so a manual rerun always
 # runs the full suite if needed.
@@ -14,6 +17,7 @@ on:
       - "docs/**"
       - "**/*.md"
       - ".github/ISSUE_TEMPLATE/**"
+      - ".github/workflows/audit.yml"
       - ".github/workflows/docs.yml"
       - ".github/workflows/docs-preview.yml"
       - ".github/workflows/release.yml"
@@ -22,6 +26,7 @@ on:
       - "docs/**"
       - "**/*.md"
       - ".github/ISSUE_TEMPLATE/**"
+      - ".github/workflows/audit.yml"
       - ".github/workflows/docs.yml"
       - ".github/workflows/docs-preview.yml"
       - ".github/workflows/release.yml"
@@ -102,147 +107,3 @@ jobs:
         env:
           RUSTDOCFLAGS: -D warnings
         run: cargo doc --manifest-path src-tauri/Cargo.toml --no-deps
-
-  # Hard-fail audits: enforce correctness on every PR.
-  audit:
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
-        with:
-          node-version: lts/*
-          cache: npm
-          cache-dependency-path: package-lock.json
-      - run: npm ci
-      - name: knip (unused exports / deps)
-        run: npm run audit:knip
-      - name: cspell (spell check)
-        run: npm run audit:spell
-      - name: size-limit (bundle budget)
-        run: npm run audit:size
-
-  # Advisory audits: surface signal without blocking merges.
-  # cargo-deny covers licenses + CVEs + duplicate-version checks.
-  # npm audit is externally-validated and can flap, so it stays advisory.
-  # lychee is now merge-blocking — its step keeps `continue-on-error`
-  # so cargo-deny / npm-audit / the sticky-comment all still run, but
-  # the job's final step exits non-zero if lychee flagged any link.
-  # Findings are aggregated into one sticky PR comment.
-  advisory:
-    runs-on: ubuntu-22.04
-    permissions:
-      contents: read
-      pull-requests: write
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
-        with:
-          node-version: lts/*
-          cache: npm
-          cache-dependency-path: package-lock.json
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: swatinem/rust-cache@v2
-        with:
-          workspaces: src-tauri
-      - run: mkdir -p audit-reports
-
-      - name: Install cargo-deny
-        uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-deny
-
-      - name: cargo-deny
-        id: deny
-        continue-on-error: true
-        working-directory: src-tauri
-        run: |
-          cargo deny check 2>&1 | tee ../audit-reports/cargo-deny.txt
-          echo "exit=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
-
-      - name: lychee (broken links)
-        id: lychee
-        continue-on-error: true
-        uses: lycheeverse/lychee-action@v2
-        with:
-          args: --config .github/audit/lychee.toml --root-dir "${{ github.workspace }}/docs" --no-progress "**/*.md"
-          output: audit-reports/lychee.md
-          fail: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - run: npm ci
-
-      - name: npm audit
-        id: npm_audit
-        continue-on-error: true
-        run: |
-          npm audit --audit-level=high 2>&1 | tee audit-reports/npm-audit.txt
-          echo "exit=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
-
-      - name: Assemble advisory report
-        if: always() && github.event_name == 'pull_request'
-        run: |
-          {
-            echo "## 🔍 Advisory audit report"
-            echo ""
-            echo "These checks don't block merges — they surface drift in dependencies, licensing, and external links."
-            echo ""
-
-            echo "### cargo-deny"
-            if [ "${{ steps.deny.outputs.exit }}" = "0" ]; then
-              echo "✅ clean (advisories, bans, licenses, sources)"
-            else
-              echo "<details><summary>⚠️ findings</summary>"
-              echo ""
-              echo '```'
-              tail -200 audit-reports/cargo-deny.txt
-              echo '```'
-              echo "</details>"
-            fi
-            echo ""
-
-            echo "### lychee (broken links)"
-            if [ "${{ steps.lychee.outcome }}" = "success" ]; then
-              echo "✅ all links resolve"
-            elif [ -s audit-reports/lychee.md ]; then
-              echo "<details><summary>⚠️ findings</summary>"
-              echo ""
-              cat audit-reports/lychee.md
-              echo "</details>"
-            else
-              echo "⚠️ lychee step failed (no report produced)"
-            fi
-            echo ""
-
-            echo "### npm audit"
-            if [ "${{ steps.npm_audit.outputs.exit }}" = "0" ]; then
-              echo "✅ no high-severity vulnerabilities"
-            else
-              echo "<details><summary>⚠️ findings</summary>"
-              echo ""
-              echo '```'
-              tail -100 audit-reports/npm-audit.txt
-              echo '```'
-              echo "</details>"
-            fi
-          } > advisory-comment.md
-
-      - name: Post / update sticky PR comment
-        if: always() && github.event_name == 'pull_request'
-        uses: marocchino/sticky-pull-request-comment@v3
-        with:
-          header: advisory-audit
-          path: advisory-comment.md
-
-      # lychee is the only audit in this job that blocks merges. Keeping
-      # the step-level `continue-on-error: true` lets cargo-deny, npm
-      # audit, and the sticky comment all run to completion; this final
-      # step then re-surfaces the lychee outcome as a job failure so the
-      # `advisory` check goes red.
-      - name: Fail if lychee found broken links
-        if: always()
-        run: |
-          if [ "${{ steps.lychee.outcome }}" = "failure" ]; then
-            echo "::error::lychee found broken links — see the sticky PR comment above for details"
-            exit 1
-          fi


### PR DESCRIPTION
## Summary

Closes #46 (supersedes — includes its cspell allowlist additions).

The `audit` and `advisory` jobs target documentation as much as code:

- **cspell** scans every `.md`
- **lychee** scans every `.md`
- **cargo-deny** and **npm audit** scan dependency manifests

But they were grouped inside `ci.yml` under a workflow-level `paths-ignore` that skipped the whole file on docs-only PRs. Result: a docs-only PR could introduce unknown words or broken links and the next non-docs PR would inherit the rot as silent main failures.

Real examples surfaced on PR #43:

- PR #41 (videos in `docs/index.md`) → lychee never ran → broken links on every subsequent PR until #45
- PR #44 (Mermaid diagrams in `docs/developer/ipc.md`) → cspell never ran → unknown-word failures on every subsequent PR

## Changes

- New [`.github/workflows/audit.yml`](.github/workflows/audit.yml) holds the `audit` and `advisory` jobs verbatim, with **no `paths-ignore`** — so docs-only PRs still gate on cspell and lychee.
- [`.github/workflows/ci.yml`](.github/workflows/ci.yml) keeps `frontend` and `rust` with the existing `paths-ignore` (no signal from docs-only diffs there). `.github/workflows/audit.yml` added to `ci.yml`'s `paths-ignore` so audit-workflow edits don't retrigger the frontend/rust matrix.
- Cherry-picked the cspell allowlist additions from #46 (autonumber, Sched, mermaid) so this PR can pass its own audit gate without depending on #46 merging first.

## Test plan

- [x] Both workflow YAMLs parse (`python3 -c yaml.safe_load`)
- [x] `ci.yml` jobs: `frontend`, `rust` only
- [x] `audit.yml` jobs: `audit`, `advisory` only
- [ ] CI: `audit` and `advisory` checks pass on this PR (was failing on #43)
- [ ] CI: `frontend` and `rust` still run on this PR (workflow-file change shouldn't be in `ci.yml` paths-ignore)
- [ ] Smoke test after merge: open a docs-only PR, confirm `audit` runs and `frontend`/`rust` skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)