### PR TITLE
docs: explain unsigned Windows installer + add praise issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/praise.yml
+++ b/.github/ISSUE_TEMPLATE/praise.yml
@@ -1,0 +1,47 @@
+name: Praise / kind words
+description: Tell us Entracte helped, share what you love, or leave a thank-you. No bug, no problem — just a nice word.
+labels: ["praise"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Hi 👋 — thanks for taking the time to leave a kind note.
+
+        Open-source maintenance is mostly bug reports and broken CI, so positive feedback genuinely fuels the project. It also helps in a concrete way: signals of public adoption and engagement are what gatekeepers like the [SignPath Foundation](https://signpath.org/foundation) look at when deciding whether to issue free code-signing certificates for open-source projects. Public praise on this repo is one of those signals.
+
+        Nothing below is required — answer whichever prompts feel natural and skip the rest.
+
+  - type: textarea
+    id: what
+    attributes:
+      label: What did Entracte help with?
+      description: A break habit that finally stuck, a wrist that stopped hurting, the bedtime nudge that actually got you off the laptop — whatever it is.
+      placeholder: |
+        I've tried about six break-reminder apps and bounced off all of them because they were too intrusive. The notification-only mode in Entracte is the first thing that's actually lasted past week two.
+    validations:
+      required: false
+
+  - type: textarea
+    id: favourite
+    attributes:
+      label: Favourite feature, or something that surprised you?
+      description: Big or small — the windowed overlay, a specific theme, the CLI, a tiny detail.
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Anything about your setup?
+      description: Optional — OS, how you discovered Entracte, what your work day looks like. Helps put the feedback in context.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: share
+    attributes:
+      label: Sharing
+      description: All optional, all appreciated.
+      options:
+        - label: I'm happy for this praise to be quoted (anonymously or by GitHub handle) on the project website or social posts.
+        - label: I've also starred ⭐ the repo or shared Entracte somewhere — these public signals help the project clear the bar for free Windows code-signing.

--- a/.github/audit/cspell/project-words.txt
+++ b/.github/audit/cspell/project-words.txt
@@ -159,3 +159,5 @@ Vion
 Shtooka
 rgba
 Datatilsynet
+macapps
+winget

--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ brew install --cask drmowinckels/entracte/entracte
 
 **Linux / Windows** — download the `.deb`, `.rpm`, `.AppImage`, `.msi`, or `.exe` from the [latest release](https://github.com/drmowinckels/entracte/releases/latest).
 
+> **Windows users:** the `.msi` / `.exe` aren't code-signed yet — SignPath Foundation turned down our first application on visibility grounds (the project is too new). SmartScreen will warn you when you run the installer; click **More info → Run anyway** to proceed. See [the install guide](https://entracte.drmowinckels.io/guide/install#windows) for how you can [help us get there](https://entracte.drmowinckels.io/guide/install#help-us-get-windows-signed) — stars, forks, mentions, and contributions all count.
+
 ## Command line
 
 The same `entracte` binary doubles as a small CLI for scripting / hotkey wiring. Action commands forward to the running tray app:

--- a/docs/guide/install.md
+++ b/docs/guide/install.md
@@ -22,9 +22,27 @@ A [Homebrew Cask](https://brew.sh/) is also planned — once submitted and accep
 - `Entracte_<version>_x64-setup.exe` — NSIS installer
 - `Entracte_<version>_x64_en-US.msi` — MSI for managed deployment
 
-Windows installers are code-signed by the [SignPath Foundation](https://signpath.org/) under their free open-source code-signing programme, with certificate issuance and signing infrastructure provided by [SignPath.io](https://signpath.io/). SmartScreen recognises the publisher and lets the installer run without the "unrecognised publisher" warning.
+::: warning Currently unsigned
+Windows installers are **not code-signed yet**. When you run the installer, Windows SmartScreen will show a blue "Windows protected your PC" dialog naming an "unknown publisher". To continue: click **More info**, then **Run anyway**.
 
-Double-click the installer; the standard Windows installation wizard takes over.
+This is a verification gap, not a security issue — the installer is the same `.msi` / `.exe` built and published by GitHub Actions from this repository, and you can verify the SHA-256 checksums against the [release assets](https://github.com/drmowinckels/entracte/releases/latest).
+
+We applied to the [SignPath Foundation](https://signpath.org/foundation) free OSS code-signing programme and were turned down on the first attempt — they look for projects that have already built up public visibility (stars, forks, contributors, third-party write-ups), and Entracte is too new to clear that bar yet. We can reapply once the project has more external traction. **[Here's how you can help →](#help-us-get-windows-signed)**
+:::
+
+Double-click the installer; once past the SmartScreen prompt, the standard Windows installation wizard takes over.
+
+#### Help us get Windows signed
+
+SignPath Foundation rejected our first application on the grounds that Entracte doesn't yet show enough public adoption to qualify. They don't judge the code — they look at the project's external footprint. Concrete things that move the needle:
+
+- ⭐ [Star the repository](https://github.com/drmowinckels/entracte) — this is the single clearest signal.
+- 🗣️ Talk about it where you hang out — Reddit (r/macapps, r/windows, r/productivity), Mastodon, Bluesky, blog posts, YouTube, Hacker News. Independent mentions are weighted heavily.
+- 🐛 [File a bug](https://github.com/drmowinckels/entracte/issues/new?template=bug_report.yml), [request a feature](https://github.com/drmowinckels/entracte/issues/new?template=feature_request.yml), or [send some praise](https://github.com/drmowinckels/entracte/issues/new?template=praise.yml) — engagement counts.
+- 🔧 [Contribute a fix](https://github.com/drmowinckels/entracte/blob/main/CONTRIBUTING.md) — being able to point at a contributor list demonstrates a real community.
+- 📦 If you maintain a package repo (Scoop, Chocolatey, winget), packaging Entracte for it adds another data point.
+
+Once we have evidence to satisfy SignPath's criteria, we'll reapply. The CI signing pipeline is already wired up — the day approval comes through, the very next release ships signed with no code changes required. The bring-up notes live in [.github/SIGNPATH_SETUP.md](https://github.com/drmowinckels/entracte/blob/main/.github/SIGNPATH_SETUP.md).
 
 ### Linux
 

--- a/docs/guide/install.md
+++ b/docs/guide/install.md
@@ -27,7 +27,7 @@ Windows installers are **not code-signed yet**. When you run the installer, Wind
 
 This is a verification gap, not a security issue — the installer is the same `.msi` / `.exe` built and published by GitHub Actions from this repository, and you can verify the SHA-256 checksums against the [release assets](https://github.com/drmowinckels/entracte/releases/latest).
 
-We applied to the [SignPath Foundation](https://signpath.org/foundation) free OSS code-signing programme and were turned down on the first attempt — they look for projects that have already built up public visibility (stars, forks, contributors, third-party write-ups), and Entracte is too new to clear that bar yet. We can reapply once the project has more external traction. **[Here's how you can help →](#help-us-get-windows-signed)**
+We applied to the [SignPath Foundation](https://signpath.org/) free OSS code-signing programme and were turned down on the first attempt — they look for projects that have already built up public visibility (stars, forks, contributors, third-party write-ups), and Entracte is too new to clear that bar yet. We can reapply once the project has more external traction. **[Here's how you can help →](#help-us-get-windows-signed)**
 :::
 
 Double-click the installer; once past the SmartScreen prompt, the standard Windows installation wizard takes over.


### PR DESCRIPTION
## Summary

- SignPath Foundation [denied our first application](https://signpath.org/foundation) on visibility grounds (not enough stars/forks/external mentions yet), so Windows binaries ship unsigned for the foreseeable future. Replace the "we're signed by SignPath" wording in [docs/guide/install.md](docs/guide/install.md) with an honest description: what SmartScreen will show, how to verify the artefact is the one GitHub Actions built, and why we got turned down. Add a **"Help us get Windows signed"** section listing concrete community signals SignPath actually weighs (stars, third-party write-ups, issues, contributions, downstream packaging).
- Add a `> **Windows users:**` heads-up paragraph in [README.md](README.md) pointing at the docs.
- New issue template [.github/ISSUE_TEMPLATE/praise.yml](.github/ISSUE_TEMPLATE/praise.yml) for kind notes — both as morale fuel and as another public-engagement signal for the next SignPath application. Matching `praise` label created on the repo (rose `#fb7185`, tying the project's teal-to-rose branding).

The CI signing pipeline at [.github/workflows/release.yml](.github/workflows/release.yml) stays as-is — the day SignPath approves us, the very next release ships signed with no code changes.

## Test plan

- [ ] Render the install docs site locally (`npm run docs:dev`) and confirm the `::: warning Currently unsigned` callout, the anchor link `#help-us-get-windows-signed`, and the praise-template deep-link all render correctly
- [ ] Open the GitHub "New issue" page and confirm the **Praise / kind words** template shows up alongside Bug / Feature with the `praise` label pre-applied
- [ ] Submit a draft praise issue end-to-end to confirm field validation (everything optional) and label auto-apply
- [ ] Skim README on github.com to confirm the blockquote renders as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)