### PR TITLE
chore(release): prep v0.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ Versions on the `0.0.X` line are public beta releases; `0.1.X` and onwards will 
 
 ## [Unreleased]
 
+## [0.0.2] — 2026-05-29
+
+Bug-fix and diagnostics beta, focused on how the breaks _feel_ and on making issues easier to triage.
+
+### Fixed
+
+- **Bedtime no longer fires when you open the laptop in the morning.** Inside an overnight bedtime window (e.g. 22:00–09:00), waking from suspend no longer triggers a stale catch-up reminder; a genuine first entry into the window still fires. ([#61](https://github.com/drmowinckels/entracte/issues/61))
+- **The end-of-break chime no longer plays at the _start_ of the next break.** A chime that didn't finish cleanly was left to resume after the overlay hid; it's now torn down, and any lingering sound is flushed when a new break opens. ([#62](https://github.com/drmowinckels/entracte/issues/62))
+- **Breaks end on time.** The overlay used to linger on "Done" for the full length of the chime, adding several seconds to every break; it now dismisses after a short fixed beat while the chime rings as it closes.
+
+### Diagnostics
+
+- The diagnostics report gained an **Environment** section (display server, desktop/compositor, webview version, monitors, local time and UTC offset, build profile) and a **Runtime** section (pause and auto-suppression state, camera/video/DND/screen-lock sensors, idle-detection probe, per-break timers with next-due, postpone counters, notification permission, autostart).
+- A startup banner and break-lifecycle / suspend-resume / overlay-outcome lines are now written to the log file, so a report's log tail tells the story of what happened. A break that fires but can't show an overlay (seen on some Linux setups) is now logged as an explicit error instead of silently doing nothing. ([#67](https://github.com/drmowinckels/entracte/issues/67))
+
 ## [0.0.1] — 2026-05-25
 
 First public beta of Entracte. macOS, Windows, and Linux installers are produced from the same Rust + Tauri codebase. Functional and usable day-to-day on macOS; Windows and Linux build and run, with a few platform-detection gaps called out below.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "entracte-desktop",
   "private": true,
-  "version": "0.0.1",
+  "version": "0.0.2",
   "type": "module",
   "engines": {
     "node": ">=20"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1154,7 +1154,7 @@ checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
 
 [[package]]
 name = "entracte"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "entracte"
-version = "0.0.1"
+version = "0.0.2"
 description = "Cross-platform break reminder"
 authors = ["Athanasia Mowinckel"]
 license = "Apache-2.0"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Entracte",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "identifier": "io.drmowinckels.entracte",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Release prep for the **v0.0.2** beta. Bumps the version in `package.json`, `src-tauri/Cargo.toml`, `src-tauri/tauri.conf.json`, and `src-tauri/Cargo.lock`, and adds the CHANGELOG entry.

Bundles the two PRs already merged to main:
- #70 — bedtime-on-wake (#61), end-chime timing (#62), on-time break dismissal, overlay-build error logging (#67)
- #71 — richer diagnostics report (Environment + Runtime sections, startup banner, lifecycle logging)

Once merged, tagging `v0.0.2` triggers the release build for binaries.