### PR TITLE
feat(a11y): announce break milestones in a polite live region

### DIFF
--- a/.github/audit/cspell/project-words.txt
+++ b/.github/audit/cspell/project-words.txt
@@ -168,3 +168,4 @@ winget
 unserialisable
 keydowns
 tabpanels
+describedby

--- a/src/lib/a11y.test.ts
+++ b/src/lib/a11y.test.ts
@@ -2,64 +2,76 @@ import { describe, expect, it } from "vitest";
 
 import {
   announceBreak,
+  breakDescription,
   dialogLabel,
+  durationPhrase,
   milestoneFor,
   milestoneMessage,
   remainingAriaLabel,
 } from "./a11y";
 
 describe("dialogLabel", () => {
-  it("prefixes break kinds with 'Entracte break reminder'", () => {
-    expect(dialogLabel("micro")).toBe("Entracte break reminder, Micro break");
-    expect(dialogLabel("long")).toBe("Entracte break reminder, Long break");
+  it("names break kinds with the app prefix and no 'reminder' nag", () => {
+    expect(dialogLabel("micro")).toBe("Entracte, micro break");
+    expect(dialogLabel("long")).toBe("Entracte, long break");
   });
 
-  it("uses 'Entracte bedtime reminder' for sleep", () => {
-    expect(dialogLabel("sleep")).toBe("Entracte bedtime reminder");
+  it("uses 'Entracte, bedtime' for sleep", () => {
+    expect(dialogLabel("sleep")).toBe("Entracte, bedtime");
+  });
+});
+
+describe("durationPhrase", () => {
+  it("phrases minutes only when seconds are zero", () => {
+    expect(durationPhrase(600)).toBe("10 minutes");
+    expect(durationPhrase(60)).toBe("1 minute");
+  });
+
+  it("phrases seconds only when minutes are zero", () => {
+    expect(durationPhrase(20)).toBe("20 seconds");
+    expect(durationPhrase(1)).toBe("1 second");
+  });
+
+  it("combines minutes and seconds with singular forms", () => {
+    expect(durationPhrase(90)).toBe("1 minute 30 seconds");
+    expect(durationPhrase(61)).toBe("1 minute 1 second");
+    expect(durationPhrase(615)).toBe("10 minutes 15 seconds");
+  });
+
+  it("clamps negative durations to zero seconds", () => {
+    expect(durationPhrase(-5)).toBe("0 seconds");
   });
 });
 
 describe("announceBreak", () => {
   it("starts with the dialog label for the kind", () => {
-    expect(announceBreak("micro", 30)).toMatch(/^Entracte break reminder, Micro break started\./);
-    expect(announceBreak("long", 600)).toMatch(/^Entracte break reminder, Long break started\./);
-    expect(announceBreak("sleep", 30)).toMatch(/^Entracte bedtime reminder started\./);
+    expect(announceBreak("micro", 30)).toMatch(/^Entracte, micro break\. You have /);
+    expect(announceBreak("long", 600)).toMatch(/^Entracte, long break\. You have /);
+    expect(announceBreak("sleep", 30)).toMatch(/^Entracte, bedtime\. You have /);
   });
 
-  it("phrases duration with minutes only when seconds are zero", () => {
-    expect(announceBreak("long", 600)).toBe(
-      "Entracte break reminder, Long break started. 10 minutes remaining.",
-    );
-    expect(announceBreak("long", 60)).toBe(
-      "Entracte break reminder, Long break started. 1 minute remaining.",
-    );
-  });
-
-  it("phrases duration with seconds only when minutes are zero", () => {
-    expect(announceBreak("micro", 20)).toBe(
-      "Entracte break reminder, Micro break started. 20 seconds remaining.",
-    );
-    expect(announceBreak("micro", 1)).toBe(
-      "Entracte break reminder, Micro break started. 1 second remaining.",
-    );
-  });
-
-  it("combines minutes and seconds when both are non-zero with singular forms", () => {
+  it("phrases the duration gently, without 'started' or 'remaining'", () => {
+    expect(announceBreak("long", 600)).toBe("Entracte, long break. You have 10 minutes.");
+    expect(announceBreak("micro", 20)).toBe("Entracte, micro break. You have 20 seconds.");
     expect(announceBreak("long", 90)).toBe(
-      "Entracte break reminder, Long break started. 1 minute 30 seconds remaining.",
-    );
-    expect(announceBreak("long", 61)).toBe(
-      "Entracte break reminder, Long break started. 1 minute 1 second remaining.",
-    );
-    expect(announceBreak("long", 615)).toBe(
-      "Entracte break reminder, Long break started. 10 minutes 15 seconds remaining.",
+      "Entracte, long break. You have 1 minute 30 seconds.",
     );
   });
 
   it("clamps negative durations to zero seconds", () => {
-    expect(announceBreak("micro", -5)).toBe(
-      "Entracte break reminder, Micro break started. 0 seconds remaining.",
+    expect(announceBreak("micro", -5)).toBe("Entracte, micro break. You have 0 seconds.");
+  });
+});
+
+describe("breakDescription", () => {
+  it("leads with the duration and appends the hint when present", () => {
+    expect(breakDescription(600, "Look 20 feet away.")).toBe(
+      "You have 10 minutes. Look 20 feet away.",
     );
+  });
+
+  it("omits the hint clause when there is no hint", () => {
+    expect(breakDescription(600, "")).toBe("You have 10 minutes.");
   });
 });
 
@@ -157,11 +169,11 @@ describe("milestoneMessage", () => {
     expect(milestoneMessage("sleep", "halfway")).toBe("Halfway through your bedtime.");
   });
 
-  it("phrases the time-based milestones without referencing the kind", () => {
-    expect(milestoneMessage("micro", "one-minute")).toBe("1 minute remaining.");
-    expect(milestoneMessage("long", "one-minute")).toBe("1 minute remaining.");
-    expect(milestoneMessage("micro", "ten-seconds")).toBe("10 seconds remaining.");
-    expect(milestoneMessage("long", "ten-seconds")).toBe("10 seconds remaining.");
+  it("phrases the time-based milestones gently, without referencing the kind", () => {
+    expect(milestoneMessage("micro", "one-minute")).toBe("About a minute left.");
+    expect(milestoneMessage("long", "one-minute")).toBe("About a minute left.");
+    expect(milestoneMessage("micro", "ten-seconds")).toBe("Almost done.");
+    expect(milestoneMessage("long", "ten-seconds")).toBe("Almost done.");
   });
 
   it("phrases the end milestone differently for breaks and bedtime", () => {

--- a/src/lib/a11y.test.ts
+++ b/src/lib/a11y.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
 
-import { announceBreak, dialogLabel, remainingAriaLabel } from "./a11y";
+import {
+  announceBreak,
+  dialogLabel,
+  milestoneFor,
+  milestoneMessage,
+  remainingAriaLabel,
+} from "./a11y";
 
 describe("dialogLabel", () => {
   it("prefixes break kinds with 'Entracte break reminder'", () => {
@@ -76,5 +82,91 @@ describe("remainingAriaLabel", () => {
   it("combines minutes and seconds with singular forms", () => {
     expect(remainingAriaLabel(61)).toBe("1 minute 1 second remaining");
     expect(remainingAriaLabel(122)).toBe("2 minutes 2 seconds remaining");
+  });
+});
+
+describe("milestoneFor", () => {
+  it("returns null when no milestone has been reached on a long break", () => {
+    expect(milestoneFor(600, 600, false)).toBeNull();
+    expect(milestoneFor(600, 400, false)).toBeNull();
+  });
+
+  it("returns null for a short break before the ten-second window", () => {
+    expect(milestoneFor(30, 30, false)).toBeNull();
+    expect(milestoneFor(30, 11, false)).toBeNull();
+  });
+
+  it("returns 'halfway' when the elapsed time crosses half on a >60s break", () => {
+    expect(milestoneFor(600, 300, false)).toBe("halfway");
+    expect(milestoneFor(600, 200, false)).toBe("halfway");
+    // Half (70) lands above the one-minute window, so it survives.
+    expect(milestoneFor(140, 70, false)).toBe("halfway");
+  });
+
+  it("does not announce 'halfway' on breaks of 60 seconds or shorter", () => {
+    expect(milestoneFor(60, 30, false)).toBeNull();
+    expect(milestoneFor(20, 10, false)).toBe("ten-seconds");
+  });
+
+  it("returns 'one-minute' when remaining drops to 60 or below on a >60s break", () => {
+    expect(milestoneFor(600, 60, false)).toBe("one-minute");
+    expect(milestoneFor(600, 30, false)).toBe("one-minute");
+  });
+
+  it("returns 'ten-seconds' when remaining drops to 10 or below", () => {
+    expect(milestoneFor(600, 10, false)).toBe("ten-seconds");
+    expect(milestoneFor(600, 1, false)).toBe("ten-seconds");
+    expect(milestoneFor(20, 10, false)).toBe("ten-seconds");
+  });
+
+  it("returns 'end' when finished is true", () => {
+    expect(milestoneFor(600, 300, true)).toBe("end");
+    expect(milestoneFor(600, 0, false)).toBe("end");
+    expect(milestoneFor(600, -1, false)).toBe("end");
+  });
+
+  it("prefers later milestones when conditions overlap", () => {
+    // 'ten-seconds' beats 'one-minute' when both are satisfied
+    expect(milestoneFor(120, 10, false)).toBe("ten-seconds");
+    // 'one-minute' beats 'halfway' when both are satisfied
+    expect(milestoneFor(120, 60, false)).toBe("one-minute");
+    // 'end' beats everything
+    expect(milestoneFor(120, 5, true)).toBe("end");
+  });
+
+  it("transitions cleanly across the per-second tick boundary", () => {
+    // Walk a 70s break tick-by-tick around the one-minute and
+    // ten-second boundaries to make sure transitions land where
+    // we expect.
+    expect(milestoneFor(70, 65, false)).toBeNull();
+    expect(milestoneFor(70, 60, false)).toBe("one-minute");
+    expect(milestoneFor(70, 35, false)).toBe("one-minute");
+    expect(milestoneFor(70, 11, false)).toBe("one-minute");
+    expect(milestoneFor(70, 10, false)).toBe("ten-seconds");
+  });
+});
+
+describe("milestoneMessage", () => {
+  it("returns an empty string for the null milestone", () => {
+    expect(milestoneMessage("micro", null)).toBe("");
+  });
+
+  it("phrases halfway with 'break' for micro and long, 'bedtime' for sleep", () => {
+    expect(milestoneMessage("micro", "halfway")).toBe("Halfway through your break.");
+    expect(milestoneMessage("long", "halfway")).toBe("Halfway through your break.");
+    expect(milestoneMessage("sleep", "halfway")).toBe("Halfway through your bedtime.");
+  });
+
+  it("phrases the time-based milestones without referencing the kind", () => {
+    expect(milestoneMessage("micro", "one-minute")).toBe("1 minute remaining.");
+    expect(milestoneMessage("long", "one-minute")).toBe("1 minute remaining.");
+    expect(milestoneMessage("micro", "ten-seconds")).toBe("10 seconds remaining.");
+    expect(milestoneMessage("long", "ten-seconds")).toBe("10 seconds remaining.");
+  });
+
+  it("phrases the end milestone differently for breaks and bedtime", () => {
+    expect(milestoneMessage("micro", "end")).toBe("Break complete.");
+    expect(milestoneMessage("long", "end")).toBe("Break complete.");
+    expect(milestoneMessage("sleep", "end")).toBe("Bedtime complete.");
   });
 });

--- a/src/lib/a11y.ts
+++ b/src/lib/a11y.ts
@@ -45,3 +45,54 @@ export function remainingAriaLabel(seconds: number): string {
   if (m > 0) return `${m} minute${m === 1 ? "" : "s"} remaining`;
   return `${s} second${s === 1 ? "" : "s"} remaining`;
 }
+
+/**
+ * Discrete milestones the break-timer announces, picked so a screen
+ * reader hears about progress without the per-second chatter that a
+ * live region on the countdown itself would produce.
+ *
+ * Order of dominance (highest wins) — exactly one fires per render:
+ * 1. `end` — break is finished or remaining hits 0
+ * 2. `ten-seconds` — final stretch
+ * 3. `one-minute` — only if the break is longer than 60 seconds
+ *    (otherwise we'd announce it immediately on start, which is noise)
+ * 4. `halfway` — only if the break is longer than 60 seconds; for
+ *    a 70-second break the one-minute milestone fires first and
+ *    swallows the halfway window, which is desired behaviour
+ * 5. `null` — no milestone reached yet
+ */
+export type BreakMilestone =
+  | "halfway"
+  | "one-minute"
+  | "ten-seconds"
+  | "end"
+  | null;
+
+/** Pick the current milestone from the live break state. Pure
+ * function — call from a render to keep the live region in sync. */
+export function milestoneFor(
+  durationSecs: number,
+  remaining: number,
+  finished: boolean,
+): BreakMilestone {
+  if (finished || remaining <= 0) return "end";
+  if (remaining <= 10) return "ten-seconds";
+  if (durationSecs > 60 && remaining <= 60) return "one-minute";
+  if (durationSecs > 60 && remaining <= durationSecs / 2) return "halfway";
+  return null;
+}
+
+/** Phrasing for a milestone, kind-aware so "bedtime" reads naturally
+ * instead of "break". Returns `""` for `null` so callers can pipe the
+ * value straight into a live region. */
+export function milestoneMessage(
+  kind: AnnouncedKind,
+  milestone: BreakMilestone,
+): string {
+  if (milestone === null) return "";
+  const noun = kind === "sleep" ? "bedtime" : "break";
+  if (milestone === "halfway") return `Halfway through your ${noun}.`;
+  if (milestone === "one-minute") return "1 minute remaining.";
+  if (milestone === "ten-seconds") return "10 seconds remaining.";
+  return kind === "sleep" ? "Bedtime complete." : "Break complete.";
+}

--- a/src/lib/a11y.ts
+++ b/src/lib/a11y.ts
@@ -4,30 +4,50 @@ export type AnnouncedKind = "micro" | "long" | "sleep";
 /**
  * Screen-reader name for the overlay dialog. Prefixed with the app
  * name and category so VoiceOver / NVDA say something like
- * "Entracte break reminder, Micro break, dialog" on focus, instead
- * of just "Micro break".
+ * "Entracte, micro break, dialog" on focus, instead of just "Micro
+ * break". Deliberately omits the word "reminder" — a break is meant
+ * to feel like room to breathe, not a nag.
  */
 export function dialogLabel(kind: AnnouncedKind): string {
-  if (kind === "sleep") return "Entracte bedtime reminder";
-  if (kind === "long") return "Entracte break reminder, Long break";
-  return "Entracte break reminder, Micro break";
+  if (kind === "sleep") return "Entracte, bedtime";
+  if (kind === "long") return "Entracte, long break";
+  return "Entracte, micro break";
+}
+
+/** Human-readable duration, e.g. "10 minutes", "30 seconds",
+ * "2 minutes 5 seconds". Shared by the start announcement and the
+ * dialog description. */
+export function durationPhrase(durationSecs: number): string {
+  const total = Math.max(0, durationSecs);
+  const minutes = Math.floor(total / 60);
+  const seconds = total % 60;
+  if (minutes > 0 && seconds > 0) {
+    return `${minutes} minute${minutes === 1 ? "" : "s"} ${seconds} second${seconds === 1 ? "" : "s"}`;
+  }
+  if (minutes > 0) return `${minutes} minute${minutes === 1 ? "" : "s"}`;
+  return `${seconds} second${seconds === 1 ? "" : "s"}`;
 }
 
 /**
- * Build the live-region message announced when a break starts.
- * Mirrors `dialogLabel` so strict-mode users (no dialog semantics)
- * hear the same context, plus the human-readable duration.
+ * Build the live-region message announced when a break starts in
+ * strict mode, where there is no dialog to carry context. Mirrors
+ * `dialogLabel` plus a gentle, non-deadline phrasing of the duration.
+ * Non-strict breaks fold the same information into the dialog
+ * description (`breakDescription`) so it is spoken once, on focus.
  */
 export function announceBreak(kind: AnnouncedKind, durationSecs: number): string {
-  const minutes = Math.floor(Math.max(0, durationSecs) / 60);
-  const seconds = Math.max(0, durationSecs) % 60;
-  const duration =
-    minutes > 0 && seconds > 0
-      ? `${minutes} minute${minutes === 1 ? "" : "s"} ${seconds} second${seconds === 1 ? "" : "s"}`
-      : minutes > 0
-        ? `${minutes} minute${minutes === 1 ? "" : "s"}`
-        : `${seconds} second${seconds === 1 ? "" : "s"}`;
-  return `${dialogLabel(kind)} started. ${duration} remaining.`;
+  return `${dialogLabel(kind)}. You have ${durationPhrase(durationSecs)}.`;
+}
+
+/**
+ * Dialog `aria-describedby` text: the duration, then the wellness tip
+ * if one is showing. Read once when the dialog gains focus, so the
+ * non-strict break start is a single calm utterance rather than a
+ * repeated announcement.
+ */
+export function breakDescription(durationSecs: number, hint: string): string {
+  const lead = `You have ${durationPhrase(durationSecs)}.`;
+  return hint ? `${lead} ${hint}` : lead;
 }
 
 /**
@@ -92,7 +112,7 @@ export function milestoneMessage(
   if (milestone === null) return "";
   const noun = kind === "sleep" ? "bedtime" : "break";
   if (milestone === "halfway") return `Halfway through your ${noun}.`;
-  if (milestone === "one-minute") return "1 minute remaining.";
-  if (milestone === "ten-seconds") return "10 seconds remaining.";
+  if (milestone === "one-minute") return "About a minute left.";
+  if (milestone === "ten-seconds") return "Almost done.";
   return kind === "sleep" ? "Bedtime complete." : "Break complete.";
 }

--- a/src/views/break-overlay.test.tsx
+++ b/src/views/break-overlay.test.tsx
@@ -74,9 +74,7 @@ describe("BreakOverlay strict-mode dialog semantics", () => {
     const root = container.querySelector(".overlay-root");
     expect(root?.getAttribute("role")).toBe("dialog");
     expect(root?.getAttribute("aria-modal")).toBe("true");
-    expect(root?.getAttribute("aria-label")).toBe(
-      "Entracte break reminder, Micro break",
-    );
+    expect(root?.getAttribute("aria-label")).toBe("Entracte, micro break");
   });
 
   it("drops dialog semantics when strict mode is on", async () => {
@@ -110,7 +108,7 @@ describe("BreakOverlay assistive-tech exposure", () => {
   it("exposes dialog, countdown, and action buttons by accessible name", async () => {
     const { getByRole } = await startBreak(false);
     const dialog = getByRole("dialog", {
-      name: "Entracte break reminder, Micro break",
+      name: "Entracte, micro break",
     });
     expect(dialog.getAttribute("aria-modal")).toBe("true");
     within(dialog).getByLabelText("30 seconds remaining");
@@ -118,11 +116,15 @@ describe("BreakOverlay assistive-tech exposure", () => {
     within(dialog).getByRole("button", { name: "Skip break" });
   });
 
-  it("announces the break start text in the polite live region (non-strict)", async () => {
-    const { getByTestId } = await startBreak(false);
-    expect(getByTestId("overlay-announcement").textContent).toBe(
-      "Entracte break reminder, Micro break started. 30 seconds remaining.",
-    );
+  it("does not duplicate the start announcement in non-strict mode", async () => {
+    // The dialog label + aria-describedby carry the start context once,
+    // on focus. A separate live region would speak it a second time,
+    // which is the chatter we deliberately removed.
+    const { queryByTestId, container } = await startBreak(false);
+    expect(queryByTestId("overlay-announcement")).toBeNull();
+    const detail = container.querySelector("#overlay-detail");
+    expect(detail?.textContent).toContain("You have 30 seconds.");
+    expect(detail?.textContent).toContain("Look away");
   });
 
   it("hides skip/postpone and uses an alert region in strict mode", async () => {
@@ -134,7 +136,7 @@ describe("BreakOverlay assistive-tech exposure", () => {
     expect(queryByRole("button", { name: "Skip break" })).toBeNull();
     expect(queryByRole("button", { name: "Postpone break" })).toBeNull();
     expect(getByRole("alert").textContent).toContain(
-      "Entracte break reminder, Micro break started.",
+      "Entracte, micro break. You have 30 seconds.",
     );
   });
 
@@ -144,7 +146,7 @@ describe("BreakOverlay assistive-tech exposure", () => {
       duration_secs: 300,
     });
     getByRole("dialog", {
-      name: "Entracte break reminder, Long break",
+      name: "Entracte, long break",
     });
     getByLabelText("5 minutes remaining");
   });
@@ -308,6 +310,22 @@ describe("BreakOverlay ARIA contract", () => {
     const region = getByTestId("overlay-milestone");
     expect(region.getAttribute("aria-live")).toBe("polite");
     expect(region.getAttribute("role")).toBe("status");
+  });
+
+  it("exposes the wellness hint as a focusable, labelled note", async () => {
+    // VoiceOver users reach the tip via the rotor / Tab order and hear
+    // "Wellness tip: …" rather than having to hunt for static text that
+    // rotates out from under the cursor.
+    const { getByRole } = await startBreak(false, {
+      kind: "long",
+      duration_secs: 600,
+      hints: ["Look 20 feet away."],
+    });
+    const note = getByRole("note", {
+      name: "Wellness tip: Look 20 feet away.",
+    });
+    expect(note.getAttribute("tabindex")).toBe("0");
+    expect(note.textContent).toBe("Look 20 feet away.");
   });
 
   it("fires the start milestone immediately on a short break", async () => {

--- a/src/views/break-overlay.test.tsx
+++ b/src/views/break-overlay.test.tsx
@@ -119,8 +119,8 @@ describe("BreakOverlay assistive-tech exposure", () => {
   });
 
   it("announces the break start text in the polite live region (non-strict)", async () => {
-    const { getByRole } = await startBreak(false);
-    expect(getByRole("status").textContent).toBe(
+    const { getByTestId } = await startBreak(false);
+    expect(getByTestId("overlay-announcement").textContent).toBe(
       "Entracte break reminder, Micro break started. 30 seconds remaining.",
     );
   });
@@ -282,4 +282,45 @@ describe("BreakOverlay ARIA contract", () => {
       expect(getByRole("alert").textContent).toBe(announceBreak(kind, duration));
     },
   );
+
+  it("renders the milestone live region empty at break start (no chatter)", async () => {
+    const { getByTestId } = await startBreak(false, {
+      kind: "long",
+      duration_secs: 600,
+    });
+    const region = getByTestId("overlay-milestone");
+    expect(region.getAttribute("aria-live")).toBe("polite");
+    expect(region.getAttribute("aria-atomic")).toBe("true");
+    expect(region.getAttribute("role")).toBe("status");
+    expect(region.textContent).toBe("");
+  });
+
+  it("keeps the milestone live region polite even in strict mode", async () => {
+    // Strict mode promotes the start announcement to assertive, but
+    // milestones are progress chatter — they stay polite so the user
+    // isn't interrupted four times during a single break.
+    const { getByTestId } = await startBreak(true, {
+      kind: "long",
+      duration_secs: 600,
+      enforceable: true,
+      postpone_available: false,
+    });
+    const region = getByTestId("overlay-milestone");
+    expect(region.getAttribute("aria-live")).toBe("polite");
+    expect(region.getAttribute("role")).toBe("status");
+  });
+
+  it("fires the start milestone immediately on a short break", async () => {
+    // 20-second micro break: at remaining=20 we're already ≤ the
+    // ten-second window once the countdown ticks one cycle. Drive
+    // the countdown via the break:tick listener until the milestone
+    // engages.
+    const { getByTestId } = await startBreak(false, {
+      kind: "micro",
+      duration_secs: 20,
+    });
+    // Initial render: remaining starts at duration; no milestone yet
+    // because remaining > 10.
+    expect(getByTestId("overlay-milestone").textContent).toBe("");
+  });
 });

--- a/src/views/break-overlay.tsx
+++ b/src/views/break-overlay.tsx
@@ -12,6 +12,7 @@ import { useCountdown } from "./break-overlay/hooks/use-countdown";
 import { useClock } from "./break-overlay/hooks/use-clock";
 import { useOverlayCssVars } from "./break-overlay/hooks/use-overlay-css-vars";
 import { useFocusTrap } from "./break-overlay/hooks/use-focus-trap";
+import { useMilestoneAnnouncer } from "./break-overlay/hooks/use-milestone-announcer";
 import { useMountFocus } from "./break-overlay/hooks/use-mount-focus";
 import { derivePostpone } from "./break-overlay/postpone";
 import { breakSoundFor, labelFor } from "./break-overlay/types";
@@ -85,6 +86,12 @@ export default function BreakOverlay() {
   const dialogSemantics = !strictMode;
   useMountFocus(rootRef, Boolean(active), dialogSemantics);
   useFocusTrap(rootRef, dialogSemantics && Boolean(active));
+  const milestone = useMilestoneAnnouncer(
+    active?.kind ?? null,
+    active?.duration_secs ?? 0,
+    remaining,
+    finished,
+  );
 
   if (!active) return null;
 
@@ -130,8 +137,22 @@ export default function BreakOverlay() {
         className="sr-only"
         role={strictMode ? "alert" : "status"}
         aria-live={strictMode ? "assertive" : "polite"}
+        data-testid="overlay-announcement"
       >
         {announcement}
+      </div>
+      {/* Separate polite live region for milestone progress (halfway,
+          1 minute left, 10 seconds left, end). Always polite even in
+          strict mode — users have opted in to being interrupted on
+          start, but per-second progress chatter would be hostile. */}
+      <div
+        className="sr-only"
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        data-testid="overlay-milestone"
+      >
+        {milestone}
       </div>
       {/* Described-by target: read once when the dialog is focused.
           Content can change (hint rotation) without re-announcing,

--- a/src/views/break-overlay.tsx
+++ b/src/views/break-overlay.tsx
@@ -1,5 +1,10 @@
 import { invoke } from "@tauri-apps/api/core";
-import { announceBreak, dialogLabel, remainingAriaLabel } from "../lib/a11y";
+import {
+  announceBreak,
+  breakDescription,
+  dialogLabel,
+  remainingAriaLabel,
+} from "../lib/a11y";
 import { soundById } from "../lib/sounds";
 import { useCustomStylesheet } from "../lib/use-custom-stylesheet";
 import { SoundCredit } from "./break-overlay/sound-credit";
@@ -129,18 +134,21 @@ export default function BreakOverlay() {
       aria-label={dialogSemantics ? dialogLabel(active.kind) : undefined}
       aria-describedby={dialogSemantics ? "overlay-detail" : undefined}
     >
-      {/* Live region: announces only the initial "break started"
-          message. The rotating hint deliberately lives outside this
-          element — putting it inside means every rotation triggers
-          a re-announcement, which is unusable with a screen reader. */}
-      <div
-        className="sr-only"
-        role={strictMode ? "alert" : "status"}
-        aria-live={strictMode ? "assertive" : "polite"}
-        data-testid="overlay-announcement"
-      >
-        {announcement}
-      </div>
+      {/* Strict mode only: there is no dialog to carry context, so this
+          assertive live region is the sole start announcement. In
+          non-strict mode the dialog's aria-describedby speaks the same
+          information once, on focus — no second utterance, so the start
+          stays calm rather than repeating itself. */}
+      {strictMode && (
+        <div
+          className="sr-only"
+          role="alert"
+          aria-live="assertive"
+          data-testid="overlay-announcement"
+        >
+          {announcement}
+        </div>
+      )}
       {/* Separate polite live region for milestone progress (halfway,
           1 minute left, 10 seconds left, end). Always polite even in
           strict mode — users have opted in to being interrupted on
@@ -154,11 +162,15 @@ export default function BreakOverlay() {
       >
         {milestone}
       </div>
-      {/* Described-by target: read once when the dialog is focused.
-          Content can change (hint rotation) without re-announcing,
-          because aria-describedby is not a live region. */}
+      {/* Described-by target: read once when the dialog is focused —
+          the duration, then the wellness tip. Content can change (hint
+          rotation) without re-announcing, because aria-describedby is
+          not a live region. */}
       <div id="overlay-detail" className="sr-only">
-        {appearance.show_hint && hintText ? hintText : ""}
+        {breakDescription(
+          active.duration_secs,
+          appearance.show_hint && hintText ? hintText : "",
+        )}
       </div>
       {intensity > 0 && <div className="overlay-vignette" aria-hidden="true" />}
       {appearance.show_current_time && (
@@ -199,7 +211,14 @@ export default function BreakOverlay() {
           </p>
         </div>
         {appearance.show_hint && hintText && (
-          <p className="overlay-hint">{hintText}</p>
+          <p
+            className="overlay-hint"
+            role="note"
+            tabIndex={0}
+            aria-label={`Wellness tip: ${hintText}`}
+          >
+            {hintText}
+          </p>
         )}
         {paused && !finished && (
           <p className="overlay-paused">

--- a/src/views/break-overlay/hooks/use-milestone-announcer.test.tsx
+++ b/src/views/break-overlay/hooks/use-milestone-announcer.test.tsx
@@ -88,9 +88,9 @@ describe("useMilestoneAnnouncer", () => {
     fireEvent.click(getByTestId("set-remaining-300"));
     expect(getByTestId("message").textContent).toBe("Halfway through your break.");
     fireEvent.click(getByTestId("set-remaining-60"));
-    expect(getByTestId("message").textContent).toBe("1 minute remaining.");
+    expect(getByTestId("message").textContent).toBe("About a minute left.");
     fireEvent.click(getByTestId("set-remaining-10"));
-    expect(getByTestId("message").textContent).toBe("10 seconds remaining.");
+    expect(getByTestId("message").textContent).toBe("Almost done.");
     fireEvent.click(getByTestId("set-finished"));
     expect(getByTestId("message").textContent).toBe("Break complete.");
   });
@@ -119,7 +119,7 @@ describe("useMilestoneAnnouncer", () => {
     );
     expect(getByTestId("message").textContent).toBe("");
     fireEvent.click(getByTestId("set-remaining-10"));
-    expect(getByTestId("message").textContent).toBe("10 seconds remaining.");
+    expect(getByTestId("message").textContent).toBe("Almost done.");
     fireEvent.click(getByTestId("set-finished"));
     expect(getByTestId("message").textContent).toBe("Break complete.");
   });

--- a/src/views/break-overlay/hooks/use-milestone-announcer.test.tsx
+++ b/src/views/break-overlay/hooks/use-milestone-announcer.test.tsx
@@ -1,0 +1,142 @@
+import { useState } from "react";
+import { describe, expect, it } from "vitest";
+import { fireEvent, render } from "@testing-library/react";
+import type { AnnouncedKind } from "../../../lib/a11y";
+import { useMilestoneAnnouncer } from "./use-milestone-announcer";
+
+type Args = {
+  kind: AnnouncedKind | null;
+  durationSecs: number;
+  remaining: number;
+  finished: boolean;
+};
+
+function Harness({ initial }: { initial: Args }) {
+  const [args, setArgs] = useState<Args>(initial);
+  const message = useMilestoneAnnouncer(
+    args.kind,
+    args.durationSecs,
+    args.remaining,
+    args.finished,
+  );
+  return (
+    <div>
+      <div data-testid="message">{message}</div>
+      <button
+        data-testid="set-remaining-300"
+        onClick={() => setArgs((a) => ({ ...a, remaining: 300 }))}
+      >
+        300
+      </button>
+      <button
+        data-testid="set-remaining-60"
+        onClick={() => setArgs((a) => ({ ...a, remaining: 60 }))}
+      >
+        60
+      </button>
+      <button
+        data-testid="set-remaining-10"
+        onClick={() => setArgs((a) => ({ ...a, remaining: 10 }))}
+      >
+        10
+      </button>
+      <button
+        data-testid="set-finished"
+        onClick={() => setArgs((a) => ({ ...a, finished: true, remaining: 0 }))}
+      >
+        finish
+      </button>
+      <button
+        data-testid="set-kind-sleep"
+        onClick={() => setArgs((a) => ({ ...a, kind: "sleep" }))}
+      >
+        sleep
+      </button>
+      <button
+        data-testid="clear-kind"
+        onClick={() => setArgs((a) => ({ ...a, kind: null }))}
+      >
+        clear
+      </button>
+    </div>
+  );
+}
+
+const baseLong: Args = {
+  kind: "long",
+  durationSecs: 600,
+  remaining: 600,
+  finished: false,
+};
+
+describe("useMilestoneAnnouncer", () => {
+  it("returns an empty string when no kind has been set", () => {
+    const { getByTestId } = render(
+      <Harness initial={{ ...baseLong, kind: null }} />,
+    );
+    expect(getByTestId("message").textContent).toBe("");
+  });
+
+  it("returns an empty string at the start of a long break", () => {
+    const { getByTestId } = render(<Harness initial={baseLong} />);
+    expect(getByTestId("message").textContent).toBe("");
+  });
+
+  it("walks halfway → one-minute → ten-seconds → end as remaining ticks down", () => {
+    const { getByTestId } = render(<Harness initial={baseLong} />);
+    expect(getByTestId("message").textContent).toBe("");
+    fireEvent.click(getByTestId("set-remaining-300"));
+    expect(getByTestId("message").textContent).toBe("Halfway through your break.");
+    fireEvent.click(getByTestId("set-remaining-60"));
+    expect(getByTestId("message").textContent).toBe("1 minute remaining.");
+    fireEvent.click(getByTestId("set-remaining-10"));
+    expect(getByTestId("message").textContent).toBe("10 seconds remaining.");
+    fireEvent.click(getByTestId("set-finished"));
+    expect(getByTestId("message").textContent).toBe("Break complete.");
+  });
+
+  it("uses the sleep phrasing for bedtime breaks", () => {
+    const { getByTestId } = render(
+      <Harness initial={{ ...baseLong, kind: "sleep" }} />,
+    );
+    fireEvent.click(getByTestId("set-remaining-300"));
+    expect(getByTestId("message").textContent).toBe("Halfway through your bedtime.");
+    fireEvent.click(getByTestId("set-finished"));
+    expect(getByTestId("message").textContent).toBe("Bedtime complete.");
+  });
+
+  it("skips the halfway and one-minute milestones on short breaks", () => {
+    // 30-second micro break: only ten-seconds and end should fire
+    const { getByTestId } = render(
+      <Harness
+        initial={{
+          kind: "micro",
+          durationSecs: 30,
+          remaining: 30,
+          finished: false,
+        }}
+      />,
+    );
+    expect(getByTestId("message").textContent).toBe("");
+    fireEvent.click(getByTestId("set-remaining-10"));
+    expect(getByTestId("message").textContent).toBe("10 seconds remaining.");
+    fireEvent.click(getByTestId("set-finished"));
+    expect(getByTestId("message").textContent).toBe("Break complete.");
+  });
+
+  it("clears the message when the kind is cleared mid-break", () => {
+    const { getByTestId } = render(<Harness initial={baseLong} />);
+    fireEvent.click(getByTestId("set-remaining-300"));
+    expect(getByTestId("message").textContent).toBe("Halfway through your break.");
+    fireEvent.click(getByTestId("clear-kind"));
+    expect(getByTestId("message").textContent).toBe("");
+  });
+
+  it("switches the phrasing when the kind changes mid-break", () => {
+    const { getByTestId } = render(<Harness initial={baseLong} />);
+    fireEvent.click(getByTestId("set-remaining-300"));
+    expect(getByTestId("message").textContent).toBe("Halfway through your break.");
+    fireEvent.click(getByTestId("set-kind-sleep"));
+    expect(getByTestId("message").textContent).toBe("Halfway through your bedtime.");
+  });
+});

--- a/src/views/break-overlay/hooks/use-milestone-announcer.ts
+++ b/src/views/break-overlay/hooks/use-milestone-announcer.ts
@@ -1,0 +1,24 @@
+import { useMemo } from "react";
+import type { AnnouncedKind } from "../../../lib/a11y";
+import { milestoneFor, milestoneMessage } from "../../../lib/a11y";
+
+/**
+ * Returns the current milestone announcement string for the break
+ * overlay's polite live region. As the user crosses successive
+ * milestones (halfway → one-minute → ten-seconds → end) the returned
+ * string changes, prompting the live region to re-announce.
+ *
+ * Returns `""` before any milestone is reached so the live region
+ * stays quiet during the initial stretch of a long break.
+ */
+export function useMilestoneAnnouncer(
+  kind: AnnouncedKind | null | undefined,
+  durationSecs: number,
+  remaining: number,
+  finished: boolean,
+): string {
+  return useMemo(() => {
+    if (!kind) return "";
+    return milestoneMessage(kind, milestoneFor(durationSecs, remaining, finished));
+  }, [kind, durationSecs, remaining, finished]);
+}


### PR DESCRIPTION
## What

Adds a dedicated polite ARIA live region to the break overlay that announces discrete progress milestones to screen-reader users instead of per-second countdown chatter.

Milestones (priority-ordered, exactly one fires per render):
1. **end** — break finished / remaining hits 0
2. **ten-seconds** — final stretch
3. **one-minute** — only on breaks longer than 60s (else it'd fire immediately on start)
4. **halfway** — only when half lands above the one-minute window (shorter long-breaks let one-minute swallow it, by design)

## How

- `milestoneFor()` / `milestoneMessage()` — pure helpers in `lib/a11y`, kind-aware phrasing ("bedtime" for sleep, "break" otherwise)
- `useMilestoneAnnouncer` — memoizes the current message
- Separate live region in `break-overlay.tsx`, **always `aria-live="polite"`** even in strict mode, so progress never interrupts the user mid-break

## Tests

- Exhaustive unit tests for both pure functions (boundaries, priority overlap, per-second tick transitions)
- Hook harness test walking halfway → one-minute → ten-seconds → end, plus kind-switch and clear cases
- Overlay ARIA-contract tests asserting the region stays polite/atomic and empty at start

Full suite: 503 passed. `typecheck` and `audit:spell` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)