### PR TITLE
feat(diagnostics): richer report — environment, runtime state, lifecycle logging

### DIFF
--- a/src-tauri/src/diagnostics.rs
+++ b/src-tauri/src/diagnostics.rs
@@ -182,9 +182,6 @@ fn format_monitors(monitors: &[MonitorFacts]) -> String {
         .join("\n")
 }
 
-/// Render the whole environment block from already-gathered facts.
-/// Pure: the caller does the env / windowing-system queries and passes
-/// the results in, so this formatting is fully unit-testable.
 /// Per-kind interval clock: how long since this kind last fired and the
 /// configured interval, so the report can show "due in / overdue by".
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -321,7 +318,16 @@ fn gather_monitors<R: Runtime>(app: &AppHandle<R>) -> Vec<MonitorFacts> {
         .collect()
 }
 
-async fn runtime_snapshot_section<R: Runtime>(app: &AppHandle<R>, scheduler: &Scheduler) -> String {
+/// Build the Runtime section from the live scheduler state plus the two
+/// values the caller fetches from plugins (`build_diagnostics_report`
+/// passes them in). Kept free of `AppHandle` so it's testable with a bare
+/// scheduler — `MockRuntime` + the notification/autostart plugins abort on
+/// headless Linux, which is the only platform CI runs tests on.
+async fn runtime_snapshot_section(
+    scheduler: &Scheduler,
+    notification_permission: String,
+    autostart_registered: Option<bool>,
+) -> String {
     use std::sync::atomic::Ordering;
     use std::time::Instant;
 
@@ -367,19 +373,6 @@ async fn runtime_snapshot_section<R: Runtime>(app: &AppHandle<R>, scheduler: &Sc
             t.micro_postpone_count,
             t.long_postpone_count,
         )
-    };
-
-    let notification_permission = {
-        use tauri_plugin_notification::NotificationExt;
-        app.notification()
-            .permission_state()
-            .map(|p| p.to_string())
-            .unwrap_or_else(|e| format!("unknown ({e})"))
-    };
-
-    let autostart_registered = {
-        use tauri_plugin_autostart::ManagerExt;
-        app.autolaunch().is_enabled().ok()
     };
 
     let snapshot = RuntimeSnapshot {
@@ -433,6 +426,9 @@ fn environment_section<R: Runtime>(app: &AppHandle<R>) -> String {
     )
 }
 
+/// Render the whole environment block from already-gathered facts.
+/// Pure: the caller does the env / windowing-system queries and passes
+/// the results in, so this formatting is fully unit-testable.
 fn format_environment(
     os: &str,
     env: &EnvFacts,
@@ -468,7 +464,23 @@ pub async fn build_diagnostics_report<R: Runtime>(
     let version = app.package_info().version.to_string();
     let os = os_description();
     let environment = environment_section(&app);
-    let runtime = runtime_snapshot_section(&app, scheduler.inner()).await;
+    let notification_permission = {
+        use tauri_plugin_notification::NotificationExt;
+        app.notification()
+            .permission_state()
+            .map(|p| p.to_string())
+            .unwrap_or_else(|e| format!("unknown ({e})"))
+    };
+    let autostart_registered = {
+        use tauri_plugin_autostart::ManagerExt;
+        app.autolaunch().is_enabled().ok()
+    };
+    let runtime = runtime_snapshot_section(
+        scheduler.inner(),
+        notification_permission,
+        autostart_registered,
+    )
+    .await;
     let settings = scheduler.settings.lock().await.clone();
     let stats = scheduler.stats.lock().await.clone();
     let settings_value = serde_json::to_value(&settings).unwrap_or(serde_json::Value::Null);
@@ -856,18 +868,17 @@ mod tests {
         assert!(out.contains("OS `unknown`"));
     }
 
-    // Integration test for the Runtime-section gathering glue (pause /
-    // suppression / sensors / idle probe / timers / plugin queries) driven
-    // through a mock app. The Environment section is *not* exercised here:
-    // `MockRuntime` panics with "not implemented" on `available_monitors`,
-    // so the monitor-gathering glue is genuinely unreachable in tests and
-    // only its pure formatters (above) are covered.
-    #[cfg(not(target_os = "windows"))]
+    // Integration test for the Runtime-section gathering: pause /
+    // suppression / sensors / idle probe / timers, assembled from a live
+    // scheduler. The two plugin-derived values are passed in (as the
+    // command does), so no mock app / AppHandle is needed — that matters
+    // because the notification/autostart plugins under MockRuntime abort on
+    // the headless Linux runner, the only platform CI runs tests on. The
+    // Environment/monitor glue stays uncovered for the same runtime reason;
+    // only its pure formatters (above) are exercised.
     #[tokio::test]
     async fn runtime_snapshot_section_reports_live_scheduler_state() {
         use crate::scheduler::{Scheduler, Settings};
-        use tauri::test::{mock_builder, mock_context, noop_assets};
-        use tauri::Manager;
 
         let dir = temp_dir();
         let sched = Scheduler::for_test(
@@ -878,25 +889,16 @@ mod tests {
             crate::config::DEFAULT_PROFILE_NAME,
             dir.path(),
         );
-        let app = mock_builder()
-            .plugin(tauri_plugin_notification::init())
-            .plugin(tauri_plugin_autostart::init(
-                tauri_plugin_autostart::MacosLauncher::LaunchAgent,
-                None,
-            ))
-            .build(mock_context(noop_assets()))
-            .expect("mock app builds");
-        app.manage(sched.clone());
 
-        let section = runtime_snapshot_section(app.handle(), &sched).await;
+        let section = runtime_snapshot_section(&sched, "granted".to_string(), Some(true)).await;
 
         // A fresh scheduler is running, not suppressed, no active break.
         assert!(section.contains("Pause: running"));
         assert!(section.contains("Auto-suppressed by: nothing"));
         assert!(section.contains("Active break: none"));
         assert!(section.contains("Idle detection:"));
-        assert!(section.contains("Notification permission:"));
-        assert!(section.contains("Autostart:"));
+        assert!(section.contains("Notification permission: `granted`"));
+        assert!(section.contains("Autostart: setting `false`, OS `registered`"));
         // Micro is enabled by default, so its break clock should render.
         assert!(section.contains("- Micro:"));
     }

--- a/src-tauri/src/diagnostics.rs
+++ b/src-tauri/src/diagnostics.rs
@@ -2,6 +2,7 @@ use std::fs::File;
 use std::io::{Read, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
 
+use chrono::Local;
 use sysinfo::System;
 use tauri::{AppHandle, Manager};
 
@@ -49,6 +50,416 @@ fn os_description() -> String {
     format!("{long} (kernel {kernel}, {arch})")
 }
 
+/// Host windowing-environment facts, gathered from process env vars.
+/// Only meaningful on Linux (X11 vs Wayland, compositor); on macOS /
+/// Windows the windowing system is implied by the OS. Split from the
+/// gathering so the markdown rendering is unit-testable.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct EnvFacts {
+    /// `XDG_SESSION_TYPE` — usually `x11` or `wayland`.
+    pub session_type: Option<String>,
+    /// Whether `WAYLAND_DISPLAY` is set.
+    pub wayland_display: bool,
+    /// `DISPLAY` (X11 socket, e.g. `:0`).
+    pub x11_display: Option<String>,
+    /// `XDG_CURRENT_DESKTOP` — the desktop environment.
+    pub desktop: Option<String>,
+    /// `DESKTOP_SESSION` — the session name.
+    pub desktop_session: Option<String>,
+}
+
+impl EnvFacts {
+    fn from_env() -> Self {
+        let var = |k: &str| std::env::var(k).ok().filter(|v| !v.is_empty());
+        Self {
+            session_type: var("XDG_SESSION_TYPE"),
+            wayland_display: var("WAYLAND_DISPLAY").is_some(),
+            x11_display: var("DISPLAY"),
+            desktop: var("XDG_CURRENT_DESKTOP"),
+            desktop_session: var("DESKTOP_SESSION"),
+        }
+    }
+}
+
+/// Compact one-line environment summary logged once at startup, so the
+/// log file (and therefore every diagnostics report's log tail) always
+/// opens with the context a bug report needs — even if the user never
+/// generates a report. Pure so the formatting is unit-testable.
+fn startup_banner(
+    version: &str,
+    os: &str,
+    display: &str,
+    webview: &str,
+    monitor_count: usize,
+    idle: &Result<u64, String>,
+) -> String {
+    let idle = match idle {
+        Ok(secs) => format!("{secs}s"),
+        Err(e) => format!("unavailable ({e})"),
+    };
+    format!(
+        "startup: Entracte {version} | os={os} | display={display} | webview={webview} \
+         | monitors={monitor_count} | idle={idle}"
+    )
+}
+
+/// Gather the startup facts and emit the banner at info level. Called
+/// once from the Tauri `setup` hook.
+pub fn log_startup_banner(app: &AppHandle) {
+    let os = std::env::consts::OS;
+    let display = display_server(os, &EnvFacts::from_env());
+    let webview = tauri::webview_version().unwrap_or_else(|_| "unknown".to_string());
+    let monitor_count = gather_monitors(app).len();
+    let idle = match user_idle::UserIdle::get_time() {
+        Ok(i) => Ok(i.as_seconds()),
+        Err(e) => Err(format!("{e}")),
+    };
+    log::info!(
+        "{}",
+        startup_banner(
+            &app.package_info().version.to_string(),
+            os,
+            &display,
+            &webview,
+            monitor_count,
+            &idle,
+        )
+    );
+}
+
+/// Best-effort name for the display server backing the app, used to
+/// triage overlay/transparency issues that only reproduce on one stack.
+fn display_server(os: &str, env: &EnvFacts) -> String {
+    match os {
+        "macos" => "Cocoa (native)".to_string(),
+        "windows" => "Win32 / WebView2 (native)".to_string(),
+        _ => {
+            let session = env.session_type.as_deref().map(str::to_ascii_lowercase);
+            if session.as_deref() == Some("wayland") || env.wayland_display {
+                "Wayland".to_string()
+            } else if session.as_deref() == Some("x11") || env.x11_display.is_some() {
+                "X11".to_string()
+            } else {
+                "unknown".to_string()
+            }
+        }
+    }
+}
+
+/// One monitor's geometry for the report. Mirrors `tauri::Monitor`
+/// fields we care about, kept plain so `format_monitors` is testable.
+#[derive(Debug, Clone, PartialEq)]
+pub struct MonitorFacts {
+    pub name: Option<String>,
+    pub width: u32,
+    pub height: u32,
+    pub x: i32,
+    pub y: i32,
+    pub scale: f64,
+    pub primary: bool,
+}
+
+fn format_monitors(monitors: &[MonitorFacts]) -> String {
+    if monitors.is_empty() {
+        return "_(no monitors reported \u{2014} headless or windowing system unavailable)_"
+            .to_string();
+    }
+    monitors
+        .iter()
+        .map(|m| {
+            let name = m.name.as_deref().unwrap_or("unnamed");
+            let primary = if m.primary { " (primary)" } else { "" };
+            format!(
+                "- `{name}`{primary}: {w}\u{00d7}{h} @ ({x}, {y}), scale {scale:.2}",
+                w = m.width,
+                h = m.height,
+                x = m.x,
+                y = m.y,
+                scale = m.scale,
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Render the whole environment block from already-gathered facts.
+/// Pure: the caller does the env / windowing-system queries and passes
+/// the results in, so this formatting is fully unit-testable.
+/// Per-kind interval clock: how long since this kind last fired and the
+/// configured interval, so the report can show "due in / overdue by".
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BreakClock {
+    pub since_secs: u64,
+    pub interval_secs: u64,
+}
+
+/// Seconds until the next break of a kind: positive = still counting
+/// down, zero or negative = overdue (the scheduler will fire as soon as
+/// no guard is suppressing it). `i64` so overdue is representable.
+fn next_due_secs(clock: BreakClock) -> i64 {
+    clock.interval_secs as i64 - clock.since_secs as i64
+}
+
+fn format_break_clock(label: &str, clock: Option<BreakClock>) -> String {
+    match clock {
+        None => format!("- {label}: disabled"),
+        Some(c) => {
+            let due = next_due_secs(c);
+            let when = if due > 0 {
+                format!("due in {due}s")
+            } else {
+                format!("overdue by {}s", -due)
+            };
+            format!(
+                "- {label}: last fired {since}s ago, interval {interval}s ({when})",
+                since = c.since_secs,
+                interval = c.interval_secs,
+            )
+        }
+    }
+}
+
+/// Everything the report needs to answer "why isn't a break happening
+/// right now". Gathered live from the scheduler + windowing system, then
+/// rendered by `format_runtime_snapshot` (kept pure for testing).
+#[derive(Debug, Clone, PartialEq)]
+pub struct RuntimeSnapshot {
+    pub paused: bool,
+    /// `Some` only for a timed pause; `None` while paused means indefinite.
+    pub pause_remaining_secs: Option<u64>,
+    /// Human label of the active auto-suppression, or `None` if breaks
+    /// are not being auto-suppressed this instant.
+    pub auto_suppress: Option<&'static str>,
+    pub dnd_active: bool,
+    pub camera_active: bool,
+    pub video_active: bool,
+    pub screen_locked: Option<bool>,
+    /// Live `UserIdle` probe: idle seconds, or the error string if the
+    /// platform query failed (the #67 "MIT-SCREEN-SAVER missing" case).
+    pub idle_probe: Result<u64, String>,
+    pub active_break: Option<&'static str>,
+    pub micro: Option<BreakClock>,
+    pub long: Option<BreakClock>,
+    pub micro_postpones: u32,
+    pub long_postpones: u32,
+    pub notification_permission: String,
+    pub autostart_setting: bool,
+    /// OS-level autostart registration, or `None` if it couldn't be read.
+    pub autostart_registered: Option<bool>,
+}
+
+fn format_runtime_snapshot(s: &RuntimeSnapshot) -> String {
+    let pause = if !s.paused {
+        "running".to_string()
+    } else {
+        match s.pause_remaining_secs {
+            Some(secs) => format!("paused ({secs}s remaining)"),
+            None => "paused (indefinitely)".to_string(),
+        }
+    };
+    let suppress = s.auto_suppress.unwrap_or("nothing");
+    let lock = match s.screen_locked {
+        Some(true) => "locked",
+        Some(false) => "unlocked",
+        None => "unknown",
+    };
+    let idle = match &s.idle_probe {
+        Ok(secs) => format!("{secs}s idle"),
+        Err(e) => format!("unavailable ({e})"),
+    };
+    let autostart_os = match s.autostart_registered {
+        Some(true) => "registered",
+        Some(false) => "not registered",
+        None => "unknown",
+    };
+    let active = s.active_break.unwrap_or("none");
+    format!(
+        "- Pause: {pause}\n\
+         - Auto-suppressed by: {suppress}\n\
+         - Sensors: camera `{cam}`, video `{vid}`, DND `{dnd}`, screen `{lock}`\n\
+         - Idle detection: {idle}\n\
+         - Active break: {active}\n\
+         {micro}\n\
+         {long}\n\
+         - Postpones this session: micro {micro_p}, long {long_p}\n\
+         - Notification permission: `{notif}`\n\
+         - Autostart: setting `{set}`, OS `{autostart_os}`",
+        cam = s.camera_active,
+        vid = s.video_active,
+        dnd = s.dnd_active,
+        micro = format_break_clock("Micro", s.micro),
+        long = format_break_clock("Long", s.long),
+        micro_p = s.micro_postpones,
+        long_p = s.long_postpones,
+        notif = s.notification_permission,
+        set = s.autostart_setting,
+    )
+}
+
+fn gather_monitors(app: &AppHandle) -> Vec<MonitorFacts> {
+    let primary = app.primary_monitor().ok().flatten();
+    let primary_key = primary
+        .as_ref()
+        .map(|m| (m.name().cloned(), m.position().x, m.position().y));
+    app.available_monitors()
+        .unwrap_or_default()
+        .iter()
+        .map(|m| {
+            let pos = m.position();
+            let size = m.size();
+            let key = (m.name().cloned(), pos.x, pos.y);
+            MonitorFacts {
+                name: m.name().cloned(),
+                width: size.width,
+                height: size.height,
+                x: pos.x,
+                y: pos.y,
+                scale: m.scale_factor(),
+                primary: primary_key.as_ref() == Some(&key),
+            }
+        })
+        .collect()
+}
+
+async fn runtime_snapshot_section(app: &AppHandle, scheduler: &Scheduler) -> String {
+    use std::sync::atomic::Ordering;
+    use std::time::Instant;
+
+    let s = scheduler.settings.lock().await.clone();
+
+    let (paused, pause_remaining_secs) = {
+        let state = scheduler.pause_state.lock().await;
+        match &*state {
+            crate::scheduler::PauseState::Running => (false, None),
+            crate::scheduler::PauseState::PausedUntil(None) => (true, None),
+            crate::scheduler::PauseState::PausedUntil(Some(deadline)) => (
+                true,
+                Some(deadline.saturating_duration_since(Instant::now()).as_secs()),
+            ),
+        }
+    };
+
+    let auto_suppress = crate::scheduler::SuppressReason::from_u8(
+        scheduler.auto_suppress_reason.load(Ordering::Relaxed),
+    )
+    .map(|r| r.human());
+
+    let idle_probe = match user_idle::UserIdle::get_time() {
+        Ok(i) => Ok(i.as_seconds()),
+        Err(e) => Err(format!("{e}")),
+    };
+
+    let (active_break, micro, long, micro_postpones, long_postpones) = {
+        let t = scheduler.timers.lock().await;
+        let now = Instant::now();
+        let micro = s.micro_enabled.then_some(BreakClock {
+            since_secs: now.saturating_duration_since(t.last_micro).as_secs(),
+            interval_secs: s.micro_interval_secs,
+        });
+        let long = s.long_enabled.then_some(BreakClock {
+            since_secs: now.saturating_duration_since(t.last_long).as_secs(),
+            interval_secs: s.long_interval_secs,
+        });
+        (
+            t.active_break.map(break_kind_label),
+            micro,
+            long,
+            t.micro_postpone_count,
+            t.long_postpone_count,
+        )
+    };
+
+    let notification_permission = {
+        use tauri_plugin_notification::NotificationExt;
+        app.notification()
+            .permission_state()
+            .map(|p| p.to_string())
+            .unwrap_or_else(|e| format!("unknown ({e})"))
+    };
+
+    let autostart_registered = {
+        use tauri_plugin_autostart::ManagerExt;
+        app.autolaunch().is_enabled().ok()
+    };
+
+    let snapshot = RuntimeSnapshot {
+        paused,
+        pause_remaining_secs,
+        auto_suppress,
+        dnd_active: crate::dnd::is_active(),
+        camera_active: scheduler.camera_active.load(Ordering::Relaxed),
+        video_active: scheduler.video_active.load(Ordering::Relaxed),
+        screen_locked: crate::scheduler::session_lock::screen_locked(),
+        idle_probe,
+        active_break,
+        micro,
+        long,
+        micro_postpones,
+        long_postpones,
+        notification_permission,
+        autostart_setting: s.autostart_enabled,
+        autostart_registered,
+    };
+    format_runtime_snapshot(&snapshot)
+}
+
+fn break_kind_label(kind: crate::scheduler::BreakKind) -> &'static str {
+    match kind {
+        crate::scheduler::BreakKind::Micro => "micro",
+        crate::scheduler::BreakKind::Long => "long",
+        crate::scheduler::BreakKind::Sleep => "bedtime",
+    }
+}
+
+fn environment_section(app: &AppHandle) -> String {
+    let os = std::env::consts::OS;
+    let env = EnvFacts::from_env();
+    let webview = tauri::webview_version().unwrap_or_else(|_| "unknown".to_string());
+    let monitors = gather_monitors(app);
+    let now = Local::now();
+    let build_profile = if cfg!(debug_assertions) {
+        "debug"
+    } else {
+        "release"
+    };
+    format_environment(
+        os,
+        &env,
+        &webview,
+        &monitors,
+        &now.format("%Y-%m-%d %H:%M:%S").to_string(),
+        &now.format("%:z").to_string(),
+        build_profile,
+    )
+}
+
+fn format_environment(
+    os: &str,
+    env: &EnvFacts,
+    webview: &str,
+    monitors: &[MonitorFacts],
+    local_now: &str,
+    utc_offset: &str,
+    build_profile: &str,
+) -> String {
+    let mut lines = vec![
+        format!("- Display server: `{}`", display_server(os, env)),
+    ];
+    if os != "macos" && os != "windows" {
+        let desktop = env.desktop.as_deref().unwrap_or("?");
+        let session = env.desktop_session.as_deref().unwrap_or("?");
+        lines.push(format!("- Desktop: `{desktop}` (session `{session}`)"));
+    }
+    lines.push(format!("- Webview: `{webview}`"));
+    lines.push(format!("- Build: `{build_profile}`"));
+    lines.push(format!("- Local time: `{local_now}` (UTC offset `{utc_offset}`)"));
+    format!(
+        "{lines}\n\n**Monitors**\n\n{monitors}",
+        lines = lines.join("\n"),
+        monitors = format_monitors(monitors),
+    )
+}
+
 #[tauri::command]
 pub async fn build_diagnostics_report(
     app: AppHandle,
@@ -56,6 +467,8 @@ pub async fn build_diagnostics_report(
 ) -> Result<String, String> {
     let version = app.package_info().version.to_string();
     let os = os_description();
+    let environment = environment_section(&app);
+    let runtime = runtime_snapshot_section(&app, scheduler.inner()).await;
     let settings = scheduler.settings.lock().await.clone();
     let stats = scheduler.stats.lock().await.clone();
     let settings_value = serde_json::to_value(&settings).unwrap_or(serde_json::Value::Null);
@@ -74,6 +487,8 @@ pub async fn build_diagnostics_report(
         "## Entracte diagnostics\n\n\
         - Version: `{version}`\n\
         - OS: `{os}`\n\n\
+        ### Environment\n\n{environment}\n\n\
+        ### Runtime\n\n{runtime}\n\n\
         ### Settings\n\n_Hook commands are redacted from this report; share them manually if needed._\n\n```json\n{settings_json}\n```\n\n\
         ### Stats\n\n```json\n{stats_json}\n```\n\n\
         ### Recent log (last {kb} KB)\n\n{log_section}\n",
@@ -199,6 +614,243 @@ mod tests {
         let value = serde_json::json!("not-an-object");
         let redacted = redact_sensitive(value.clone());
         assert_eq!(redacted, value);
+    }
+
+    #[test]
+    fn startup_banner_is_a_compact_one_liner_with_idle_state() {
+        let ok = startup_banner("0.0.1", "macos", "Cocoa (native)", "WKWebView", 2, &Ok(3));
+        assert!(ok.starts_with("startup: Entracte 0.0.1"));
+        assert!(ok.contains("os=macos"));
+        assert!(ok.contains("display=Cocoa (native)"));
+        assert!(ok.contains("monitors=2"));
+        assert!(ok.contains("idle=3s"));
+        assert!(!ok.contains('\n'), "banner must be a single line");
+
+        let bad = startup_banner(
+            "0.0.1",
+            "linux",
+            "X11",
+            "WebKitGTK",
+            1,
+            &Err("MIT-SCREEN-SAVER missing".into()),
+        );
+        assert!(bad.contains("idle=unavailable (MIT-SCREEN-SAVER missing)"));
+    }
+
+    #[test]
+    fn display_server_is_native_on_desktop_oses() {
+        assert_eq!(display_server("macos", &EnvFacts::default()), "Cocoa (native)");
+        assert_eq!(
+            display_server("windows", &EnvFacts::default()),
+            "Win32 / WebView2 (native)"
+        );
+    }
+
+    #[test]
+    fn display_server_infers_wayland_then_x11_then_unknown() {
+        let wl = EnvFacts {
+            session_type: Some("wayland".into()),
+            ..Default::default()
+        };
+        assert_eq!(display_server("linux", &wl), "Wayland");
+
+        // Wayland socket present even though session_type is unset.
+        let wl2 = EnvFacts {
+            wayland_display: true,
+            ..Default::default()
+        };
+        assert_eq!(display_server("linux", &wl2), "Wayland");
+
+        // The #67 shape: only DISPLAY set → X11.
+        let x = EnvFacts {
+            x11_display: Some(":0".into()),
+            ..Default::default()
+        };
+        assert_eq!(display_server("linux", &x), "X11");
+
+        assert_eq!(display_server("linux", &EnvFacts::default()), "unknown");
+    }
+
+    #[test]
+    fn format_monitors_lists_each_with_primary_marker() {
+        let out = format_monitors(&[
+            MonitorFacts {
+                name: Some("eDP-1".into()),
+                width: 2560,
+                height: 1440,
+                x: 0,
+                y: 0,
+                scale: 2.0,
+                primary: true,
+            },
+            MonitorFacts {
+                name: None,
+                width: 1920,
+                height: 1080,
+                x: 2560,
+                y: 0,
+                scale: 1.0,
+                primary: false,
+            },
+        ]);
+        assert!(out.contains("`eDP-1` (primary): 2560\u{00d7}1440 @ (0, 0), scale 2.00"));
+        assert!(out.contains("`unnamed`: 1920\u{00d7}1080 @ (2560, 0), scale 1.00"));
+        assert!(!out.contains("unnamed (primary)"));
+    }
+
+    #[test]
+    fn format_monitors_notes_when_none_reported() {
+        let out = format_monitors(&[]);
+        assert!(out.contains("no monitors reported"));
+    }
+
+    #[test]
+    fn format_environment_includes_desktop_only_on_linux() {
+        let env = EnvFacts {
+            session_type: Some("x11".into()),
+            x11_display: Some(":0".into()),
+            desktop: Some("GNOME".into()),
+            desktop_session: Some("ubuntu".into()),
+            ..Default::default()
+        };
+        let linux = format_environment(
+            "linux",
+            &env,
+            "WebKitGTK 2.44",
+            &[],
+            "2026-05-29 10:00:00",
+            "+02:00",
+            "release",
+        );
+        assert!(linux.contains("Display server: `X11`"));
+        assert!(linux.contains("Desktop: `GNOME` (session `ubuntu`)"));
+        assert!(linux.contains("Webview: `WebKitGTK 2.44`"));
+        assert!(linux.contains("UTC offset `+02:00`"));
+
+        let mac = format_environment(
+            "macos",
+            &EnvFacts::default(),
+            "WKWebView",
+            &[],
+            "2026-05-29 10:00:00",
+            "-07:00",
+            "debug",
+        );
+        assert!(mac.contains("Cocoa (native)"));
+        assert!(!mac.contains("Desktop: "));
+        assert!(mac.contains("Build: `debug`"));
+    }
+
+    #[test]
+    fn next_due_secs_positive_when_counting_down_negative_when_overdue() {
+        assert_eq!(
+            next_due_secs(BreakClock {
+                since_secs: 100,
+                interval_secs: 1200
+            }),
+            1100
+        );
+        assert_eq!(
+            next_due_secs(BreakClock {
+                since_secs: 1300,
+                interval_secs: 1200
+            }),
+            -100
+        );
+    }
+
+    #[test]
+    fn format_break_clock_reports_disabled_due_and_overdue() {
+        assert_eq!(format_break_clock("Micro", None), "- Micro: disabled");
+        let due = format_break_clock(
+            "Micro",
+            Some(BreakClock {
+                since_secs: 100,
+                interval_secs: 1200,
+            }),
+        );
+        assert!(due.contains("last fired 100s ago"));
+        assert!(due.contains("due in 1100s"));
+        let overdue = format_break_clock(
+            "Long",
+            Some(BreakClock {
+                since_secs: 1300,
+                interval_secs: 1200,
+            }),
+        );
+        assert!(overdue.contains("overdue by 100s"));
+    }
+
+    fn sample_snapshot() -> RuntimeSnapshot {
+        RuntimeSnapshot {
+            paused: false,
+            pause_remaining_secs: None,
+            auto_suppress: None,
+            dnd_active: false,
+            camera_active: false,
+            video_active: false,
+            screen_locked: Some(false),
+            idle_probe: Ok(5),
+            active_break: None,
+            micro: Some(BreakClock {
+                since_secs: 10,
+                interval_secs: 1200,
+            }),
+            long: None,
+            micro_postpones: 0,
+            long_postpones: 0,
+            notification_permission: "granted".into(),
+            autostart_setting: true,
+            autostart_registered: Some(true),
+        }
+    }
+
+    #[test]
+    fn format_runtime_snapshot_reports_a_healthy_running_state() {
+        let out = format_runtime_snapshot(&sample_snapshot());
+        assert!(out.contains("Pause: running"));
+        assert!(out.contains("Auto-suppressed by: nothing"));
+        assert!(out.contains("screen `unlocked`"));
+        assert!(out.contains("Idle detection: 5s idle"));
+        assert!(out.contains("Active break: none"));
+        assert!(out.contains("- Long: disabled"));
+        assert!(out.contains("Notification permission: `granted`"));
+        assert!(out.contains("Autostart: setting `true`, OS `registered`"));
+    }
+
+    #[test]
+    fn format_runtime_snapshot_surfaces_the_blocking_conditions() {
+        let snap = RuntimeSnapshot {
+            paused: true,
+            pause_remaining_secs: Some(600),
+            auto_suppress: Some(crate::scheduler::SuppressReason::Dnd.human()),
+            dnd_active: true,
+            // The #67 shape: idle query failed, breaks still expected to fire.
+            idle_probe: Err("MIT-SCREEN-SAVER missing".into()),
+            active_break: Some("micro"),
+            ..sample_snapshot()
+        };
+        let out = format_runtime_snapshot(&snap);
+        assert!(out.contains("Pause: paused (600s remaining)"));
+        assert!(out.contains("Auto-suppressed by: Do Not Disturb"));
+        assert!(out.contains("DND `true`"));
+        assert!(out.contains("Idle detection: unavailable (MIT-SCREEN-SAVER missing)"));
+        assert!(out.contains("Active break: micro"));
+    }
+
+    #[test]
+    fn format_runtime_snapshot_marks_indefinite_pause_and_unknown_states() {
+        let snap = RuntimeSnapshot {
+            paused: true,
+            pause_remaining_secs: None,
+            screen_locked: None,
+            autostart_registered: None,
+            ..sample_snapshot()
+        };
+        let out = format_runtime_snapshot(&snap);
+        assert!(out.contains("Pause: paused (indefinitely)"));
+        assert!(out.contains("screen `unknown`"));
+        assert!(out.contains("OS `unknown`"));
     }
 
     #[test]

--- a/src-tauri/src/diagnostics.rs
+++ b/src-tauri/src/diagnostics.rs
@@ -318,16 +318,24 @@ fn gather_monitors<R: Runtime>(app: &AppHandle<R>) -> Vec<MonitorFacts> {
         .collect()
 }
 
-/// Build the Runtime section from the live scheduler state plus the two
-/// values the caller fetches from plugins (`build_diagnostics_report`
-/// passes them in). Kept free of `AppHandle` so it's testable with a bare
-/// scheduler — `MockRuntime` + the notification/autostart plugins abort on
-/// headless Linux, which is the only platform CI runs tests on.
-async fn runtime_snapshot_section(
-    scheduler: &Scheduler,
-    notification_permission: String,
-    autostart_registered: Option<bool>,
-) -> String {
+/// Volatile readings gathered by the command from the OS / plugins:
+/// the idle probe, DND state, screen-lock, notification permission, and
+/// OS-level autostart. Bundled and passed into `runtime_snapshot_section`
+/// so that function touches only in-memory scheduler state — these probes
+/// go through X11 / dbus / plugin FFI that segfaults on the headless CI
+/// runner, so they must stay out of the testable path.
+pub struct LiveReadings {
+    pub idle_probe: Result<u64, String>,
+    pub dnd_active: bool,
+    pub screen_locked: Option<bool>,
+    pub notification_permission: String,
+    pub autostart_registered: Option<bool>,
+}
+
+/// Build the Runtime section from in-memory scheduler state plus the
+/// already-gathered `LiveReadings`. No OS / plugin / `AppHandle` access,
+/// so it's testable with a bare scheduler.
+async fn runtime_snapshot_section(scheduler: &Scheduler, live: LiveReadings) -> String {
     use std::sync::atomic::Ordering;
     use std::time::Instant;
 
@@ -349,11 +357,6 @@ async fn runtime_snapshot_section(
         scheduler.auto_suppress_reason.load(Ordering::Relaxed),
     )
     .map(|r| r.human());
-
-    let idle_probe = match user_idle::UserIdle::get_time() {
-        Ok(i) => Ok(i.as_seconds()),
-        Err(e) => Err(format!("{e}")),
-    };
 
     let (active_break, micro, long, micro_postpones, long_postpones) = {
         let t = scheduler.timers.lock().await;
@@ -379,19 +382,19 @@ async fn runtime_snapshot_section(
         paused,
         pause_remaining_secs,
         auto_suppress,
-        dnd_active: crate::dnd::is_active(),
+        dnd_active: live.dnd_active,
         camera_active: scheduler.camera_active.load(Ordering::Relaxed),
         video_active: scheduler.video_active.load(Ordering::Relaxed),
-        screen_locked: crate::scheduler::session_lock::screen_locked(),
-        idle_probe,
+        screen_locked: live.screen_locked,
+        idle_probe: live.idle_probe,
         active_break,
         micro,
         long,
         micro_postpones,
         long_postpones,
-        notification_permission,
+        notification_permission: live.notification_permission,
         autostart_setting: s.autostart_enabled,
-        autostart_registered,
+        autostart_registered: live.autostart_registered,
     };
     format_runtime_snapshot(&snapshot)
 }
@@ -475,12 +478,17 @@ pub async fn build_diagnostics_report<R: Runtime>(
         use tauri_plugin_autostart::ManagerExt;
         app.autolaunch().is_enabled().ok()
     };
-    let runtime = runtime_snapshot_section(
-        scheduler.inner(),
+    let live = LiveReadings {
+        idle_probe: match user_idle::UserIdle::get_time() {
+            Ok(i) => Ok(i.as_seconds()),
+            Err(e) => Err(format!("{e}")),
+        },
+        dnd_active: crate::dnd::is_active(),
+        screen_locked: crate::scheduler::session_lock::screen_locked(),
         notification_permission,
         autostart_registered,
-    )
-    .await;
+    };
+    let runtime = runtime_snapshot_section(scheduler.inner(), live).await;
     let settings = scheduler.settings.lock().await.clone();
     let stats = scheduler.stats.lock().await.clone();
     let settings_value = serde_json::to_value(&settings).unwrap_or(serde_json::Value::Null);
@@ -890,7 +898,14 @@ mod tests {
             dir.path(),
         );
 
-        let section = runtime_snapshot_section(&sched, "granted".to_string(), Some(true)).await;
+        let live = LiveReadings {
+            idle_probe: Ok(7),
+            dnd_active: false,
+            screen_locked: Some(false),
+            notification_permission: "granted".to_string(),
+            autostart_registered: Some(true),
+        };
+        let section = runtime_snapshot_section(&sched, live).await;
 
         // A fresh scheduler is running, not suppressed, no active break.
         assert!(section.contains("Pause: running"));

--- a/src-tauri/src/diagnostics.rs
+++ b/src-tauri/src/diagnostics.rs
@@ -442,9 +442,7 @@ fn format_environment(
     utc_offset: &str,
     build_profile: &str,
 ) -> String {
-    let mut lines = vec![
-        format!("- Display server: `{}`", display_server(os, env)),
-    ];
+    let mut lines = vec![format!("- Display server: `{}`", display_server(os, env))];
     if os != "macos" && os != "windows" {
         let desktop = env.desktop.as_deref().unwrap_or("?");
         let session = env.desktop_session.as_deref().unwrap_or("?");
@@ -452,7 +450,9 @@ fn format_environment(
     }
     lines.push(format!("- Webview: `{webview}`"));
     lines.push(format!("- Build: `{build_profile}`"));
-    lines.push(format!("- Local time: `{local_now}` (UTC offset `{utc_offset}`)"));
+    lines.push(format!(
+        "- Local time: `{local_now}` (UTC offset `{utc_offset}`)"
+    ));
     format!(
         "{lines}\n\n**Monitors**\n\n{monitors}",
         lines = lines.join("\n"),
@@ -639,7 +639,10 @@ mod tests {
 
     #[test]
     fn display_server_is_native_on_desktop_oses() {
-        assert_eq!(display_server("macos", &EnvFacts::default()), "Cocoa (native)");
+        assert_eq!(
+            display_server("macos", &EnvFacts::default()),
+            "Cocoa (native)"
+        );
         assert_eq!(
             display_server("windows", &EnvFacts::default()),
             "Win32 / WebView2 (native)"

--- a/src-tauri/src/diagnostics.rs
+++ b/src-tauri/src/diagnostics.rs
@@ -4,14 +4,14 @@ use std::path::{Path, PathBuf};
 
 use chrono::Local;
 use sysinfo::System;
-use tauri::{AppHandle, Manager};
+use tauri::{AppHandle, Manager, Runtime};
 
 use crate::scheduler::Scheduler;
 
 const LOG_FILE_NAME: &str = "entracte.log";
 const REPORT_LOG_BYTES: u64 = 50 * 1024;
 
-fn log_file_path(app: &AppHandle) -> PathBuf {
+fn log_file_path<R: Runtime>(app: &AppHandle<R>) -> PathBuf {
     app.path()
         .app_log_dir()
         .unwrap_or_else(|_| std::env::temp_dir())
@@ -105,7 +105,7 @@ fn startup_banner(
 
 /// Gather the startup facts and emit the banner at info level. Called
 /// once from the Tauri `setup` hook.
-pub fn log_startup_banner(app: &AppHandle) {
+pub fn log_startup_banner<R: Runtime>(app: &AppHandle<R>) {
     let os = std::env::consts::OS;
     let display = display_server(os, &EnvFacts::from_env());
     let webview = tauri::webview_version().unwrap_or_else(|_| "unknown".to_string());
@@ -296,7 +296,7 @@ fn format_runtime_snapshot(s: &RuntimeSnapshot) -> String {
     )
 }
 
-fn gather_monitors(app: &AppHandle) -> Vec<MonitorFacts> {
+fn gather_monitors<R: Runtime>(app: &AppHandle<R>) -> Vec<MonitorFacts> {
     let primary = app.primary_monitor().ok().flatten();
     let primary_key = primary
         .as_ref()
@@ -321,7 +321,7 @@ fn gather_monitors(app: &AppHandle) -> Vec<MonitorFacts> {
         .collect()
 }
 
-async fn runtime_snapshot_section(app: &AppHandle, scheduler: &Scheduler) -> String {
+async fn runtime_snapshot_section<R: Runtime>(app: &AppHandle<R>, scheduler: &Scheduler) -> String {
     use std::sync::atomic::Ordering;
     use std::time::Instant;
 
@@ -411,7 +411,7 @@ fn break_kind_label(kind: crate::scheduler::BreakKind) -> &'static str {
     }
 }
 
-fn environment_section(app: &AppHandle) -> String {
+fn environment_section<R: Runtime>(app: &AppHandle<R>) -> String {
     let os = std::env::consts::OS;
     let env = EnvFacts::from_env();
     let webview = tauri::webview_version().unwrap_or_else(|_| "unknown".to_string());
@@ -461,8 +461,8 @@ fn format_environment(
 }
 
 #[tauri::command]
-pub async fn build_diagnostics_report(
-    app: AppHandle,
+pub async fn build_diagnostics_report<R: Runtime>(
+    app: AppHandle<R>,
     scheduler: tauri::State<'_, Scheduler>,
 ) -> Result<String, String> {
     let version = app.package_info().version.to_string();
@@ -854,6 +854,51 @@ mod tests {
         assert!(out.contains("Pause: paused (indefinitely)"));
         assert!(out.contains("screen `unknown`"));
         assert!(out.contains("OS `unknown`"));
+    }
+
+    // Integration test for the Runtime-section gathering glue (pause /
+    // suppression / sensors / idle probe / timers / plugin queries) driven
+    // through a mock app. The Environment section is *not* exercised here:
+    // `MockRuntime` panics with "not implemented" on `available_monitors`,
+    // so the monitor-gathering glue is genuinely unreachable in tests and
+    // only its pure formatters (above) are covered.
+    #[cfg(not(target_os = "windows"))]
+    #[tokio::test]
+    async fn runtime_snapshot_section_reports_live_scheduler_state() {
+        use crate::scheduler::{Scheduler, Settings};
+        use tauri::test::{mock_builder, mock_context, noop_assets};
+        use tauri::Manager;
+
+        let dir = temp_dir();
+        let sched = Scheduler::for_test(
+            vec![crate::config::Profile {
+                name: crate::config::DEFAULT_PROFILE_NAME.to_string(),
+                settings: Settings::default(),
+            }],
+            crate::config::DEFAULT_PROFILE_NAME,
+            dir.path(),
+        );
+        let app = mock_builder()
+            .plugin(tauri_plugin_notification::init())
+            .plugin(tauri_plugin_autostart::init(
+                tauri_plugin_autostart::MacosLauncher::LaunchAgent,
+                None,
+            ))
+            .build(mock_context(noop_assets()))
+            .expect("mock app builds");
+        app.manage(sched.clone());
+
+        let section = runtime_snapshot_section(app.handle(), &sched).await;
+
+        // A fresh scheduler is running, not suppressed, no active break.
+        assert!(section.contains("Pause: running"));
+        assert!(section.contains("Auto-suppressed by: nothing"));
+        assert!(section.contains("Active break: none"));
+        assert!(section.contains("Idle detection:"));
+        assert!(section.contains("Notification permission:"));
+        assert!(section.contains("Autostart:"));
+        // Micro is enabled by default, so its break clock should render.
+        assert!(section.contains("- Micro:"));
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -169,6 +169,8 @@ pub fn run() {
             if let Err(e) = ipc::start_server(app.handle().clone(), data_dir.clone()) {
                 log::warn!("ipc: failed to start server: {e}");
             }
+
+            diagnostics::log_startup_banner(app.handle());
             Ok(())
         })
         .run(tauri::generate_context!())

--- a/src-tauri/src/scheduler/commands/breaks.rs
+++ b/src-tauri/src/scheduler/commands/breaks.rs
@@ -199,6 +199,7 @@ pub async fn end_break<R: Runtime>(
     reason: Option<String>,
 ) -> Result<(), String> {
     let reason = reason.unwrap_or_else(|| "completed".to_string());
+    log::info!("scheduler: break ended (reason={reason})");
     {
         let mut stats = scheduler.stats.lock().await;
         match reason.as_str() {

--- a/src-tauri/src/scheduler/mod.rs
+++ b/src-tauri/src/scheduler/mod.rs
@@ -4,7 +4,7 @@ mod overlay;
 mod pause;
 mod run_loop;
 mod screen_time;
-mod session_lock;
+pub(crate) mod session_lock;
 mod settings;
 mod timers;
 mod tray_countdown;

--- a/src-tauri/src/scheduler/overlay.rs
+++ b/src-tauri/src/scheduler/overlay.rs
@@ -100,7 +100,10 @@ fn ensure_overlay<R: Runtime>(app: &AppHandle<R>, idx: usize) -> Option<tauri::W
     .focused(false)
     .build()
     {
-        Ok(w) => Some(w),
+        Ok(w) => {
+            log::debug!("overlay: created break window '{label}'");
+            Some(w)
+        }
         // Don't swallow this silently: a failed build means the break is
         // completely invisible (no overlay, no preview, no test break) with
         // no other symptom. On some Linux setups the windowing system
@@ -227,6 +230,7 @@ pub fn fire_break<R: Runtime>(
 
     let monitors = select_overlay_monitors(app, placement);
     let count = monitors.len().max(1);
+    let mut shown = 0usize;
 
     for (idx, monitor) in monitors.iter().enumerate() {
         if let Some(window) = ensure_overlay(app, idx) {
@@ -247,7 +251,20 @@ pub fn fire_break<R: Runtime>(
             let _ = window.set_fullscreen(false);
             let _ = window.show();
             let _ = window.set_focus();
+            shown += 1;
         }
+    }
+
+    // Logged to the rotating log file (not just the stats event log) so a
+    // diagnostics report's log tail shows the break actually firing — and
+    // flags the Linux case where no overlay could be built (shown == 0).
+    if shown == 0 {
+        log::error!(
+            "scheduler: break kind={kind:?} fired but NO overlay window could be shown \
+             ({count} monitor(s) targeted) — the break is invisible"
+        );
+    } else {
+        log::info!("scheduler: break kind={kind:?} shown on {shown}/{count} monitor(s)");
     }
 
     // Close (not just hide) any overlays for monitors that disconnected since

--- a/src-tauri/src/scheduler/run_loop.rs
+++ b/src-tauri/src/scheduler/run_loop.rs
@@ -73,6 +73,13 @@ pub(super) async fn run_loop(app: AppHandle, sched: Scheduler) {
         let now_wall = SystemTime::now();
         let resumed_from_suspend =
             resumed_after_gap(last_tick_wall, now_wall, SUSPEND_GAP_THRESHOLD);
+        if resumed_from_suspend {
+            let gap = now_wall
+                .duration_since(last_tick_wall)
+                .map(|d| d.as_secs())
+                .unwrap_or(0);
+            log::info!("scheduler: resumed from suspend after {gap}s gap");
+        }
         last_tick_wall = now_wall;
 
         // Early-out while an import is mid-flight. This is an


### PR DESCRIPTION
Follow-on to the #67 logging change: makes the diagnostics report (and the log file behind it) actually capture what we need to triage issues. #67 was the prompt — the display server, webview, monitors, and the missing screensaver extension were all invisible in the report.

> **Stacked on #70** (`fix/bedtime-morning-and-end-sound`) because the suspend/resume log line builds on the `resumed_from_suspend` detection added there. Base retargets to `main` once #70 merges.

## What's added

**Report — `### Environment` section**
Display server (X11 / Wayland / native), desktop + compositor, webview version, monitor topology (geometry + scale + primary), local time & UTC offset, debug/release.

**Report — `### Runtime` section** ("why isn't a break firing right now")
Pause state, active auto-suppression reason, live camera/video/DND/screen-lock sensors, a `UserIdle` capability probe (surfaces the #67 failure), per-kind break clocks with next-due/overdue, postpone counters, notification permission, and autostart (setting vs OS-registered).

**Startup banner**
One info line at launch — version, OS, display server, webview, monitor count, idle capability — so every log tail opens with full context even if no report is generated.

**Event logging to the rotating log file** (the report only tails this, not `events.jsonl`)
Break fired (+ how many monitors), break ended (+ reason), overlay window created, resume-from-suspend gaps, and an **error when a break fires but no overlay can be shown** (the #67 invisible-break case).

## Design / tests
All formatting is split into pure functions (`format_environment`, `format_monitors`, `format_runtime_snapshot`, `format_break_clock`, `next_due_secs`, `startup_banner`, `display_server`) with unit tests; the live OS/windowing/plugin queries are thin gathering glue. **Rust 612 passing**, clippy clean.

## Notes
- New sections carry only system facts (monitor names, desktop session, permissions) — no secrets — so they don't need the log/settings redaction pass.
- Per-tick guard suppression is intentionally **not** logged (spam); the current suppression reason is in the Runtime snapshot instead.
- Coverage: the gathering glue and the new run_loop/overlay/command log lines sit in surfaces unit tests can't reach (the extractable logic is in the tested pure fns) — same admin-bypass category as the rest of the loop body.

## Follow-up
Persistence-failure logging (pause/screen-time writes that are currently swallowed) would be a small next step if useful.