### PR TITLE
docs(legal): add Terms of Service and Privacy Policy

### DIFF
--- a/.github/audit/cspell/project-words.txt
+++ b/.github/audit/cspell/project-words.txt
@@ -158,3 +158,4 @@ tʁakt
 Vion
 Shtooka
 rgba
+Datatilsynet

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -73,7 +73,8 @@ export default withMermaid({
       { icon: "github", link: "https://github.com/drmowinckels/entracte" },
     ],
     footer: {
-      message: "Released under the Apache 2.0 License.",
+      message:
+        'Released under the Apache 2.0 License. <a href="/legal/terms">Terms</a> · <a href="/legal/privacy">Privacy</a>.',
       copyright: "Copyright © Athanasia Mowinckel",
     },
     search: { provider: "local" },

--- a/docs/legal/privacy.md
+++ b/docs/legal/privacy.md
@@ -45,7 +45,7 @@ If you purchase the Entracte Supporter Pack, the following personal data is invo
 
 Supporter Pack purchases are processed by **Lemon Squeezy** (Lemon Squeezy LLC), who acts as **merchant of record**. Lemon Squeezy collects and processes the information needed to take payment, calculate VAT or sales tax, issue an invoice, and email you a receipt and your license key. This typically includes your name, email address, billing address (for tax purposes), and payment-method details.
 
-Lemon Squeezy is the data controller for that processing. Their handling of your data is governed by the [Lemon Squeezy Privacy Policy](https://www.lemonsqueezy.com/legal/privacy-policy). Payment-method details (card number, CVV, etc.) are handled by Lemon Squeezy and its payment processors; we never see them.
+Lemon Squeezy is the data controller for that processing. Their handling of your data is governed by the [Lemon Squeezy Privacy Policy](https://www.lemonsqueezy.com/privacy). Payment-method details (card number, CVV, etc.) are handled by Lemon Squeezy and its payment processors; we never see them.
 
 ### 2.2 Data we receive from Lemon Squeezy
 

--- a/docs/legal/privacy.md
+++ b/docs/legal/privacy.md
@@ -1,0 +1,130 @@
+# Privacy Policy
+
+_Last updated: 2026-05-20_
+
+This Privacy Policy explains what personal information is involved when you use the Entracte website ([entracte.drmowinckels.io](https://entracte.drmowinckels.io)), the Entracte desktop application ("the App"), or the Entracte Supporter Pack, and how it is handled.
+
+Entracte is operated by Athanasia Mowinckel, a sole trader based in Norway ("we", "us", "our"). For questions about this policy or to exercise your data rights, contact [entracte@drmowinckels.io](mailto:entracte@drmowinckels.io). For bug reports and general questions, please use [GitHub issues](https://github.com/drmowinckels/entracte/issues) instead — they're public, so don't include personal data there.
+
+The short version: **the App stores everything locally on your computer and does not send your usage data anywhere.** The website is static and has no analytics. The only personal data we touch is what's needed to process a Supporter Pack purchase, which is handled by Lemon Squeezy as merchant of record, and to validate a Supporter Pack license key when one has been entered.
+
+## 1. The App
+
+The Entracte App runs entirely on your computer. It does not include analytics, telemetry, crash reporting, or user tracking of any kind. The App's source code is open and auditable at [github.com/drmowinckels/entracte](https://github.com/drmowinckels/entracte).
+
+### 1.1 Data stored locally
+
+The App stores the following on your machine, and only on your machine:
+
+- **Settings** — your break schedule, profiles, theme choice, hook commands, and other preferences (`settings.json`, in the OS app-config directory).
+- **Break history** — local statistics on breaks taken, skipped, postponed, and suppressed, used to render the stats screen and the 12-week heatmap.
+- **Supporter Pack record** — if you have entered a Supporter Pack license key, a small `supporter.json` record in the OS app-config directory, containing the license token and last-validation timestamp.
+- **Logs** — a rolling local log file for troubleshooting.
+
+None of this data leaves your machine through normal use of the App. You can clear break history at any time from the Stats screen, and you can remove the Supporter Pack record at any time from **About → Supporter**.
+
+Settings, break history, and logs are stored in the OS app-config directory:
+
+- **macOS** — `~/Library/Application Support/io.drmowinckels.entracte/`
+- **Windows** — `%APPDATA%\io.drmowinckels.entracte\`
+- **Linux** — `~/.config/io.drmowinckels.entracte/`
+
+### 1.2 OS sensors used for break suppression
+
+To decide whether to interrupt you with a break, the App reads signals from the operating system: whether **Do Not Disturb** is on, whether the **camera** is currently in use (so it can skip breaks during meetings), and **system idle time** (so it doesn't fire a break when you've already stepped away). These signals are read in-process and are never transmitted off your machine.
+
+### 1.3 Update checks
+
+The App may check for new releases by contacting the Entracte GitHub release feed. This request reveals only your IP address to GitHub and contains no personally identifying information from the App. You can disable update checks in Settings.
+
+## 2. Supporter Pack purchases
+
+If you purchase the Entracte Supporter Pack, the following personal data is involved.
+
+### 2.1 Data processed by Lemon Squeezy
+
+Supporter Pack purchases are processed by **Lemon Squeezy** (Lemon Squeezy LLC), who acts as **merchant of record**. Lemon Squeezy collects and processes the information needed to take payment, calculate VAT or sales tax, issue an invoice, and email you a receipt and your license key. This typically includes your name, email address, billing address (for tax purposes), and payment-method details.
+
+Lemon Squeezy is the data controller for that processing. Their handling of your data is governed by the [Lemon Squeezy Privacy Policy](https://www.lemonsqueezy.com/legal/privacy-policy). Payment-method details (card number, CVV, etc.) are handled by Lemon Squeezy and its payment processors; we never see them.
+
+### 2.2 Data we receive from Lemon Squeezy
+
+For each completed purchase, Lemon Squeezy forwards to us:
+
+- your **email address** (so we can support you if you need help with your license),
+- the **order ID** and **license key** issued for the purchase,
+- the **product**, **price**, **currency**, and **purchase date**,
+- the **country** used for tax purposes.
+
+We act as the data controller for this subset of information. We use it solely to:
+
+- support your purchase (e.g., resending a license key, processing a refund),
+- validate the license key when your App calls our validation endpoint (see §2.3),
+- meet our bookkeeping and tax-record obligations.
+
+We do not sell, rent, or share this information with third parties for marketing purposes.
+
+### 2.3 License validation calls
+
+When you activate a Supporter Pack license key in the App, and once per day thereafter while the key is active, the App calls the Lemon Squeezy License API to check that the key is still valid. Each call sends the **license key** and a **machine identifier** that binds the key to one machine at a time. It does not send your settings, your break history, or any other personal data.
+
+If you are offline, the App falls back to a 30-day grace window before re-checking, so brief connectivity gaps do not lock you out.
+
+If a key is later refunded or revoked, the next validation call returns "invalid" and the App removes the local `supporter.json` record on its own.
+
+### 2.4 Lawful basis (EU/EEA)
+
+For EU/EEA users, our lawful bases under the GDPR are:
+
+- **Performance of a contract** — to process your purchase, deliver the license key, and validate it.
+- **Legal obligation** — to retain billing records required by Norwegian tax and accounting law.
+- **Legitimate interests** — to provide customer support and prevent abuse of the licensing system.
+
+### 2.5 Retention
+
+We retain purchase records (order ID, email, license key, country, amount, date) for as long as required by Norwegian bookkeeping law (currently five years from the end of the financial year of the transaction), after which they are deleted or anonymised.
+
+You may request a copy of, correction of, or deletion of any data we hold about you that is not subject to the legal-retention requirement above; see §5.
+
+## 3. The website
+
+The Entracte website is a static documentation site served from GitHub Pages and built with [VitePress](https://vitepress.dev). The website itself does not set tracking cookies, run analytics, or fingerprint visitors.
+
+Standard HTTP server logs (IP address, user agent, requested path, timestamp) are recorded transiently by the hosting provider (GitHub) for operational and security purposes. We do not access or process these logs ourselves. See the [GitHub Privacy Statement](https://docs.github.com/site-policy/privacy-policies/github-general-privacy-statement) for details.
+
+The site embeds video clips and screenshots served from the same origin; no third-party embeds, fonts, or scripts run by default.
+
+## 4. Sharing and international transfers
+
+Aside from the use of Lemon Squeezy as merchant of record (see §2.1), we do not share your personal data with third parties. We do not sell personal data.
+
+Because Lemon Squeezy and GitHub are based outside the EU/EEA, processing your purchase or accessing the website may involve transfers of your personal data to the United States or other jurisdictions. Those providers maintain their own safeguards for international transfers, including, where applicable, the EU–US Data Privacy Framework and the European Commission's Standard Contractual Clauses.
+
+## 5. Your rights
+
+Depending on where you live, you may have the right to:
+
+- access the personal data we hold about you,
+- correct inaccurate data,
+- request deletion of data that is not subject to a legal-retention requirement,
+- object to or restrict certain processing,
+- receive a portable copy of data you provided to us,
+- lodge a complaint with a supervisory authority (in Norway, the [Datatilsynet](https://www.datatilsynet.no)).
+
+To exercise any of these rights, email [entracte@drmowinckels.io](mailto:entracte@drmowinckels.io). We will respond within the timeframes required by applicable law (under the GDPR, within one month).
+
+## 6. Children
+
+Entracte is not directed to children under 13 and we do not knowingly collect personal data from children. If you believe a child has provided personal data through the Supporter Pack checkout, contact us and we will delete it.
+
+## 7. Security
+
+Personal data we hold (purchase records, license keys) is stored on systems protected by access controls and is transmitted over TLS. No system is perfectly secure; if a breach occurs that affects your personal data, we will notify you and the relevant supervisory authority as required by law.
+
+## 8. Changes to this policy
+
+We may update this policy from time to time. The "Last updated" date at the top of this page reflects the most recent change. Material changes will be announced on the website.
+
+## 9. Contact
+
+For privacy questions, data-rights requests, or any other matter concerning this policy, contact [entracte@drmowinckels.io](mailto:entracte@drmowinckels.io).

--- a/docs/legal/terms.md
+++ b/docs/legal/terms.md
@@ -18,7 +18,7 @@ The Supporter Pack is an optional one-time digital purchase that unlocks persona
 
 ### 2.1 Merchant of record
 
-Supporter Pack purchases are processed by **Lemon Squeezy** (Lemon Squeezy LLC), who acts as merchant of record. Lemon Squeezy is responsible for payment processing, invoicing, VAT and sales tax collection and remittance, and providing payment receipts. Their own [terms](https://www.lemonsqueezy.com/legal/terms-of-service) and [privacy policy](https://www.lemonsqueezy.com/legal/privacy-policy) apply to the payment transaction.
+Supporter Pack purchases are processed by **Lemon Squeezy** (Lemon Squeezy LLC), who acts as merchant of record. Lemon Squeezy is responsible for payment processing, invoicing, VAT and sales tax collection and remittance, and providing payment receipts. Their own [terms](https://www.lemonsqueezy.com/terms) and [privacy policy](https://www.lemonsqueezy.com/privacy) apply to the payment transaction.
 
 ### 2.2 Delivery
 

--- a/docs/legal/terms.md
+++ b/docs/legal/terms.md
@@ -1,0 +1,88 @@
+# Terms of Service
+
+_Last updated: 2026-05-20_
+
+These Terms of Service ("Terms") govern your use of the Entracte website ([entracte.drmowinckels.io](https://entracte.drmowinckels.io)), the Entracte desktop application ("the App"), and any purchase of the Entracte Supporter Pack ("Supporter Pack"). By using the website, installing the App, or purchasing the Supporter Pack, you agree to these Terms.
+
+Entracte is operated by Athanasia Mowinckel, a sole trader based in Norway ("we", "us", "our"). For privacy, refund, or other legal matters, contact [entracte@drmowinckels.io](mailto:entracte@drmowinckels.io). For bug reports and general questions, please use [GitHub issues](https://github.com/drmowinckels/entracte/issues).
+
+## 1. The App
+
+Entracte is a desktop break-reminder application for macOS, Windows, and Linux. The App is free software, released under the [Apache License 2.0](https://github.com/drmowinckels/entracte/blob/main/LICENSE). Source code is available at [github.com/drmowinckels/entracte](https://github.com/drmowinckels/entracte).
+
+The Apache 2.0 license governs your rights to use, copy, modify, and redistribute the App's source code and binaries. These Terms do not restrict or replace that license; they apply to the website and to purchases of the Supporter Pack.
+
+## 2. Supporter Pack
+
+The Supporter Pack is an optional one-time digital purchase that unlocks personalisation features inside the already-installed App. The features unlocked by the Supporter Pack are listed at [/guide/supporter](/guide/supporter).
+
+### 2.1 Merchant of record
+
+Supporter Pack purchases are processed by **Lemon Squeezy** (Lemon Squeezy LLC), who acts as merchant of record. Lemon Squeezy is responsible for payment processing, invoicing, VAT and sales tax collection and remittance, and providing payment receipts. Their own [terms](https://www.lemonsqueezy.com/legal/terms-of-service) and [privacy policy](https://www.lemonsqueezy.com/legal/privacy-policy) apply to the payment transaction.
+
+### 2.2 Delivery
+
+The Supporter Pack is delivered as a **license key** emailed to the address you provide at checkout, typically within a few minutes of a successful payment. You activate the key inside the App via **About → Supporter** to enable the unlocked features. There is nothing further to ship; delivery is complete once the license key has been issued.
+
+### 2.3 License grant
+
+On payment, you receive a personal, non-transferable, non-exclusive license to activate the Supporter Pack on machines you own or control. The license is perpetual for the major version of the App it was purchased against and does not expire on its own.
+
+The license key is **machine-bound**: it activates the unlocked features on the machine where it is entered. You may move the license to a different machine at any time by removing it from the previous one and re-activating it on the new one.
+
+You may not resell, sublicense, or share your license key with anyone else. The App's unlock check is plain source code and not a technical lock — the license terms in this section are an honour-system agreement.
+
+### 2.4 Pricing and currency
+
+Pricing for the Supporter Pack is shown at checkout. Prices are quoted in US dollars unless otherwise indicated; Lemon Squeezy may display equivalent prices in your local currency. Applicable VAT or sales tax is calculated and collected by Lemon Squeezy based on your billing location.
+
+### 2.5 Refunds
+
+We offer a **14-day refund window** from the date of purchase. If you are not satisfied with the Supporter Pack, contact us at [entracte@drmowinckels.io](mailto:entracte@drmowinckels.io) within 14 days and we will refund the purchase price via Lemon Squeezy. Refund requests after 14 days are considered on a case-by-case basis.
+
+EU and EEA consumers who would otherwise be entitled to a 14-day statutory right of withdrawal under Directive 2011/83/EU retain that right; our voluntary 14-day window meets or exceeds it.
+
+When a refund is issued, the corresponding license key is revoked and the unlocked features will return to their locked state on next validation.
+
+## 3. Acceptable use
+
+The App is intended for personal and professional use as a break-reminder tool. You agree not to use the website, the App, or the Supporter Pack to:
+
+- violate any applicable law;
+- attempt to compromise the integrity or security of the website or its hosting infrastructure;
+- distribute malware, spam, or fraudulent content via any contact channel we provide;
+- misrepresent yourself or your affiliation with us.
+
+We may refuse service, terminate a license, or block access in response to abuse.
+
+## 4. Intellectual property
+
+The Entracte name and logo, the website content, and the contents of `docs/` are © Athanasia Mowinckel. The source code of the App is licensed under Apache 2.0; see the [LICENSE](https://github.com/drmowinckels/entracte/blob/main/LICENSE) file for terms.
+
+Nothing in these Terms transfers ownership of the website content, the marks, or the source code to you.
+
+## 5. Disclaimer of warranties
+
+The website, the App, and the Supporter Pack are provided **"as is" and "as available"**, without warranties of any kind, whether express or implied, including but not limited to warranties of merchantability, fitness for a particular purpose, or non-infringement.
+
+We do not warrant that the website or the App will be uninterrupted, error-free, or free of harmful components, or that any defect will be corrected. Use of the App is at your own risk. The App is a break reminder, not a medical device, and is not a substitute for medical, ergonomic, or occupational-health advice.
+
+## 6. Limitation of liability
+
+To the maximum extent permitted by law, in no event will we be liable for any indirect, incidental, special, consequential, or punitive damages, or any loss of profits, revenue, data, or goodwill, arising from or related to your use of the website, the App, or the Supporter Pack — even if we have been advised of the possibility of such damages.
+
+Our total aggregate liability arising out of or related to these Terms or the Supporter Pack shall not exceed the amount you paid us for the Supporter Pack in the twelve (12) months preceding the event giving rise to liability.
+
+Nothing in these Terms limits or excludes liability that cannot be limited or excluded under applicable law, including statutory consumer rights for EU/EEA consumers.
+
+## 7. Changes to these Terms
+
+We may update these Terms from time to time. The "Last updated" date at the top of this page reflects the most recent change. Material changes will be announced on the website. Continued use of the website, the App, or activation of a new license after a change constitutes acceptance of the updated Terms. Changes do not apply retroactively to purchases already completed.
+
+## 8. Governing law and jurisdiction
+
+These Terms are governed by the laws of Norway, without regard to its conflict-of-laws rules. Any dispute arising out of or relating to these Terms shall be subject to the exclusive jurisdiction of the courts of Norway, save where mandatory consumer-protection laws of your country of residence provide otherwise.
+
+## 9. Contact
+
+For questions about these Terms, refund requests, or any other matter concerning Entracte, contact us at [entracte@drmowinckels.io](mailto:entracte@drmowinckels.io).


### PR DESCRIPTION
## Summary

- Adds `/legal/terms` and `/legal/privacy` pages, linked from the VitePress footer.
- Required by Lemon Squeezy for storefront approval (they pushed back asking for clearer product framing and legal pages on the site).

## What's in the pages

**Terms of Service** — covers the free Apache-2.0 app, the Supporter Pack as a one-time digital purchase via Lemon Squeezy as merchant of record, machine-bound personal license, 14-day refund window (meets/exceeds the EU statutory minimum), Norway governing law.

**Privacy Policy** — leads with "everything stored locally on your computer." Discloses what Lemon Squeezy processes for purchases, what data they forward to us, the daily license-validation call, GitHub Pages server logs, GDPR lawful bases, 5-year Norwegian bookkeeping retention for purchase records, and data-rights routes.

## Contact

- Privacy / refunds / legal → `entracte@drmowinckels.io` (new alias on drmowinckels.io)
- Bug reports / general questions → GitHub issues (existing channel)

## Things to double-check before merging

1. **Sole-trader vs incorporated** — pages describe the operator as "a sole trader based in Norway." Swap in your org.nr if you've registered an ENK/AS.
2. **Update checks** — Privacy §1.3 claims the App checks the GitHub release feed and the check can be disabled in Settings. Verify against what's actually wired up; remove the section if there's no in-app update check yet.
3. **Refund window** — 14 days. Bump to 30 if you'd prefer.

## Test plan

- [x] `npx vitepress build` succeeds
- [x] `docs/.vitepress/dist/legal/terms.html` and `privacy.html` are emitted
- [ ] Visual check of footer link in deployed preview
- [ ] Confirm both pages render with no sidebar (they're outside the configured sidebar paths, so VitePress should fall through to no sidebar — expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)