### PR TITLE
fix(release): manifest naming + install docs + Cask bump for the v0.0.1 beta

### DIFF
--- a/.github/workflows/bump-cask.yml
+++ b/.github/workflows/bump-cask.yml
@@ -25,7 +25,13 @@ concurrency:
 
 jobs:
   bump-cask:
-    if: github.event_name == 'workflow_dispatch' || !github.event.release.prerelease
+    # We deliberately accept prereleases too: there's only one Cask, and
+    # the project is in the 0.0.X beta window. Letting beta releases bump
+    # the Cask means `brew tap … && brew install --cask` actually works
+    # while we're pre-1.0. The moment v0.1.0 stable ships, the next bump
+    # snaps everyone back to the stable line — beta users who stayed on
+    # `brew upgrade` get the stable upgrade at the same time. Add an
+    # `entracte-beta` Cask if we ever need parallel lines.
     runs-on: ubuntu-latest
     steps:
       - name: Resolve tag and version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -221,15 +221,19 @@ jobs:
           REPO_URL="https://github.com/${{ github.repository }}"
 
           # tauri-action's bundle naming conventions, by target:
-          #   macOS   : <productName>_<version>_<arch>.app.tar.gz[.sig]
+          #   macOS   : <productName>_<arch>.app.tar.gz[.sig]
           #             productName="Entracte", arches "aarch64" + "x64".
+          #             NOTE: tauri-action's matrix uploader drops the
+          #             version from `.app.tar.gz` artifact names (since
+          #             the matrix produces two files that would otherwise
+          #             collide). Linux + Windows keep the version.
           #   Linux   : <productNameLower>_<version>_amd64.AppImage[.sig]
           #             productName lowercases on Linux.
           #   Windows : <productName>_<version>_x64_en-US.msi[.sig]
           #             the locale suffix is what tauri-bundler emits;
           #             update here if we ever switch the MSI locale.
-          AARCH64_FILE="Entracte_${VERSION}_aarch64.app.tar.gz"
-          X64_FILE="Entracte_${VERSION}_x64.app.tar.gz"
+          AARCH64_FILE="Entracte_aarch64.app.tar.gz"
+          X64_FILE="Entracte_x64.app.tar.gz"
           APPIMAGE_FILE="entracte_${VERSION}_amd64.AppImage"
           MSI_FILE="Entracte_${VERSION}_x64_en-US.msi"
 

--- a/Casks/entracte.rb
+++ b/Casks/entracte.rb
@@ -2,8 +2,8 @@ cask "entracte" do
   arch arm: "aarch64", intel: "x64"
 
   version "0.0.1"
-  sha256 arm:   "0000000000000000000000000000000000000000000000000000000000000000",
-         intel: "0000000000000000000000000000000000000000000000000000000000000000"
+  sha256 arm:   "d747837c3bd91613cf4e8c37b027ddab17632f330606e6e5d92c34ac9e8c0d05",
+         intel: "489799abb289cb4b631a49535a85ee45975519b96dc7bc8e446edefec55579c5"
 
   url "https://github.com/drmowinckels/entracte/releases/download/v#{version}/Entracte_#{version}_#{arch}.dmg",
       verified: "github.com/drmowinckels/entracte/"

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ brew tap drmowinckels/entracte https://github.com/drmowinckels/entracte
 brew install --cask drmowinckels/entracte/entracte
 ```
 
-**Linux / Windows** — download the `.deb`, `.rpm`, `.AppImage`, `.msi`, or `.exe` from the [latest release](https://github.com/drmowinckels/entracte/releases/latest).
+**Linux / Windows** — download the `.deb`, `.rpm`, `.AppImage`, `.msi`, or `.exe` from the [Releases page](https://github.com/drmowinckels/entracte/releases) (pick the latest tag; pre-releases — the `0.0.X` beta line — don't surface under `releases/latest`).
 
 > **Windows users:** the `.msi` / `.exe` aren't code-signed yet — SignPath Foundation turned down our first application on visibility grounds (the project is too new). SmartScreen will warn you when you run the installer; click **More info → Run anyway** to proceed. See [the install guide](https://entracte.drmowinckels.io/guide/install#windows) for how you can [help us get there](https://entracte.drmowinckels.io/guide/install#help-us-get-windows-signed) — stars, forks, mentions, and contributions all count.
 
@@ -165,6 +165,8 @@ Platform support matrix, scheduler internals, and OS-specific quirks are documen
 ## Updates
 
 Updates ship via [`tauri-plugin-updater`](https://v2.tauri.app/plugin/updater) against GitHub Releases. The About tab calls `check_for_update`, which delegates to the plugin: it fetches the signed `latest.json` manifest at `releases/latest/download/latest.json`, verifies the bundled signature against the public key pinned in `tauri.conf.json`, and reports whether a newer version is announced. macOS (Apple-signed + Tauri-signed), Linux AppImages (Tauri-signed), and Windows `.msi` (Tauri-signed) are all in `latest.json`. The check is manual — clicking **Check for updates** opens the release page in your browser; no automatic check on app start, no silent download_and_install. `.deb` / `.rpm` users update through their system package manager and are deliberately outside the updater flow.
+
+> **Beta caveat.** `releases/latest` only resolves to stable releases. While we're on the `0.0.X` beta line (no stable yet), the in-app **Check for updates** returns _no update available_ even when a newer beta has shipped. Beta-to-beta upgrades are manual — watch the [Releases page](https://github.com/drmowinckels/entracte/releases) or `brew upgrade --cask entracte` if you installed via the tap. Once `0.1.0` ships and is published as a non-prerelease, the in-app check starts working for everyone.
 
 Windows specifically: until [SignPath Foundation](https://signpath.org) approves the project, the `.msi` is unsigned-via-Authenticode and SmartScreen warns every install. The About tab calls this out next to the "Open release page" link so users know to click **More info → Run anyway**.
 

--- a/docs/guide/install.md
+++ b/docs/guide/install.md
@@ -1,21 +1,30 @@
 # Install
 
-::: tip Pre-release
-Entracte does not yet have official binary releases. The release pipeline is in place — signed bundles will land here as soon as the first `v*` tag is cut. Until then, [build from source](#build-from-source).
+::: tip Public beta
+Entracte is in its public beta line (`0.0.X`). Bundles ship from the same release pipeline as the eventual stable line; macOS is signed and notarised, Linux ships unsigned by convention, Windows is unsigned until SignPath approves the project. See the [Releases page](https://github.com/drmowinckels/entracte/releases) for every published version. Stable (`0.1.X`) is some way ahead.
 :::
 
 ## Download official builds
 
-Tagged releases appear on the [Releases page](https://github.com/drmowinckels/entracte/releases) with signed installers for every supported platform. Pick the artefact that matches your OS and architecture.
+Tagged releases appear on the [Releases page](https://github.com/drmowinckels/entracte/releases) with signed installers for every supported platform. Pick the artefact that matches your OS and architecture. Beta releases (`0.0.X`) are flagged as pre-releases on GitHub, so `releases/latest` won't surface them — open the Releases page directly until the stable line begins.
 
 ### macOS
 
 - `Entracte_<version>_aarch64.dmg` — Apple Silicon (M-series)
 - `Entracte_<version>_x64.dmg` — Intel
 
-Both `.dmg` builds are code-signed and notarised with an Apple Developer ID certificate, so macOS Gatekeeper opens them without the "unidentified developer" warning. Mount the disk image, drag **Entracte** into Applications, eject.
+Both `.dmg` builds are code-signed; the inner `.app` is notarised with an Apple Developer ID certificate and the ticket is stapled, so macOS Gatekeeper opens the installed app without the "unidentified developer" warning. Mount the disk image, drag **Entracte** into Applications, eject.
 
-A [Homebrew Cask](https://brew.sh/) is also planned — once submitted and accepted by `homebrew-cask`, you'll be able to install via `brew install --cask entracte` and let Homebrew handle upgrades.
+### Homebrew
+
+The project ships its own [Homebrew Cask](https://brew.sh/) hosted in this repo. Until we submit to `homebrew-cask` upstream (planned after `0.1.0` stable lands), install via the custom tap:
+
+```sh
+brew tap drmowinckels/entracte https://github.com/drmowinckels/entracte
+brew install --cask drmowinckels/entracte/entracte
+```
+
+`brew upgrade --cask entracte` handles updates once Homebrew refreshes the tap. The Cask currently tracks the latest published release (including the `0.0.X` beta line) — once `0.1.0` ships, the next bump snaps everyone to the stable line automatically.
 
 ### Windows
 
@@ -25,7 +34,7 @@ A [Homebrew Cask](https://brew.sh/) is also planned — once submitted and accep
 ::: warning Currently unsigned
 Windows installers are **not code-signed yet**. When you run the installer, Windows SmartScreen will show a blue "Windows protected your PC" dialog naming an "unknown publisher". To continue: click **More info**, then **Run anyway**.
 
-This is a verification gap, not a security issue — the installer is the same `.msi` / `.exe` built and published by GitHub Actions from this repository, and you can verify the SHA-256 checksums against the [release assets](https://github.com/drmowinckels/entracte/releases/latest).
+This is a verification gap, not a security issue — the installer is the same `.msi` / `.exe` built and published by GitHub Actions from this repository, and you can verify the SHA-256 checksums against the [release assets](https://github.com/drmowinckels/entracte/releases) (open the specific release tag — pre-releases don't appear under `releases/latest`).
 
 We applied to the [SignPath Foundation](https://signpath.org/) free OSS code-signing programme and were turned down on the first attempt — they look for projects that have already built up public visibility (stars, forks, contributors, third-party write-ups), and Entracte is too new to clear that bar yet. We can reapply once the project has more external traction. **[Here's how you can help →](#help-us-get-windows-signed)**
 :::

--- a/src/assets/sounds/CREDITS.md
+++ b/src/assets/sounds/CREDITS.md
@@ -43,7 +43,7 @@ All bundled tracks are safe for commercial distribution. Non-commercial (CC-BY-N
 ## Music / meditation
 
 - **Relaxation music #69** — [ZHRØ](https://freesound.org/people/ZHR%C3%98/) — [source](https://freesound.org/people/ZHR%C3%98/sounds/808969/) — CC-BY 4.0
-- **Calm Ambient Piano Loop** — [rotlily](https://freesound.org/people/rotlily/) — [source](https://freesound.org/people/rotlily/sounds/832628/) — CC0
+- **Calm Ambient Piano Loop** — rotlily (freesound.org account since deleted) — CC0
 
 ---
 


### PR DESCRIPTION
## Summary

Originally a one-line workflow fix; expanded into a release-machinery sweep after the v0.0.1 draft surfaced several stale spots. Three concerns, kept in one PR since they all converge on "make the beta installable and accurate":

### 1. `latest.json` composer (c36ac99 predecessor, eb87a38)

The `publish-updater-manifest` job crashed at the v0.0.1 release because `tauri-action`'s matrix uploader drops the version from macOS `.app.tar.gz` artifact names (otherwise the two macOS targets would collide). The composer was looking for \`Entracte_\${VERSION}_aarch64.app.tar.gz\`; actual names are \`Entracte_aarch64.app.tar.gz\` and \`Entracte_x64.app.tar.gz\`. Linux + Windows keep the version.

I patched the v0.0.1 draft manually (composed locally from the on-draft \`.sig\` sidecars, replaced the partial auto-generated manifest); this fix makes v0.0.2+ work straight through.

### 2. Lychee CI flake unblock (a48df9b)

The freesound.org user \`rotlily\` deleted their account, so both URLs in [src/assets/sounds/CREDITS.md:46](https://github.com/drmowinckels/entracte/blob/fix/release-manifest-macos-naming/src/assets/sounds/CREDITS.md#L46) started 404ing. Sound is CC0 so the courtesy credit stays — just dropped the link wrappers. Unrelated to the manifest fix; bundled because it was blocking the advisory gate.

### 3. Install docs + Homebrew Cask wiring for the beta line (c36ac99)

The install documentation predated any actual release and several spots were stale:

- [docs/guide/install.md](https://github.com/drmowinckels/entracte/blob/fix/release-manifest-macos-naming/docs/guide/install.md) — top banner said "no releases yet, build from source"; Homebrew section said "planned"; `releases/latest` link won't resolve for pre-releases
- [README.md](https://github.com/drmowinckels/entracte/blob/fix/release-manifest-macos-naming/README.md) — same `releases/latest` issue + the Updates section advertised the in-app updater as working for everyone (it doesn't: `releases/latest/download/latest.json` 404s during the prerelease window)
- [Casks/entracte.rb](https://github.com/drmowinckels/entracte/blob/fix/release-manifest-macos-naming/Casks/entracte.rb) — SHA256s were still `0000…0000` placeholders, so `brew install --cask` would fail integrity check
- [.github/workflows/bump-cask.yml](https://github.com/drmowinckels/entracte/blob/fix/release-manifest-macos-naming/.github/workflows/bump-cask.yml) — gated on `!github.event.release.prerelease`, so the Cask would never auto-bump during the 0.0.X beta. Dropped the guard with an explanation comment: single Cask tracks newest published release, beta users opt in, stable release snaps everyone forward.

## Out of scope, tracked as follow-ups

- **#59** — Notarise the `.dmg` container itself (not just the inner `.app`). Cosmetic for now; defer to 0.1.0.
- **#60** — Submit Entracte to homebrew-cask upstream so `brew install --cask entracte` works without the tap step. Blocked on 0.1.0 stable + community-signal acceptance criteria.

## Test plan

- [x] Locally composed `latest.json` matches the fixed composer's expected output; v0.0.1 draft already updated
- [x] All four platform signatures decode cleanly
- [x] Lychee passes on the PR (no broken links)
- [x] Cask SHA256s match the v0.0.1 draft DMG sums
- [ ] `brew tap drmowinckels/entracte https://github.com/drmowinckels/entracte && brew install --cask drmowinckels/entracte/entracte` works once the v0.0.1 draft is published

🤖 Generated with [Claude Code](https://claude.com/claude-code)