### PR TITLE
feat(a11y): :focus-visible baseline across the renderer

### DIFF
--- a/docs/developer/architecture-internals.md
+++ b/docs/developer/architecture-internals.md
@@ -225,7 +225,7 @@ Keyboard:
 - **Tab** — leaves the tablist and lands on the panel (`tabindex={0}` makes that work even when the panel contains no focusable children).
 - **Click / Enter / Space** — activate.
 
-Focus styling lives in [`src/views/settings/settings.css`](https://github.com/drmowinckels/entracte/blob/main/src/views/settings/settings.css) under `.settings .tabs button:focus-visible` and `.settings .tab-content:focus-visible`. Keep these in sync with the `--accent` token so dark and light modes both get a contrast-AA outline.
+Focus styling lives in [`src/views/settings/settings.css`](https://github.com/drmowinckels/entracte/blob/main/src/views/settings/settings.css) and uses the `--focus-ring` / `--focus-ring-width` / `--focus-ring-offset` tokens at `:root` so every interactive control gets a consistent outline. The baseline covers `.settings button`, the form controls (`input`, `select`, `.textarea`, `.hook-command`), the skip link, the tab buttons and the tabpanel. Add `:focus-visible` (never `:focus` alone) so mouse clicks don't pick up the heavy ring. The break overlay's `.overlay-button` has its own white-on-translucent ring; the high-contrast yellow ring keeps overriding it inside `.overlay-root.high-contrast`.
 
 ### Break overlay
 

--- a/src/brand.css
+++ b/src/brand.css
@@ -73,6 +73,10 @@ body.overlay-window {
   color: inherit;
   cursor: pointer;
 }
+.error-boundary-actions button:focus-visible {
+  outline: 2px solid #f4f6fb;
+  outline-offset: 2px;
+}
 .error-boundary-actions button.secondary {
   background: transparent;
 }

--- a/src/views/break-overlay.css
+++ b/src/views/break-overlay.css
@@ -142,6 +142,11 @@
   background: rgba(244, 246, 251, 0.16);
 }
 
+.overlay-button:focus-visible {
+  outline: 2px solid #f4f6fb;
+  outline-offset: 2px;
+}
+
 .overlay-button:disabled {
   opacity: 0.4;
   cursor: not-allowed;

--- a/src/views/settings/settings.css
+++ b/src/views/settings/settings.css
@@ -13,6 +13,17 @@
   --pop: var(--accent-color);
   --pop-soft: var(--secondary-color);
   --on-accent: #ffffff;
+  /* Focus ring tokens. --focus-ring resolves to --light-primary-color
+   * (#81989d) in dark mode and --primary-color (#2e545d) in light mode.
+   * Verified contrast vs page bg (--bg): dark 4.6:1, light 7.4:1 —
+   * both clear WCAG 2.4.11's 3:1 non-text minimum. Tab buttons sit on
+   * a transparent background so they inherit the page bg behind the
+   * outline; .settings button uses outline-offset so the ring lands
+   * on the page bg rather than the filled button. Re-verify if you
+   * retune --light-primary-color or --primary-color. */
+  --focus-ring: var(--accent);
+  --focus-ring-width: 2px;
+  --focus-ring-offset: 2px;
   color-scheme: light dark;
 }
 
@@ -61,8 +72,8 @@ body,
 
 .skip-link:focus-visible {
   transform: translateY(0);
-  outline: 2px solid var(--accent);
-  outline-offset: 2px;
+  outline: var(--focus-ring-width) solid var(--focus-ring);
+  outline-offset: var(--focus-ring-offset);
 }
 
 .settings {
@@ -127,8 +138,8 @@ body,
 }
 
 .settings .tabs button:focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: 2px;
+  outline: var(--focus-ring-width) solid var(--focus-ring);
+  outline-offset: var(--focus-ring-offset);
   border-radius: 4px;
   color: var(--fg);
 }
@@ -148,7 +159,7 @@ body,
 }
 
 .settings .tab-content:focus-visible {
-  outline: 2px solid var(--accent);
+  outline: var(--focus-ring-width) solid var(--focus-ring);
   outline-offset: 4px;
   border-radius: 4px;
 }
@@ -325,6 +336,29 @@ body,
 
 .settings button:hover {
   background: var(--accent-hover);
+}
+
+.settings button:focus-visible {
+  outline: var(--focus-ring-width) solid var(--focus-ring);
+  outline-offset: var(--focus-ring-offset);
+}
+
+.settings input[type="time"]:focus-visible,
+.settings input[type="number"]:focus-visible,
+.settings input[type="text"]:focus-visible,
+.settings input.time-input:focus-visible,
+.settings select:focus-visible,
+.settings .textarea:focus-visible,
+.settings .hook-command:focus-visible {
+  outline: var(--focus-ring-width) solid var(--focus-ring);
+  outline-offset: var(--focus-ring-offset);
+}
+
+.settings input[type="checkbox"]:focus-visible,
+.settings input[type="range"]:focus-visible,
+.settings input[type="color"]:focus-visible {
+  outline: var(--focus-ring-width) solid var(--focus-ring);
+  outline-offset: var(--focus-ring-offset);
 }
 
 .settings button.secondary {


### PR DESCRIPTION
Third PR in #63. **Stacked on #65** (which is stacked on #64). The base will retarget to \`main\` as the upstream PRs land.

## Summary

- Tokenise the focus ring in [settings.css](../blob/main/src/views/settings/settings.css): \`--focus-ring\`, \`--focus-ring-width\`, \`--focus-ring-offset\`.
- Add \`:focus-visible\` outlines on every interactive control in the Settings shell that previously had none or relied on a 1px border-color change: \`.settings button\`, all form inputs (\`time\`, \`number\`, \`text\`, \`time-input\`, \`select\`, \`.textarea\`, \`.hook-command\`), checkboxes, ranges, color pickers.
- Refactor the skip-link, tab buttons, and tabpanel (added in #64 / #65) to use the new tokens.
- Add a default-mode \`:focus-visible\` ring for \`.overlay-button\` (previously only the high-contrast mode had one).
- Add a \`:focus-visible\` ring for the error-boundary action buttons in [brand.css](../blob/main/src/brand.css).
- Update the AT contract section in [docs/developer/architecture-internals.md](../blob/main/docs/developer/architecture-internals.md).

## Why no new tests

This PR is CSS-only — no executable lines, no new functions, no event handlers. The existing \`npm run audit:a11y\` gate covers the structural side (axe flags missing accessible names, contrast violations, focus targets without a name); browser-rendered focus rings are visual and can't be asserted in jsdom. Behaviour-level coverage of focus management already lives in the hook tests added in #64 (\`useRovingTabList\`) and the Settings shell test (\`#settings-main\` focus target) in #65.

## Verification

- \`npx vitest run\` — 475 tests pass (no regression)
- \`npx tsc --noEmit\` — clean
- \`npm run audit:a11y\` — axe clean across all 7 tabs × light/dark

## Notes for review

The token defaults to \`var(--accent)\`, which is \`--light-primary-color: #81989d\` in dark mode and \`--primary-color: #2e545d\` in light mode. Both clear WCAG 2.4.11's 3:1 non-text contrast bar against their respective backgrounds. The overlay button's ring is hard-coded \`#f4f6fb\` because the overlay window is always dark regardless of system mode.