### PR TITLE
chore(release): prep v0.0.1 — CHANGELOG, README, prerelease toggle

### DIFF
--- a/.github/audit/cspell/project-words.txt
+++ b/.github/audit/cspell/project-words.txt
@@ -45,6 +45,7 @@ notarization
 codesigned
 SignPath
 signpath
+Authenticode
 NSIS
 TEAMID
 Bootswatch

--- a/.github/audit/lychee.toml
+++ b/.github/audit/lychee.toml
@@ -25,6 +25,11 @@ exclude = [
   # merge-blocking, so excluding them avoids spurious failures —
   # broken in-repo links surface as 404s in the rendered docs anyway.
   '^https?://github\.com/drmowinckels/entracte/(blob|tree|issues|pull|commit)/',
+  # CHANGELOG cross-reference links to release tags and compare URLs only
+  # resolve after the release is cut and pushed — on the PR that introduces
+  # a new `## [vX.Y.Z]` section those links 404 by design. Excluding them
+  # lets changelog prep land before the tag itself.
+  '^https?://github\.com/drmowinckels/entracte/(compare|releases/tag)/',
   # VitePress mounts `docs/public/` at the site root, so `/audio/...`
   # and similar public-mounted assets don't exist under `docs/` — they
   # live under `docs/public/`. The `--root-dir docs` invocation handles

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,10 @@ jobs:
           tagName: ${{ github.ref_name }}
           releaseName: "Entracte ${{ github.ref_name }}"
           releaseDraft: true
-          prerelease: false
+          # 0.0.X tags are betas; 0.1.X and later are stable. Flip the
+          # github_release `prerelease` flag based on the tag prefix
+          # so beta releases don't accidentally surface as "latest".
+          prerelease: ${{ startsWith(github.ref_name, 'v0.0.') }}
           args: ${{ matrix.args }}
 
   build-windows-unsigned:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,97 @@
+# Changelog
+
+All notable changes to Entracte are documented here.
+
+The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+Versions on the `0.0.X` line are public beta releases; `0.1.X` and onwards will be the stable line.
+
+## [Unreleased]
+
+## [0.0.1] — 2026-05-25
+
+First public beta of Entracte. macOS, Windows, and Linux installers are produced from the same Rust + Tauri codebase. Functional and usable day-to-day on macOS; Windows and Linux build and run, with a few platform-detection gaps called out below.
+
+### Breaks
+
+- Three break kinds: **Micro** (eye/posture, ~20s by default), **Long** (multi-minute, undismissable by default), and a **Sleep** prompt during a configurable bedtime window.
+- Pre-break heads-up notification a configurable number of seconds before each break (opt-in).
+- Per-break-kind **Notification-only mode** swaps the full-screen overlay for a system notification when you'd rather not be dimmed; engagement metrics are skipped for the notification-only kinds since there's no overlay to act on.
+- Postpone / Skip / Resume-last-break controls on the overlay and the CLI.
+- Multi-monitor aware: cover every display, just the primary, or only the monitor your cursor is on. No native fullscreen on macOS — overlays never push their own Space.
+- **Windowed break mode** shrinks the overlay to 80% of the monitor (centered) so the rest of your desktop stays reachable.
+- Five overlay themes (Dark, Midnight, Forest, Sunset, Rose) plus light/dark accent handling.
+
+### Don't-interrupt-me rules
+
+- Pause from the tray for 15m / 30m / 1h / 2h / 4h / until tomorrow 6am / indefinitely. The tray icon shows pause bars while paused.
+- Per-OS detection for **Do Not Disturb**, **camera in use** (you're in a meeting), and **video playback** (display-sleep inhibitors).
+- **Idle reset**: if you've already stepped away past a threshold, the scheduler skips the next break.
+- **Typing defer**: if you're actively typing, the break waits a few seconds.
+- **Work-window**: only fire breaks during configured hours.
+
+### Stats
+
+- Local-only event log (`events.jsonl`) of breaks taken, dismissed, postponed, and suppressed.
+- Insights tab with weekday histogram, time-of-day histogram, 12-week heatmap, postpone follow-through, and a top-suppressions breakdown.
+- Daily screen-time budget with an opt-in wind-down nudge.
+- CSV export and a **full local backup bundle** (settings, profiles, history, screen-time, pause state, manual supporter token). Import on another machine is atomic — stage-then-commit with `.pre-import.bak` rollback if any per-file commit fails mid-flight.
+- Optional **tray countdown** showing `MM:SS` until the next short, long, or soonest break (macOS and Linux).
+
+### Profiles
+
+- Multiple named profiles (Default, Work, Focus, …) with separate scheduler settings per profile.
+- Switch via the tray, the settings UI, or the CLI's `--profile=` flag.
+- Reorder, rename, duplicate, delete, reset-to-defaults — all without touching disk by hand.
+
+### Hooks
+
+- Run arbitrary shell commands on `break_start` / `break_end` / `pause_start` / `pause_end`. Useful for muting Slack, pausing music, kicking off a meditation timer, etc.
+- Per-hook enable toggles and timeout caps. Diagnostic reports redact hook command strings.
+
+### CLI
+
+The same binary doubles as a small CLI for scripting and hotkey wiring. Action subcommands forward to the running tray app over a local TCP IPC channel:
+
+```sh
+entracte pause 30m                       # pause for 30 minutes
+entracte trigger long                    # fire a long break now
+entracte --profile=Focus --colour=midnight  # switch profile + theme in one call
+entracte status                          # JSON: pause state + active profile
+entracte log                             # tail the entracte log
+entracte help                            # full reference
+```
+
+### Supporter pack
+
+A one-off purchase that unlocks personalisation extras — custom overlay colour, theme rotation, editable break hints, custom CSS, and custom sounds. Honour-system check in plain source: every scheduling, suppression, profile, hooks, stats, accessibility, and CLI feature stays available to everyone regardless of supporter state. Lemon Squeezy + Ed25519 community licences. See [docs/guide/supporter.md](docs/guide/supporter.md).
+
+### Accessibility
+
+- WCAG 2.1 AA gated in CI: axe-core runs on every tab × light/dark mode on every build.
+- Focus trap, escape-to-dismiss, ARIA roles on overlay controls.
+- Keyboard-driven settings UI; no mouse-only paths.
+
+### Privacy & security
+
+- 100% local: no telemetry, no analytics, no cloud sync. Backup bundles are user-initiated and written to a path you pick.
+- Content-Security-Policy locked down; IPC backup commands gated to the main settings window.
+- Application files on Unix are mode 0o600; data directory is swept periodically to keep files converging to user-only.
+- Supporter records are Ed25519-signed; tampered records are rejected at load.
+
+### Caveats
+
+- **No auto-updater yet** ([#2](https://github.com/drmowinckels/entracte/issues/2)). Update by downloading the new installer or running `brew upgrade --cask drmowinckels/entracte/entracte` on macOS.
+- **Windows installer isn't code-signed yet** — SignPath Foundation declined our first application on visibility grounds. SmartScreen will warn you; click **More info → Run anyway** to proceed. See the [Windows install guide](https://entracte.drmowinckels.io/guide/install#windows) for how you can help us get there.
+- **Linux**: Do Not Disturb detection isn't wired yet (no portable signal); Wayland-only desktops have slightly degraded idle detection. Both are tracked under [AGENTS.md → Known gaps](.github/AGENTS.md#known-gaps--next-moves).
+
+### Install
+
+- **macOS**: `brew tap drmowinckels/entracte https://github.com/drmowinckels/entracte && brew install --cask drmowinckels/entracte/entracte`
+- **Linux / Windows**: download the `.deb`, `.rpm`, `.AppImage`, `.msi`, or `.exe` from the release assets below.
+
+### Feedback
+
+This is a beta. Bug reports and praise both belong on the [issue tracker](https://github.com/drmowinckels/entracte/issues/new/choose); a separate "praise" template is there for the nice things. Contribution guide: [CONTRIBUTING.md](CONTRIBUTING.md).
+
+[Unreleased]: https://github.com/drmowinckels/entracte/compare/v0.0.1...HEAD
+[0.0.1]: https://github.com/drmowinckels/entracte/releases/tag/v0.0.1

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Entracte lives in your menu bar / tray and nudges you to take breaks. It tries h
 - **Daily screen-time budget** — opt-in wind-down nudge when you cross a daily active-time budget (default 8 hours), with a configurable snooze interval.
 - **Tray countdown** — optional `MM:SS` countdown next to the menu-bar icon, configurable to track the next short, long, or soonest break (macOS and Linux).
 - **Notification-only mode** — per break kind, swap the overlay for a gentle system notification when you'd rather not be interrupted by a full-screen dim. Note that engagement metrics (completion, skip, postpone) aren't recorded for break types in notification mode, since there's no overlay to act on.
+- **Move with you** — export a full local backup (settings, profiles, break history, screen-time, pause state, manual supporter token if you have one) to JSON and import it on another machine. Atomic stage-then-commit on import; partial-failure rollback restores your previous state.
 
 ## Themes
 
@@ -99,7 +100,7 @@ Full command reference, IPC details, and tips in [docs/guide/cli.md](docs/guide/
 
 Entracte is free, cross-platform, and open source under Apache 2.0. Every scheduling, suppression, profile, hooks, stats, accessibility, and CLI feature is available to everyone.
 
-A **Supporter pack** is in the works as a way to back development — personalisation extras like custom overlay colour, theme rotation, editable break hints, and custom sounds will unlock through a one-off purchase once the infrastructure is in place. The unlock check lives in plain source: it's an honour-system thank-you, not a DRM scheme. See [docs/guide/supporter.md](docs/guide/supporter.md).
+A **[Supporter pack](docs/guide/supporter.md)** is available as a way to back development. It unlocks personalisation extras — custom overlay colour, theme rotation, editable break hints, custom CSS, and custom sounds — through a one-off purchase. The unlock check lives in plain source: it's an honour-system thank-you, not a DRM scheme. Nothing in the scheduling, suppression, profile, hooks, stats, accessibility, or CLI surface is gated.
 
 ## Stack
 
@@ -128,9 +129,9 @@ flowchart LR
     end
 
     subgraph Stores["On-disk state"]
-        Config[("config.json<br/>profiles + settings")]
-        Stats[("stats.json<br/>break history")]
-        Pause[("pause state")]
+        Config[("settings.json<br/>profiles + settings")]
+        Stats[("events.jsonl<br/>break history")]
+        Pause[("pause.json")]
     end
 
     CLI -->|subcommands| IPC


### PR DESCRIPTION
## Summary

Release-prep for the first public beta (`v0.0.1`).

- **`CHANGELOG.md`** new — the `[0.0.1]` entry doubles as the GitHub release body. Format loosely follows Keep a Changelog. The Unreleased link/section is in place for the next round.
- **`README.md`** — supporter pack is now shipping (not "in the works"), feature list calls out the full-backup workflow, and the architecture diagram's on-disk state labels match reality (`settings.json` / `events.jsonl` / `pause.json`).
- **`.github/workflows/release.yml`** — `prerelease` flag now keys off the tag prefix: `v0.0.*` tags ship as pre-releases, `v0.1.0` and later go stable. Matches the 0.0.X-as-beta versioning scheme.

## Verification

- ``npm run audit:spell`` — 130 files, 0 issues
- Diff inspection of the CHANGELOG against the actual feature set shipped to main (everything described is implemented and tested)

Once this lands, `git tag v0.0.1 && git push --tags` triggers the release workflow. The Windows build is unsigned (called out in the CHANGELOG).