### PR TITLE
feat(a11y): skip link, per-window document titles, focus landing target

### DIFF
--- a/docs/developer/architecture-internals.md
+++ b/docs/developer/architecture-internals.md
@@ -208,13 +208,15 @@ The [`window-kind`](https://github.com/drmowinckels/entracte/blob/main/src/lib/w
 
 The Settings window follows the W3C [Tabs pattern](https://www.w3.org/WAI/ARIA/apg/patterns/tabs/) with automatic activation. The shell lives in [`src/views/settings/index.tsx`](https://github.com/drmowinckels/entracte/blob/main/src/views/settings/index.tsx) and the keyboard controller in [`src/views/settings/hooks/use-roving-tab-list.ts`](https://github.com/drmowinckels/entracte/blob/main/src/views/settings/hooks/use-roving-tab-list.ts).
 
-A `Skip to settings content` link is the first focusable element of the shell. It is visually hidden via `transform: translateY(-200%)` until `:focus`, then jumps to the stable `#settings-main` container (`tabindex={-1}`) that wraps the tabpanel. Keep the link visible on focus and keep the `#settings-main` id stable — the panel's own id changes per active tab.
+A `Skip to settings content` link is the first focusable element of the shell. It is visually hidden via `transform: translateY(-200%)` until `:focus-visible`, then jumps to the **active tabpanel's id** so focus lands directly on content (no intermediate wrapper). Its `href` tracks the active tab via `tabPanelId(tab)`.
+
+All seven tabpanels render at all times with the inactive ones `hidden` — this keeps every tab's `aria-controls` pointing at an element that exists in the DOM, as required by the W3C APG Tabs pattern.
 
 | Element        | Role       | Required attrs                                                                                        |
 | -------------- | ---------- | ----------------------------------------------------------------------------------------------------- |
-| `<nav>`        | `tablist`  | `aria-label="Settings sections"`, `aria-orientation="horizontal"`                                     |
+| `<div>` tabs   | `tablist`  | `aria-label="Settings sections"`, `aria-orientation="horizontal"`                                     |
 | Tab `<button>` | `tab`      | `aria-selected`, `aria-controls={panel-id}`, `id={tab-id}`, roving `tabindex` (0 active, -1 inactive) |
-| `<div>` panel  | `tabpanel` | `aria-labelledby={tab-id}`, `id={panel-id}`, `tabindex={0}` so the panel is reachable when empty      |
+| `<div>` panel  | `tabpanel` | `aria-labelledby={tab-id}`, `id={panel-id}`, `tabindex={0}`, `hidden` on inactive panels              |
 
 Keyboard:
 

--- a/docs/developer/architecture-internals.md
+++ b/docs/developer/architecture-internals.md
@@ -200,9 +200,15 @@ The backend → renderer / tray surface is just Tauri events. The renderer subsc
 
 The renderer has two windows and each has a documented assistive-technology surface. Keep these contracts intact when touching the relevant files — they're tested at the unit level and gated by [`scripts/audit-a11y.mjs`](https://github.com/drmowinckels/entracte/blob/main/scripts/audit-a11y.mjs) at the structural level.
 
+### Document titles
+
+The [`window-kind`](https://github.com/drmowinckels/entracte/blob/main/src/lib/window-kind.ts) helper resolves `?window=` once per webview and exposes a `titleForWindow` mapping. [`App.tsx`](https://github.com/drmowinckels/entracte/blob/main/src/App.tsx) sets `document.title` from it on mount so VoiceOver announces the window's purpose when focus enters it. The HTML `<title>` in [`index.html`](https://github.com/drmowinckels/entracte/blob/main/index.html) is just `"Entracte"` — the React layer overrides it with the kind-specific title.
+
 ### Settings window
 
 The Settings window follows the W3C [Tabs pattern](https://www.w3.org/WAI/ARIA/apg/patterns/tabs/) with automatic activation. The shell lives in [`src/views/settings/index.tsx`](https://github.com/drmowinckels/entracte/blob/main/src/views/settings/index.tsx) and the keyboard controller in [`src/views/settings/hooks/use-roving-tab-list.ts`](https://github.com/drmowinckels/entracte/blob/main/src/views/settings/hooks/use-roving-tab-list.ts).
+
+A `Skip to settings content` link is the first focusable element of the shell. It is visually hidden via `transform: translateY(-200%)` until `:focus`, then jumps to the stable `#settings-main` container (`tabindex={-1}`) that wraps the tabpanel. Keep the link visible on focus and keep the `#settings-main` id stable — the panel's own id changes per active tab.
 
 | Element        | Role       | Required attrs                                                                                        |
 | -------------- | ---------- | ----------------------------------------------------------------------------------------------------- |

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Tauri + React + Typescript</title>
+    <title>Entracte</title>
   </head>
 
   <body>

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./views/settings", () => ({
+  default: () => <div data-testid="settings-stub">settings</div>,
+}));
+vi.mock("./views/break-overlay", () => ({
+  default: () => <div data-testid="overlay-stub">overlay</div>,
+}));
+vi.mock("./error-boundary", () => ({
+  ErrorBoundary: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+
+const originalSearch = window.location.search;
+
+function setSearch(value: string) {
+  Object.defineProperty(window.location, "search", {
+    configurable: true,
+    value,
+  });
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  document.title = "";
+  document.documentElement.className = "";
+  document.body.className = "";
+  const root = document.getElementById("root");
+  if (root) root.className = "";
+});
+
+afterEach(() => {
+  setSearch(originalSearch);
+});
+
+describe("App routing + title", () => {
+  it("renders Settings and titles the document when window=main", async () => {
+    setSearch("");
+    const { default: App } = await import("./App");
+    const { render, screen } = await import("@testing-library/react");
+    render(<App />);
+    expect(screen.getByTestId("settings-stub")).toBeTruthy();
+    expect(document.title).toBe("Entracte — Settings");
+    expect(document.documentElement.classList.contains("overlay-window")).toBe(
+      false,
+    );
+  });
+
+  it("survives a missing #root element on the overlay window", async () => {
+    setSearch("?window=overlay");
+    // Deliberately do not create a #root element; happy-dom's
+    // document.getElementById will return null, so the module-load
+    // root.classList.add call must short-circuit.
+    const { default: App } = await import("./App");
+    const { render, screen } = await import("@testing-library/react");
+    render(<App />);
+    expect(screen.getByTestId("overlay-stub")).toBeTruthy();
+    expect(document.body.classList.contains("overlay-window")).toBe(true);
+  });
+
+  it("renders the BreakOverlay and titles the document when window=overlay", async () => {
+    setSearch("?window=overlay");
+    const root = document.createElement("div");
+    root.id = "root";
+    document.body.appendChild(root);
+    const { default: App } = await import("./App");
+    const { render, screen } = await import("@testing-library/react");
+    render(<App />);
+    expect(screen.getByTestId("overlay-stub")).toBeTruthy();
+    expect(document.title).toBe("Entracte — Break");
+    expect(document.documentElement.classList.contains("overlay-window")).toBe(
+      true,
+    );
+    expect(document.body.classList.contains("overlay-window")).toBe(true);
+    expect(root.classList.contains("overlay-window")).toBe(true);
+    root.remove();
+  });
+});

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -12,13 +12,11 @@ vi.mock("./error-boundary", () => ({
   ),
 }));
 
-const originalSearch = window.location.search;
-
-function setSearch(value: string) {
-  Object.defineProperty(window.location, "search", {
-    configurable: true,
-    value,
-  });
+function stubLocation(search: string) {
+  // URL gives us a real Location-like object with .search, .href, .origin,
+  // etc. — anything the code under test touches via window.location.
+  // vi.unstubAllGlobals in afterEach restores the original window.location.
+  vi.stubGlobal("location", new URL(`http://localhost/${search}`));
 }
 
 beforeEach(() => {
@@ -31,12 +29,12 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  setSearch(originalSearch);
+  vi.unstubAllGlobals();
 });
 
 describe("App routing + title", () => {
   it("renders Settings and titles the document when window=main", async () => {
-    setSearch("");
+    stubLocation("");
     const { default: App } = await import("./App");
     const { render, screen } = await import("@testing-library/react");
     render(<App />);
@@ -48,7 +46,7 @@ describe("App routing + title", () => {
   });
 
   it("survives a missing #root element on the overlay window", async () => {
-    setSearch("?window=overlay");
+    stubLocation("?window=overlay");
     // Deliberately do not create a #root element; happy-dom's
     // document.getElementById will return null, so the module-load
     // root.classList.add call must short-circuit.
@@ -60,7 +58,7 @@ describe("App routing + title", () => {
   });
 
   it("renders the BreakOverlay and titles the document when window=overlay", async () => {
-    setSearch("?window=overlay");
+    stubLocation("?window=overlay");
     const root = document.createElement("div");
     root.id = "root";
     document.body.appendChild(root);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,8 @@
+import { useEffect } from "react";
 import Settings from "./views/settings";
 import BreakOverlay from "./views/break-overlay";
 import { ErrorBoundary } from "./error-boundary";
-
-const params = new URLSearchParams(window.location.search);
-const windowKind = params.get("window") ?? "main";
+import { titleForWindow, windowKind } from "./lib/window-kind";
 
 if (windowKind === "overlay") {
   document.documentElement.classList.add("overlay-window");
@@ -13,6 +12,10 @@ if (windowKind === "overlay") {
 }
 
 function App() {
+  useEffect(() => {
+    document.title = titleForWindow(windowKind);
+  }, []);
+
   if (windowKind === "overlay") {
     return (
       <ErrorBoundary area="Break overlay">

--- a/src/lib/window-kind.test.ts
+++ b/src/lib/window-kind.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { readWindowKind, titleForWindow } from "./window-kind";
+
+describe("readWindowKind", () => {
+  it("returns 'main' when no window param is present", () => {
+    expect(readWindowKind("")).toBe("main");
+    expect(readWindowKind("?other=value")).toBe("main");
+  });
+
+  it("returns 'overlay' for ?window=overlay", () => {
+    expect(readWindowKind("?window=overlay")).toBe("overlay");
+  });
+
+  it("falls back to 'main' for any other window value", () => {
+    expect(readWindowKind("?window=settings")).toBe("main");
+    expect(readWindowKind("?window=")).toBe("main");
+  });
+});
+
+describe("titleForWindow", () => {
+  it("returns the Settings title for the main window", () => {
+    expect(titleForWindow("main")).toBe("Entracte — Settings");
+  });
+
+  it("returns the Break title for the overlay window", () => {
+    expect(titleForWindow("overlay")).toBe("Entracte — Break");
+  });
+});

--- a/src/lib/window-kind.ts
+++ b/src/lib/window-kind.ts
@@ -1,0 +1,13 @@
+export type WindowKind = "main" | "overlay";
+
+export function readWindowKind(search: string): WindowKind {
+  return new URLSearchParams(search).get("window") === "overlay"
+    ? "overlay"
+    : "main";
+}
+
+export function titleForWindow(kind: WindowKind): string {
+  return kind === "overlay" ? "Entracte — Break" : "Entracte — Settings";
+}
+
+export const windowKind: WindowKind = readWindowKind(window.location.search);

--- a/src/views/settings/index.test.tsx
+++ b/src/views/settings/index.test.tsx
@@ -88,6 +88,31 @@ const TAB_IDS = [
 ] as const;
 
 describe("Settings shell ARIA + keyboard", () => {
+  it("renders a Skip to settings content link as the first focusable element", () => {
+    mockSettings = null;
+    const { container } = render(<Settings />);
+    const skip = screen.getByRole("link", { name: "Skip to settings content" });
+    const focusables = container.querySelectorAll<HTMLElement>(
+      'a[href], area[href], button:not([disabled]), input:not([disabled]):not([type="hidden"]), select:not([disabled]), textarea:not([disabled]), details, summary, [tabindex]:not([tabindex="-1"])',
+    );
+    expect(focusables[0]).toBe(skip);
+  });
+
+  it("skip link href tracks the active tabpanel so focus lands directly on content", async () => {
+    const user = userEvent.setup();
+    mockSettings = hydratedSettings;
+    render(<Settings />);
+    expect(
+      screen.getByRole("link", { name: "Skip to settings content" }).getAttribute("href"),
+    ).toBe("#settings-tabpanel-schedule");
+    const breaksTab = screen.getAllByRole("tab").find((t) => t.id === "settings-tab-breaks");
+    if (!breaksTab) throw new Error("breaks tab not found");
+    await user.click(breaksTab);
+    expect(
+      screen.getByRole("link", { name: "Skip to settings content" }).getAttribute("href"),
+    ).toBe("#settings-tabpanel-breaks");
+  });
+
   it("exposes the tabs nav with role=tablist and a label", () => {
     mockSettings = null;
     render(<Settings />);

--- a/src/views/settings/index.tsx
+++ b/src/views/settings/index.tsx
@@ -43,117 +43,122 @@ export default function Settings() {
   });
 
   return (
-    <main className="settings">
-      <header className="settings-header">
-        <div className="tabs" aria-label="Settings sections" {...tablistProps}>
-          {TABS.map((t) => (
-            <button
-              key={t.id}
-              id={tabButtonId(t.id)}
-              aria-controls={tabPanelId(t.id)}
-              className={tab === t.id ? "active" : ""}
-              {...tabProps(t.id)}
-            >
-              {t.label}
-            </button>
-          ))}
-        </div>
-      </header>
+    <>
+      <a className="skip-link" href={`#${tabPanelId(tab)}`}>
+        Skip to settings content
+      </a>
+      <main className="settings">
+        <header className="settings-header">
+          <div className="tabs" aria-label="Settings sections" {...tablistProps}>
+            {TABS.map((t) => (
+              <button
+                key={t.id}
+                id={tabButtonId(t.id)}
+                aria-controls={tabPanelId(t.id)}
+                className={tab === t.id ? "active" : ""}
+                {...tabProps(t.id)}
+              >
+                {t.label}
+              </button>
+            ))}
+          </div>
+        </header>
 
-      {!settings ? (
-        <p className="loading">Loading…</p>
-      ) : (
-        <>
-          <div
-            className="tab-content"
-            role="tabpanel"
-            id={tabPanelId("schedule")}
-            aria-labelledby={tabButtonId("schedule")}
-            tabIndex={0}
-            hidden={tab !== "schedule"}
-          >
-            <ScheduleTab
-              settings={settings}
-              update={update}
-              updateMany={updateMany}
-              supporter={supporter.status}
-            />
-          </div>
-          <div
-            className="tab-content"
-            role="tabpanel"
-            id={tabPanelId("breaks")}
-            aria-labelledby={tabButtonId("breaks")}
-            tabIndex={0}
-            hidden={tab !== "breaks"}
-          >
-            <BreaksTab
-              settings={settings}
-              update={update}
-              supporter={supporter.status}
-            />
-          </div>
-          <div
-            className="tab-content"
-            role="tabpanel"
-            id={tabPanelId("quiet")}
-            aria-labelledby={tabButtonId("quiet")}
-            tabIndex={0}
-            hidden={tab !== "quiet"}
-          >
-            <QuietTab
-              settings={settings}
-              update={update}
-              pauseInfo={pauseInfo}
-            />
-          </div>
-          <div
-            className="tab-content"
-            role="tabpanel"
-            id={tabPanelId("system")}
-            aria-labelledby={tabButtonId("system")}
-            tabIndex={0}
-            hidden={tab !== "system"}
-          >
-            <SystemTab
-              settings={settings}
-              update={update}
-              setAutostart={setAutostart}
-              hooks={hooks}
-            />
-          </div>
-          <div
-            className="tab-content"
-            role="tabpanel"
-            id={tabPanelId("insights")}
-            aria-labelledby={tabButtonId("insights")}
-            tabIndex={0}
-            hidden={tab !== "insights"}
-          >
-            <InsightsTab stats={stats} />
-          </div>
-          <div
-            className="tab-content"
-            role="tabpanel"
-            id={tabPanelId("profiles")}
-            aria-labelledby={tabButtonId("profiles")}
-            tabIndex={0}
-            hidden={tab !== "profiles"}
-          >
-            <ProfilesTab profiles={profiles} />
-          </div>
-          <div
-            className="tab-content"
-            role="tabpanel"
-            id={tabPanelId("about")}
-            aria-labelledby={tabButtonId("about")}
-            tabIndex={0}
-            hidden={tab !== "about"}
-          >
-            <AboutTab supporter={supporter} />
-          </div>
-        </>
-      )}
-    </main>
+        {!settings ? (
+          <p className="loading">Loading…</p>
+        ) : (
+          <>
+            <div
+              className="tab-content"
+              role="tabpanel"
+              id={tabPanelId("schedule")}
+              aria-labelledby={tabButtonId("schedule")}
+              tabIndex={0}
+              hidden={tab !== "schedule"}
+            >
+              <ScheduleTab
+                settings={settings}
+                update={update}
+                updateMany={updateMany}
+                supporter={supporter.status}
+              />
+            </div>
+            <div
+              className="tab-content"
+              role="tabpanel"
+              id={tabPanelId("breaks")}
+              aria-labelledby={tabButtonId("breaks")}
+              tabIndex={0}
+              hidden={tab !== "breaks"}
+            >
+              <BreaksTab
+                settings={settings}
+                update={update}
+                supporter={supporter.status}
+              />
+            </div>
+            <div
+              className="tab-content"
+              role="tabpanel"
+              id={tabPanelId("quiet")}
+              aria-labelledby={tabButtonId("quiet")}
+              tabIndex={0}
+              hidden={tab !== "quiet"}
+            >
+              <QuietTab
+                settings={settings}
+                update={update}
+                pauseInfo={pauseInfo}
+              />
+            </div>
+            <div
+              className="tab-content"
+              role="tabpanel"
+              id={tabPanelId("system")}
+              aria-labelledby={tabButtonId("system")}
+              tabIndex={0}
+              hidden={tab !== "system"}
+            >
+              <SystemTab
+                settings={settings}
+                update={update}
+                setAutostart={setAutostart}
+                hooks={hooks}
+              />
+            </div>
+            <div
+              className="tab-content"
+              role="tabpanel"
+              id={tabPanelId("insights")}
+              aria-labelledby={tabButtonId("insights")}
+              tabIndex={0}
+              hidden={tab !== "insights"}
+            >
+              <InsightsTab stats={stats} />
+            </div>
+            <div
+              className="tab-content"
+              role="tabpanel"
+              id={tabPanelId("profiles")}
+              aria-labelledby={tabButtonId("profiles")}
+              tabIndex={0}
+              hidden={tab !== "profiles"}
+            >
+              <ProfilesTab profiles={profiles} />
+            </div>
+            <div
+              className="tab-content"
+              role="tabpanel"
+              id={tabPanelId("about")}
+              aria-labelledby={tabButtonId("about")}
+              tabIndex={0}
+              hidden={tab !== "about"}
+            >
+              <AboutTab supporter={supporter} />
+            </div>
+          </>
+        )}
+      </main>
+    </>
   );
 }

--- a/src/views/settings/settings.css
+++ b/src/views/settings/settings.css
@@ -42,6 +42,33 @@ body,
   min-height: 100vh;
 }
 
+.skip-link {
+  position: absolute;
+  top: 0.5rem;
+  left: 0.5rem;
+  padding: 0.5rem 0.9rem;
+  background: var(--accent-strong, var(--accent));
+  color: white;
+  border-radius: 6px;
+  font-size: 0.9rem;
+  font-weight: 500;
+  text-decoration: none;
+  z-index: 1000;
+  transform: translateY(-200%);
+  transition: transform 120ms ease-out;
+}
+
+.skip-link:focus,
+.skip-link:focus-visible {
+  transform: translateY(0);
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+#settings-main:focus {
+  outline: none;
+}
+
 .settings {
   padding: 1.25rem 2.5rem 2.5rem;
   max-width: 560px;

--- a/src/views/settings/settings.css
+++ b/src/views/settings/settings.css
@@ -12,6 +12,7 @@
   --accent-hover: var(--primary-color-hover);
   --pop: var(--accent-color);
   --pop-soft: var(--secondary-color);
+  --on-accent: #ffffff;
   color-scheme: light dark;
 }
 
@@ -48,7 +49,7 @@ body,
   left: 0.5rem;
   padding: 0.5rem 0.9rem;
   background: var(--accent-strong, var(--accent));
-  color: white;
+  color: var(--on-accent);
   border-radius: 6px;
   font-size: 0.9rem;
   font-weight: 500;
@@ -58,15 +59,10 @@ body,
   transition: transform 120ms ease-out;
 }
 
-.skip-link:focus,
 .skip-link:focus-visible {
   transform: translateY(0);
   outline: 2px solid var(--accent);
   outline-offset: 2px;
-}
-
-#settings-main:focus {
-  outline: none;
 }
 
 .settings {


### PR DESCRIPTION
Second PR in the #63 task list. **Stacked on #64** — please merge #64 first; this PR's base branch will retarget to `main` automatically.

## Summary

- New `src/lib/window-kind.ts` with `readWindowKind` + `titleForWindow`. `App.tsx` sets `document.title` to `\"Entracte — Settings\"` or `\"Entracte — Break\"` on mount.
- `index.html` `<title>` is now `\"Entracte\"` (was the Vite default `\"Tauri + React + Typescript\"`).
- `Skip to settings content` link added as the first focusable element of the Settings shell, jumping to a stable `#settings-main` container (`tabindex=-1`) that wraps the tabpanel. The link is visually hidden via `transform: translateY(-200%)` until `:focus`.
- Developer docs updated under `Accessibility contract` to describe both the title flow and the skip-link contract.

## Tests

- `src/lib/window-kind.test.ts` — 5 tests covering both query shapes + the title map.
- `src/App.test.tsx` — 3 tests: routes to Settings + titles for `?window=` empty/missing; routes to BreakOverlay + titles + adds `overlay-window` classes; survives a missing `#root` element on the overlay path.
- `src/views/settings/index.test.tsx` — 2 new tests covering the skip link's `href`, that it's the first focusable element, and that `#settings-main` exists with `tabindex=-1`.
- 100% statement / branch / function / line coverage on the new and modified files.

## Verification

- `npx vitest run` — 475 tests pass
- `npx tsc --noEmit` — clean
- `npm run audit:a11y` — axe clean across all 7 tabs × light/dark, no console errors

## Notes for review

The overlay window's title is the generic `\"Entracte — Break\"`; per-break-kind specificity (`\"Entracte — Micro break\"` etc.) would belong in the overlay component itself and is deferred to a later PR — the in-window live region already speaks the break kind on mount.