### PR TITLE
fix(overlay): end-of-break dismiss could get cancelled, sticking on 'Done'

### DIFF
--- a/src/views/break-overlay/hooks/use-countdown.test.ts
+++ b/src/views/break-overlay/hooks/use-countdown.test.ts
@@ -110,6 +110,71 @@ describe("useCountdown", () => {
     expect(clearBreak).toHaveBeenCalled();
   });
 
+  it("still dismisses after a paused toggle during the Done beat (no stuck overlay)", () => {
+    // Regression: typing during the 800ms Done beat flips `paused`, which
+    // re-runs the countdown effect. The dismiss timer must survive that
+    // re-run — otherwise the overlay sticks on "Done" with no way out.
+    const invoke = vi.fn(async () => null);
+    const clearBreak = vi.fn();
+    const { rerender } = renderHook(
+      ({ paused }: { paused: boolean }) =>
+        useCountdown(
+          makeBreak(),
+          0,
+          paused,
+          DEFAULT_OVERLAY_SETTINGS,
+          vi.fn(),
+          vi.fn(),
+          clearBreak,
+          {
+            invoke: invoke as unknown as typeof import("@tauri-apps/api/core").invoke,
+            playSound: vi.fn(() => Promise.resolve()),
+          },
+        ),
+      { initialProps: { paused: false } },
+    );
+    act(() => {
+      rerender({ paused: true });
+    });
+    act(() => {
+      vi.advanceTimersByTime(DONE_LINGER_MS);
+    });
+    expect(invoke).toHaveBeenCalledWith("end_break", { reason: "completed" });
+    expect(invoke).toHaveBeenCalledTimes(1);
+    expect(clearBreak).toHaveBeenCalledTimes(1);
+  });
+
+  it("triggerFinish dismisses exactly once even if invoked twice", () => {
+    // Double-clicking "I'm back" must not fire end_break twice (which would
+    // double-count the taken break in stats).
+    const invoke = vi.fn(async () => null);
+    const clearBreak = vi.fn();
+    const { result } = renderHook(() =>
+      useCountdown(
+        makeBreak({ manual_finish: true }),
+        0,
+        false,
+        DEFAULT_OVERLAY_SETTINGS,
+        vi.fn(),
+        vi.fn(),
+        clearBreak,
+        {
+          invoke: invoke as unknown as typeof import("@tauri-apps/api/core").invoke,
+          playSound: vi.fn(() => Promise.resolve()),
+        },
+      ),
+    );
+    act(() => {
+      result.current.triggerFinish();
+      result.current.triggerFinish();
+    });
+    act(() => {
+      vi.advanceTimersByTime(DONE_LINGER_MS);
+    });
+    expect(invoke).toHaveBeenCalledTimes(1);
+    expect(clearBreak).toHaveBeenCalledTimes(1);
+  });
+
   it("does not auto-end on manual_finish breaks", () => {
     const invoke = vi.fn();
     const clearBreak = vi.fn();

--- a/src/views/break-overlay/hooks/use-countdown.ts
+++ b/src/views/break-overlay/hooks/use-countdown.ts
@@ -74,6 +74,12 @@ export function useCountdown(
   };
 
   const endingRef = useRef(false);
+  // The dismiss timer lives in a ref, not the countdown effect's cleanup:
+  // a `paused` toggle (typing during the Done beat) re-runs that effect,
+  // and tying the timer to its cleanup would cancel the pending dismiss
+  // without rescheduling — leaving the overlay stuck on "Done" with no
+  // escape. Scheduled at most once; cleared only on unmount.
+  const dismissTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const playEndChime = (): void => {
     const snap = endChimeRef.current;
@@ -86,8 +92,17 @@ export function useCountdown(
   };
 
   const dismiss = () => {
+    dismissTimerRef.current = null;
     invokeFn("end_break", { reason: "completed" });
     clearBreak();
+  };
+
+  // Schedule the single end-of-break dismissal. Idempotent: a second call
+  // (effect re-run, or a double-click on "I'm back") is a no-op, so we
+  // never fire `end_break` twice and double-count a taken break.
+  const scheduleDismiss = () => {
+    if (dismissTimerRef.current !== null) return;
+    dismissTimerRef.current = setTimeout(dismiss, DONE_LINGER_MS);
   };
 
   useEffect(() => {
@@ -104,8 +119,8 @@ export function useCountdown(
       // hold "Done" for a short fixed beat instead so the break ends
       // close to its set length regardless of the chime's length.
       playEndChime();
-      const t = setTimeout(dismiss, DONE_LINGER_MS);
-      return () => clearTimeout(t);
+      scheduleDismiss();
+      return;
     }
     if (paused) return;
     const t = setTimeout(() => setRemaining((r) => r - 1), 1000);
@@ -113,11 +128,18 @@ export function useCountdown(
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [active, remaining, paused]);
 
+  // Clear a pending dismiss on unmount so it can't fire on a dead component.
+  useEffect(() => {
+    return () => {
+      if (dismissTimerRef.current !== null) clearTimeout(dismissTimerRef.current);
+    };
+  }, []);
+
   const triggerFinish = () => {
     if (!active) return;
     setFinished(true);
     playEndChime();
-    setTimeout(dismiss, DONE_LINGER_MS);
+    scheduleDismiss();
   };
 
   return { triggerFinish };


### PR DESCRIPTION
Critical-code-review follow-up on the v0.0.2 changes (#70).

## Blocking bug
The on-time-dismissal change put the dismiss `setTimeout` in the countdown effect's cleanup. The effect's deps include `paused`, so if `pause_countdown_if_typing` is on and the user **types during the 800ms "Done" beat** (resuming work the instant a break ends), the effect re-runs → cleanup clears the dismiss timer → the `endingRef` guard returns without rescheduling. The break never dismisses, and for a non-`manual_finish` break the Skip/Postpone buttons are hidden once `finished`, so **the overlay is stuck on "Done" with no way out**.

## Fix
- Hold the dismiss timer in a ref, scheduled at most once, cleared only on unmount — so effect re-runs can't cancel it.
- `scheduleDismiss()` is idempotent, which also stops a double-click on "I'm back" from firing `end_break` twice (which double-counted the taken break in stats).

## Tests
Two regressions added to `use-countdown.test.ts`: dismissal survives a `paused` toggle during the Done beat, and `triggerFinish` dismisses exactly once when invoked twice. Full suite: 440 passing; typecheck clean.

Review feedback assisted by the [critical-code-reviewer skill](https://github.com/posit-dev/skills/blob/main/posit-dev/critical-code-reviewer/SKILL.md).