### PR TITLE
fix: break-experience bugs — bedtime-on-wake, end-chime timing, and on-time dismissal

### DIFF
--- a/src-tauri/src/scheduler/overlay.rs
+++ b/src-tauri/src/scheduler/overlay.rs
@@ -85,7 +85,7 @@ fn ensure_overlay<R: Runtime>(app: &AppHandle<R>, idx: usize) -> Option<tauri::W
     if let Some(w) = app.get_webview_window(&label) {
         return Some(w);
     }
-    tauri::WebviewWindowBuilder::new(
+    match tauri::WebviewWindowBuilder::new(
         app,
         &label,
         tauri::WebviewUrl::App("index.html?window=overlay".into()),
@@ -99,7 +99,19 @@ fn ensure_overlay<R: Runtime>(app: &AppHandle<R>, idx: usize) -> Option<tauri::W
     .visible(false)
     .focused(false)
     .build()
-    .ok()
+    {
+        Ok(w) => Some(w),
+        // Don't swallow this silently: a failed build means the break is
+        // completely invisible (no overlay, no preview, no test break) with
+        // no other symptom. On some Linux setups the windowing system
+        // rejects a transparent always-on-top surface, which used to look
+        // like "breaks just don't fire". Logging it gives users and bug
+        // reports something to go on. See issue #67.
+        Err(e) => {
+            log::error!("overlay: failed to create break window '{label}': {e}");
+            None
+        }
+    }
 }
 
 fn select_overlay_monitors<R: Runtime>(

--- a/src-tauri/src/scheduler/run_loop.rs
+++ b/src-tauri/src/scheduler/run_loop.rs
@@ -33,6 +33,24 @@ fn import_pending(flag: &AtomicBool) -> bool {
     flag.load(Ordering::Relaxed)
 }
 
+/// Inter-tick wall-clock gap above which we treat the tick as the first
+/// one after a wake from suspend. Well clear of the 1s cadence and any
+/// scheduler jitter, but far below the smallest useful bedtime interval.
+const SUSPEND_GAP_THRESHOLD: Duration = Duration::from_secs(30);
+
+/// Whether the gap between the previous tick's wall clock and `now`
+/// indicates a wake from suspend (or a forward clock leap). Pulled out
+/// of the loop body so the threshold logic is unit-testable without
+/// driving the 1Hz loop. A backwards clock step yields `Err` from
+/// `duration_since` and is treated as "not resumed".
+#[inline]
+fn resumed_after_gap(prev_wall: SystemTime, now_wall: SystemTime, threshold: Duration) -> bool {
+    now_wall
+        .duration_since(prev_wall)
+        .map(|gap| gap >= threshold)
+        .unwrap_or(false)
+}
+
 pub(super) async fn run_loop(app: AppHandle, sched: Scheduler) {
     let mut sysinfo_system: Option<System> = None;
     // `Instant - Duration` panics if the result would precede the
@@ -42,9 +60,19 @@ pub(super) async fn run_loop(app: AppHandle, sched: Scheduler) {
         .checked_sub(Duration::from_secs(60))
         .unwrap_or_else(Instant::now);
     let mut app_pause_active = false;
+    // Wall-clock anchor for wake-from-suspend detection. The loop ticks
+    // at 1Hz, so a jump far beyond that between ticks means the machine
+    // was asleep (or the clock leapt). `SystemTime` is used rather than
+    // `Instant` because it reflects the wall clock regardless of whether
+    // the monotonic clock counts suspended time on this platform.
+    let mut last_tick_wall = SystemTime::now();
 
     loop {
         sleep(Duration::from_secs(1)).await;
+
+        let now_wall = SystemTime::now();
+        let resumed_from_suspend = resumed_after_gap(last_tick_wall, now_wall, SUSPEND_GAP_THRESHOLD);
+        last_tick_wall = now_wall;
 
         // Early-out while an import is mid-flight. This is an
         // optimisation, not the actual safety mechanism — the
@@ -159,6 +187,7 @@ pub(super) async fn run_loop(app: AppHandle, sched: Scheduler) {
                 s.bedtime_interval_secs,
                 t.last_sleep,
                 now,
+                resumed_from_suspend,
             )
         };
         if !matches!(bedtime_decision, BedtimeAction::NotInWindow) {
@@ -205,6 +234,15 @@ pub(super) async fn run_loop(app: AppHandle, sched: Scheduler) {
                 t.last_long = Instant::now();
                 t.micro_deferred_since = None;
                 t.long_deferred_since = None;
+                // On the wake tick we demoted a stale catch-up fire to a
+                // reset; re-anchor `last_sleep` to now so the next (no
+                // longer "resumed") tick doesn't immediately re-fire on
+                // the same huge elapsed interval. Normal in-interval
+                // resets leave `last_sleep` alone so the re-prompt cadence
+                // keeps counting from the real last fire.
+                if resumed_from_suspend {
+                    t.last_sleep = Some(Instant::now());
+                }
             }
             // Bedtime has its own tray snapshot (`TrayCountdownSnapshot::Bedtime`),
             // so we don't need to store a `SuppressReason` here — the
@@ -922,6 +960,36 @@ mod tests {
     fn import_pending_returns_true_when_flag_set() {
         let flag = AtomicBool::new(true);
         assert!(import_pending(&flag));
+    }
+
+    #[test]
+    fn resumed_after_gap_true_when_gap_exceeds_threshold() {
+        let prev = SystemTime::now();
+        let now = prev + Duration::from_secs(8 * 3600);
+        assert!(resumed_after_gap(prev, now, SUSPEND_GAP_THRESHOLD));
+    }
+
+    #[test]
+    fn resumed_after_gap_false_for_a_normal_tick() {
+        let prev = SystemTime::now();
+        let now = prev + Duration::from_secs(1);
+        assert!(!resumed_after_gap(prev, now, SUSPEND_GAP_THRESHOLD));
+    }
+
+    #[test]
+    fn resumed_after_gap_false_on_backwards_clock_step() {
+        // duration_since errors when now precedes prev; that must read as
+        // "not resumed" rather than panic.
+        let now = SystemTime::now();
+        let prev = now + Duration::from_secs(120);
+        assert!(!resumed_after_gap(prev, now, SUSPEND_GAP_THRESHOLD));
+    }
+
+    #[test]
+    fn resumed_after_gap_is_inclusive_at_threshold() {
+        let prev = SystemTime::now();
+        let now = prev + SUSPEND_GAP_THRESHOLD;
+        assert!(resumed_after_gap(prev, now, SUSPEND_GAP_THRESHOLD));
     }
 
     #[test]

--- a/src-tauri/src/scheduler/run_loop.rs
+++ b/src-tauri/src/scheduler/run_loop.rs
@@ -71,7 +71,8 @@ pub(super) async fn run_loop(app: AppHandle, sched: Scheduler) {
         sleep(Duration::from_secs(1)).await;
 
         let now_wall = SystemTime::now();
-        let resumed_from_suspend = resumed_after_gap(last_tick_wall, now_wall, SUSPEND_GAP_THRESHOLD);
+        let resumed_from_suspend =
+            resumed_after_gap(last_tick_wall, now_wall, SUSPEND_GAP_THRESHOLD);
         last_tick_wall = now_wall;
 
         // Early-out while an import is mid-flight. This is an

--- a/src-tauri/src/scheduler/timers.rs
+++ b/src-tauri/src/scheduler/timers.rs
@@ -216,6 +216,17 @@ pub enum BedtimeAction {
 ///
 /// `last_sleep == None` always fires on the first tick of the window —
 /// the cap only kicks in for re-prompts.
+///
+/// `resumed_from_suspend` is `true` on the single tick that follows a
+/// wake from sleep (detected via a wall-clock jump in the run loop). The
+/// monotonic `last_sleep` anchor can show an arbitrarily large elapsed
+/// interval across a suspend, which would otherwise fire a stale catch-up
+/// prompt the instant the lid opens. When we've *already* prompted this
+/// window (`last_sleep` is `Some`), we demote that catch-up to
+/// `ResetTimersOnly` so opening the laptop mid-window stays quiet. A
+/// first entry into the window (`last_sleep` is `None`, e.g. the laptop
+/// was closed before bedtime and opened inside it) still fires normally.
+#[allow(clippy::too_many_arguments)]
 pub fn decide_bedtime(
     enabled: bool,
     now_min: u32,
@@ -224,6 +235,7 @@ pub fn decide_bedtime(
     interval_secs: u64,
     last_sleep_fire: Option<Instant>,
     now: Instant,
+    resumed_from_suspend: bool,
 ) -> BedtimeAction {
     if !enabled || !in_window(now_min, start_min, end_min) {
         return BedtimeAction::NotInWindow;
@@ -233,6 +245,9 @@ pub fn decide_bedtime(
         Some(t) => now.saturating_duration_since(t) >= Duration::from_secs(interval_secs),
     };
     if should_fire {
+        if resumed_from_suspend && last_sleep_fire.is_some() {
+            return BedtimeAction::ResetTimersOnly;
+        }
         BedtimeAction::Fire
     } else {
         BedtimeAction::ResetTimersOnly
@@ -683,7 +698,7 @@ mod tests {
         let now = Instant::now();
         // 12:00, window 22:00–06:00
         assert_eq!(
-            decide_bedtime(true, 12 * 60, 22 * 60, 6 * 60, 1800, None, now),
+            decide_bedtime(true, 12 * 60, 22 * 60, 6 * 60, 1800, None, now, false),
             BedtimeAction::NotInWindow
         );
     }
@@ -692,7 +707,7 @@ mod tests {
     fn bedtime_disabled_returns_not_in_window_even_in_range() {
         let now = Instant::now();
         assert_eq!(
-            decide_bedtime(false, 23 * 60, 22 * 60, 6 * 60, 1800, None, now),
+            decide_bedtime(false, 23 * 60, 22 * 60, 6 * 60, 1800, None, now, false),
             BedtimeAction::NotInWindow
         );
     }
@@ -701,7 +716,7 @@ mod tests {
     fn bedtime_first_tick_of_window_fires() {
         let now = Instant::now();
         assert_eq!(
-            decide_bedtime(true, 23 * 60, 22 * 60, 6 * 60, 1800, None, now),
+            decide_bedtime(true, 23 * 60, 22 * 60, 6 * 60, 1800, None, now, false),
             BedtimeAction::Fire
         );
     }
@@ -711,7 +726,7 @@ mod tests {
         let last = Instant::now();
         let now = last + Duration::from_secs(1800);
         assert_eq!(
-            decide_bedtime(true, 23 * 60, 22 * 60, 6 * 60, 1800, Some(last), now),
+            decide_bedtime(true, 23 * 60, 22 * 60, 6 * 60, 1800, Some(last), now, false),
             BedtimeAction::Fire
         );
     }
@@ -722,7 +737,7 @@ mod tests {
         let last = Instant::now();
         let now = last + Duration::from_secs(900);
         assert_eq!(
-            decide_bedtime(true, 23 * 60, 22 * 60, 6 * 60, 1800, Some(last), now),
+            decide_bedtime(true, 23 * 60, 22 * 60, 6 * 60, 1800, Some(last), now, false),
             BedtimeAction::ResetTimersOnly
         );
     }
@@ -732,7 +747,7 @@ mod tests {
         let now = Instant::now();
         // 02:00 should still be in window 22:00–06:00
         assert_eq!(
-            decide_bedtime(true, 2 * 60, 22 * 60, 6 * 60, 1800, None, now),
+            decide_bedtime(true, 2 * 60, 22 * 60, 6 * 60, 1800, None, now, false),
             BedtimeAction::Fire
         );
     }
@@ -744,8 +759,50 @@ mod tests {
         let now = Instant::now();
         let future = now + Duration::from_secs(60);
         assert_eq!(
-            decide_bedtime(true, 23 * 60, 22 * 60, 6 * 60, 1800, Some(future), now),
+            decide_bedtime(true, 23 * 60, 22 * 60, 6 * 60, 1800, Some(future), now, false),
             BedtimeAction::ResetTimersOnly
+        );
+    }
+
+    #[test]
+    fn bedtime_resume_from_suspend_does_not_refire_after_prior_prompt() {
+        // Issue #61: prompt fired in the evening (last_sleep = Some), the
+        // laptop slept for hours, and the user opens it still inside the
+        // overnight window. The monotonic elapsed dwarfs the interval, so
+        // the plain rule would fire — but the wake tick must stay quiet.
+        let last = Instant::now();
+        let now = last + Duration::from_secs(8 * 3600);
+        assert_eq!(
+            decide_bedtime(true, 8 * 60, 22 * 60, 9 * 60, 300, Some(last), now, true),
+            BedtimeAction::ResetTimersOnly
+        );
+        // Without the resume flag the same inputs would (wrongly, for the
+        // user) re-fire — proving the flag is what suppresses it.
+        assert_eq!(
+            decide_bedtime(true, 8 * 60, 22 * 60, 9 * 60, 300, Some(last), now, false),
+            BedtimeAction::Fire
+        );
+    }
+
+    #[test]
+    fn bedtime_resume_into_first_entry_still_fires() {
+        // Laptop closed before bedtime, opened inside the window: no prompt
+        // has fired this window (last_sleep = None), so even a wake tick
+        // should fire the first reminder.
+        let now = Instant::now();
+        assert_eq!(
+            decide_bedtime(true, 23 * 60, 22 * 60, 9 * 60, 300, None, now, true),
+            BedtimeAction::Fire
+        );
+    }
+
+    #[test]
+    fn bedtime_resume_outside_window_is_noop() {
+        // A wake well outside the window is still just NotInWindow.
+        let now = Instant::now();
+        assert_eq!(
+            decide_bedtime(true, 12 * 60, 22 * 60, 9 * 60, 300, Some(now), now, true),
+            BedtimeAction::NotInWindow
         );
     }
 }

--- a/src-tauri/src/scheduler/timers.rs
+++ b/src-tauri/src/scheduler/timers.rs
@@ -759,7 +759,16 @@ mod tests {
         let now = Instant::now();
         let future = now + Duration::from_secs(60);
         assert_eq!(
-            decide_bedtime(true, 23 * 60, 22 * 60, 6 * 60, 1800, Some(future), now, false),
+            decide_bedtime(
+                true,
+                23 * 60,
+                22 * 60,
+                6 * 60,
+                1800,
+                Some(future),
+                now,
+                false
+            ),
             BedtimeAction::ResetTimersOnly
         );
     }

--- a/src/lib/sounds.test.ts
+++ b/src/lib/sounds.test.ts
@@ -18,6 +18,7 @@ const {
   soundsForMode,
   startAmbient,
   startCustomAmbient,
+  stopAllSounds,
 } = await import("./sounds");
 
 // We don't mock the catalogue — these tests assert against the real
@@ -193,6 +194,17 @@ describe("playSound", () => {
     await expect(promise).resolves.toBeUndefined();
   });
 
+  it("tears down the element when play() rejects so a deferred play can't resume later", async () => {
+    installFakeAudio(async () => {
+      throw new Error("autoplay blocked");
+    });
+    const promise = playSound("398496", 0.5);
+    const audio = await waitForAudio();
+    await promise;
+    expect(audio.pause).toHaveBeenCalled();
+    expect(audio.src).toBe("");
+  });
+
   it("resolves via the safety timeout even if neither 'ended' nor 'error' ever fires", async () => {
     // Critical invariant: the breakSoundFor caller awaits playSound and
     // must not hang forever if the Audio element gets wedged (e.g. a
@@ -206,8 +218,39 @@ describe("playSound", () => {
         new Promise((_, reject) => setTimeout(() => reject(new Error("playSound hung past safety timeout")), 3500)),
       ]),
     ).resolves.toBeUndefined();
-    void audio; // referenced to anchor the lint scope
+    // The safety timeout must also tear the element down — a chime that
+    // never started while the overlay was visible would otherwise resume
+    // and bleed into the start of the next break (issue #62).
+    expect(audio.pause).toHaveBeenCalled();
+    expect(audio.src).toBe("");
   }, 5000);
+});
+
+describe("stopAllSounds", () => {
+  beforeEach(() => {
+    installFakeAudio();
+  });
+
+  afterEach(() => {
+    restoreAudio();
+  });
+
+  it("stops a one-shot playback still in flight and clears its src", async () => {
+    const promise = playSound("398496", 0.5);
+    const audio = await waitForAudio();
+    // Neither 'ended' nor 'error' has fired — the chime is still live.
+    stopAllSounds();
+    expect(audio.pause).toHaveBeenCalled();
+    expect(audio.src).toBe("");
+    // Settle the still-pending promise so the test leaves nothing hanging.
+    audio.fire("ended");
+    await promise;
+  });
+
+  it("is a no-op when nothing is playing", () => {
+    expect(() => stopAllSounds()).not.toThrow();
+    expect(createdAudios.length).toBe(0);
+  });
 });
 
 describe("startAmbient", () => {

--- a/src/lib/sounds.ts
+++ b/src/lib/sounds.ts
@@ -83,28 +83,56 @@ function clampVolume(volume: number): number {
 const livePlaybacks = new Set<HTMLAudioElement>();
 const PLAYBACK_TIMEOUT_MS = 2500;
 
+function teardownPlayback(audio: HTMLAudioElement): void {
+  try {
+    audio.pause();
+    audio.currentTime = 0;
+    audio.src = "";
+  } catch {
+    // ignore — element may already be torn down
+  }
+}
+
 async function playUrlOnce(url: string, volume: number): Promise<void> {
   const audio = new Audio(url);
   audio.volume = clampVolume(volume);
   livePlaybacks.add(audio);
   return new Promise<void>((resolve) => {
     let settled = false;
-    const finish = () => {
+    // `stop` is true when we're giving up on a playback that never
+    // finished cleanly (safety timeout, or `play()` rejected). A break
+    // overlay can suspend its webview's media when it hides; an
+    // untorn-down element with a deferred `play()` then resumes and the
+    // chime bleeds into the *start* of the next break. Tearing it down
+    // here makes a missed chime stay missed instead of mistimed.
+    const finish = (stop: boolean) => {
       if (settled) return;
       settled = true;
+      if (stop) teardownPlayback(audio);
       livePlaybacks.delete(audio);
       resolve();
     };
-    audio.addEventListener("ended", finish, { once: true });
-    audio.addEventListener("error", finish, { once: true });
-    const timeoutId = setTimeout(finish, PLAYBACK_TIMEOUT_MS);
+    audio.addEventListener("ended", () => finish(false), { once: true });
+    audio.addEventListener("error", () => finish(false), { once: true });
+    const timeoutId = setTimeout(() => finish(true), PLAYBACK_TIMEOUT_MS);
     audio.addEventListener(
       "ended",
       () => clearTimeout(timeoutId),
       { once: true },
     );
-    audio.play().catch(() => finish());
+    audio.play().catch(() => finish(true));
   });
+}
+
+/** Immediately stop and discard any one-shot playbacks still in flight.
+ * Called when a new break overlay opens so a chime that's still playing
+ * (or was deferred by the previous overlay hiding) can't bleed into the
+ * new break. Ambient loops manage their own lifecycle and are untouched. */
+export function stopAllSounds(): void {
+  for (const audio of livePlaybacks) {
+    teardownPlayback(audio);
+  }
+  livePlaybacks.clear();
 }
 
 /** Play a sound once. Resolves when the audio ends, errors, or the

--- a/src/views/break-overlay/hooks/use-break-state.test.ts
+++ b/src/views/break-overlay/hooks/use-break-state.test.ts
@@ -77,6 +77,30 @@ describe("useBreakState", () => {
     expect(result.current.finished).toBe(false);
   });
 
+  it("flushes any lingering chime when a new break starts", async () => {
+    const invoke = vi.fn(async (cmd: string) => {
+      if (cmd === "get_current_break") return null;
+      if (cmd === "get_settings") return DEFAULT_OVERLAY_SETTINGS;
+      if (cmd === "get_postpone_state") return { count: 0, max: 3, remaining: 3 };
+      return null;
+    });
+    const stopAllSounds = vi.fn();
+    const { listen, emit } = makeListener();
+    const { result } = renderHook(() =>
+      useBreakState({
+        invoke: invoke as unknown as typeof import("@tauri-apps/api/core").invoke,
+        listen: listen as unknown as typeof import("@tauri-apps/api/event").listen,
+        stopAllSounds,
+      }),
+    );
+    await waitFor(() => expect(listen).toHaveBeenCalledTimes(2));
+    await act(async () => {
+      emit("break:start", sampleBreak);
+    });
+    await waitFor(() => expect(result.current.active).not.toBeNull());
+    expect(stopAllSounds).toHaveBeenCalled();
+  });
+
   it("clears active state when a break:end event arrives", async () => {
     const invoke = vi.fn(async (cmd: string) => {
       if (cmd === "get_settings") return DEFAULT_OVERLAY_SETTINGS;

--- a/src/views/break-overlay/hooks/use-break-state.ts
+++ b/src/views/break-overlay/hooks/use-break-state.ts
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { pickRotationTheme } from "../../../lib/color";
+import { stopAllSounds as defaultStopAllSounds } from "../../../lib/sounds";
 import {
   DEFAULT_OVERLAY_SETTINGS,
   type BreakEvent,
@@ -17,6 +18,7 @@ function resolveTheme(setting: string, previous: string): string {
 export type BreakStateDeps = {
   invoke?: typeof invoke;
   listen?: typeof listen;
+  stopAllSounds?: typeof defaultStopAllSounds;
 };
 
 export type BreakStateApi = {
@@ -36,6 +38,7 @@ export type BreakStateApi = {
 export function useBreakState(deps: BreakStateDeps = {}): BreakStateApi {
   const invokeFn = deps.invoke ?? invoke;
   const listenFn = deps.listen ?? listen;
+  const stopAllSoundsFn = deps.stopAllSounds ?? defaultStopAllSounds;
 
   const [active, setActive] = useState<BreakEvent | null>(null);
   const [remaining, setRemaining] = useState(0);
@@ -51,6 +54,9 @@ export function useBreakState(deps: BreakStateDeps = {}): BreakStateApi {
   useEffect(() => {
     let cancelled = false;
     const applyBreak = async (payload: BreakEvent) => {
+      // Flush any chime still in flight from a previous break before the
+      // new overlay takes over, so a deferred end-sound can't play here.
+      stopAllSoundsFn();
       try {
         const s = await invokeFn<OverlaySettings>("get_settings");
         if (cancelled) return;
@@ -132,7 +138,7 @@ export function useBreakState(deps: BreakStateDeps = {}): BreakStateApi {
       unlistenStartFn?.();
       unlistenEndFn?.();
     };
-  }, [invokeFn, listenFn]);
+  }, [invokeFn, listenFn, stopAllSoundsFn]);
 
   const clearBreak = () => {
     setActive(null);

--- a/src/views/break-overlay/hooks/use-countdown.test.ts
+++ b/src/views/break-overlay/hooks/use-countdown.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { act, renderHook } from "@testing-library/react";
-import { useCountdown } from "./use-countdown";
+import { DONE_LINGER_MS, useCountdown } from "./use-countdown";
 import { DEFAULT_OVERLAY_SETTINGS, type BreakEvent, type OverlaySettings } from "../types";
 
 function makeBreak(overrides: Partial<BreakEvent> = {}): BreakEvent {
@@ -70,7 +70,7 @@ describe("useCountdown", () => {
     expect(setRemaining).not.toHaveBeenCalled();
   });
 
-  it("fires end-chime and end_break when remaining hits 0 on non-manual breaks", async () => {
+  it("fires the end-chime immediately but defers end_break to the Done-linger beat", () => {
     const invoke = vi.fn(async () => null);
     const playSound = vi.fn(() => Promise.resolve());
     const setFinished = vi.fn();
@@ -95,12 +95,19 @@ describe("useCountdown", () => {
         },
       ),
     );
+    // Done shows and the chime fires right away — but the overlay must
+    // not dismiss until the short linger elapses (issue: breaks felt long
+    // because dismissal waited for the whole chime).
     expect(setFinished).toHaveBeenCalledWith(true);
-    await vi.waitFor(() => {
-      expect(playSound).toHaveBeenCalledWith("chime-1", 0.5);
-      expect(invoke).toHaveBeenCalledWith("end_break", { reason: "completed" });
-      expect(clearBreak).toHaveBeenCalled();
+    expect(playSound).toHaveBeenCalledWith("chime-1", 0.5);
+    expect(invoke).not.toHaveBeenCalled();
+    expect(clearBreak).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(DONE_LINGER_MS);
     });
+    expect(invoke).toHaveBeenCalledWith("end_break", { reason: "completed" });
+    expect(clearBreak).toHaveBeenCalled();
   });
 
   it("does not auto-end on manual_finish breaks", () => {
@@ -159,9 +166,7 @@ describe("useCountdown", () => {
     act(() => {
       result.current.triggerFinish();
     });
-    await vi.waitFor(() => {
-      expect(playSound).toHaveBeenCalledWith("chime-new", 0.8);
-    });
+    expect(playSound).toHaveBeenCalledWith("chime-new", 0.8);
   });
 
   it("routes to playCustomSound when end-chime sound_id is the custom sentinel", async () => {
@@ -193,9 +198,7 @@ describe("useCountdown", () => {
         },
       ),
     );
-    await vi.waitFor(() => {
-      expect(playCustomSound).toHaveBeenCalledWith("/Users/me/chime.mp3", 0.7);
-    });
+    expect(playCustomSound).toHaveBeenCalledWith("/Users/me/chime.mp3", 0.7);
     expect(playSound).not.toHaveBeenCalled();
   });
 
@@ -228,12 +231,42 @@ describe("useCountdown", () => {
         },
       ),
     );
-    await vi.waitFor(() => {
-      expect(invoke).toHaveBeenCalledWith("end_break", { reason: "completed" });
-      expect(clearBreak).toHaveBeenCalled();
+    act(() => {
+      vi.advanceTimersByTime(DONE_LINGER_MS);
     });
+    expect(invoke).toHaveBeenCalledWith("end_break", { reason: "completed" });
+    expect(clearBreak).toHaveBeenCalled();
     expect(playSound).not.toHaveBeenCalled();
     expect(playCustomSound).not.toHaveBeenCalled();
+  });
+
+  it("triggerFinish dismisses after the Done-linger beat, not immediately", () => {
+    const invoke = vi.fn(async () => null);
+    const clearBreak = vi.fn();
+    const { result } = renderHook(() =>
+      useCountdown(
+        makeBreak({ manual_finish: true }),
+        0,
+        false,
+        DEFAULT_OVERLAY_SETTINGS,
+        vi.fn(),
+        vi.fn(),
+        clearBreak,
+        {
+          invoke: invoke as unknown as typeof import("@tauri-apps/api/core").invoke,
+          playSound: vi.fn(() => Promise.resolve()),
+        },
+      ),
+    );
+    act(() => {
+      result.current.triggerFinish();
+    });
+    expect(invoke).not.toHaveBeenCalled();
+    act(() => {
+      vi.advanceTimersByTime(DONE_LINGER_MS);
+    });
+    expect(invoke).toHaveBeenCalledWith("end_break", { reason: "completed" });
+    expect(clearBreak).toHaveBeenCalled();
   });
 
   it("triggerFinish is a no-op when no break is active", () => {

--- a/src/views/break-overlay/hooks/use-countdown.ts
+++ b/src/views/break-overlay/hooks/use-countdown.ts
@@ -12,6 +12,13 @@ import {
 } from "../../../lib/sounds";
 import { CUSTOM_SOUND_ID } from "../../../lib/break-sound";
 
+/** How long the "Done" state stays on screen after the countdown ends
+ * before the overlay dismisses. Long enough to register the end of the
+ * break and let the chime ring, short enough that the break still ends
+ * close to its set duration — previously the overlay lingered for the
+ * full chime (up to several seconds), which made every break feel long. */
+export const DONE_LINGER_MS = 800;
+
 export type CountdownDeps = {
   invoke?: typeof invoke;
   playSound?: typeof defaultPlaySound;
@@ -68,13 +75,19 @@ export function useCountdown(
 
   const endingRef = useRef(false);
 
-  const playEndChime = (): Promise<void> => {
+  const playEndChime = (): void => {
     const snap = endChimeRef.current;
-    if (!snap.sound) return Promise.resolve();
+    if (!snap.sound) return;
     if (snap.sound.sound_id === CUSTOM_SOUND_ID) {
-      return playCustomSoundFn(snap.sound.custom_path ?? "", snap.volume);
+      void playCustomSoundFn(snap.sound.custom_path ?? "", snap.volume);
+      return;
     }
-    return playSoundFn(snap.sound.sound_id, snap.volume);
+    void playSoundFn(snap.sound.sound_id, snap.volume);
+  };
+
+  const dismiss = () => {
+    invokeFn("end_break", { reason: "completed" });
+    clearBreak();
   };
 
   useEffect(() => {
@@ -87,11 +100,12 @@ export function useCountdown(
       endingRef.current = true;
       setFinished(true);
       if (active.manual_finish) return;
-      playEndChime().finally(() => {
-        invokeFn("end_break", { reason: "completed" });
-        clearBreak();
-      });
-      return;
+      // Fire the chime but don't gate the dismissal on it finishing —
+      // hold "Done" for a short fixed beat instead so the break ends
+      // close to its set length regardless of the chime's length.
+      playEndChime();
+      const t = setTimeout(dismiss, DONE_LINGER_MS);
+      return () => clearTimeout(t);
     }
     if (paused) return;
     const t = setTimeout(() => setRemaining((r) => r - 1), 1000);
@@ -102,10 +116,8 @@ export function useCountdown(
   const triggerFinish = () => {
     if (!active) return;
     setFinished(true);
-    playEndChime().finally(() => {
-      invokeFn("end_break", { reason: "completed" });
-      clearBreak();
-    });
+    playEndChime();
+    setTimeout(dismiss, DONE_LINGER_MS);
   };
 
   return { triggerFinish };


### PR DESCRIPTION
Three break-experience fixes from issues opened against the app, plus a diagnostic for a Linux report.

## What's fixed

### Bedtime fires on opening the laptop in the morning — closes #61
The re-prompt gate compared the monotonic `last_sleep` anchor against the interval; across a multi-hour suspend that elapsed time dwarfs any interval, so the first tick after waking inside an overnight window (e.g. 22:00–09:00) re-fired the prompt. We now detect the wake via a wall-clock (`SystemTime`) jump between 1Hz ticks and demote that catch-up to a timer reset when a prompt already fired this window. A genuine first entry into the window still fires.

### End-chime plays at the *start* of the next break — closes #62
The overlay window is reused across breaks, so its webview keeps its `<audio>` elements alive. A chime that didn't finish cleanly (2.5s safety timeout, or `play()` rejected) was left untorn-down; a deferred `play()` then resumed and rang at the start of the next break. We now tear the element down on those paths and flush anything still in flight (`stopAllSounds()`) when a new overlay opens.

### Every break ran 3–4s past its set time
The overlay only dismissed after `playEndChime()` resolved — i.e. after the chime's `ended` event or its 2.5s safety timeout — so "Done" lingered for the full chime length. We now fire the chime without gating dismissal on it and close after a short fixed `DONE_LINGER_MS` (800ms) beat, so the break ends close to its set length while the chime still rings as it closes.

### Linux: breaks silently never appear — refs #67
`ensure_overlay` used `.build().ok()`, swallowing window-creation errors so a failed build (overlay, preview, and test break) did nothing with no log line. Now logged as an error. This is a **diagnostic**, not a confirmed fix for #67 — see that issue for the X11 follow-up.

## Tests
- Rust: **601 passing** — new `decide_bedtime` resume/demote cases + pure `resumed_after_gap` tests.
- Vitest: **438 passing** — chime teardown-on-timeout/reject, `stopAllSounds`, break-start flush, deferred-dismissal timing.
- `cargo clippy --all-targets` clean; `tsc --noEmit` clean.

## Coverage note (admin bypass expected)
A few new lines sit inside surfaces no test can reach: the 1Hz `run_loop` body wiring (the `last_tick_wall` plumbing and `last_sleep` re-anchor, beside the existing untested `t.last_micro = …` assignments) and the `ensure_overlay` build-failure branch (needs a real failing window manager). All extractable logic was pulled into pure, tested functions (`resumed_after_gap`, `decide_bedtime`). These are the genuinely-unreachable category the codecov policy allows bypassing.

## Follow-up
Opened #69 to replace the `#[allow(clippy::too_many_arguments)]` suppressions (incl. the one this PR adds to `decide_bedtime`) with parameter structs.