### PR TITLE
fix(release): resolve AppImage filename from artifact (Windows auto-update regression)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -227,14 +227,20 @@ jobs:
           #             version from `.app.tar.gz` artifact names (since
           #             the matrix produces two files that would otherwise
           #             collide). Linux + Windows keep the version.
-          #   Linux   : <productNameLower>_<version>_amd64.AppImage[.sig]
-          #             productName lowercases on Linux.
+          #   Linux   : <productName?>_<version>_amd64.AppImage[.sig]
+          #             The AppImage basename's casing has drifted across
+          #             tauri-bundler versions (`entracte_…` through v0.0.1,
+          #             `Entracte_…` from v0.0.2), so resolve it from the
+          #             actual artifact rather than hardcoding the casing.
           #   Windows : <productName>_<version>_x64_en-US.msi[.sig]
           #             the locale suffix is what tauri-bundler emits;
           #             update here if we ever switch the MSI locale.
           AARCH64_FILE="Entracte_aarch64.app.tar.gz"
           X64_FILE="Entracte_x64.app.tar.gz"
-          APPIMAGE_FILE="entracte_${VERSION}_amd64.AppImage"
+          APPIMAGE_FILE=""
+          for cand in release-assets/*_amd64.AppImage; do
+            [ -e "$cand" ] && APPIMAGE_FILE="$(basename "$cand")" && break
+          done
           MSI_FILE="Entracte_${VERSION}_x64_en-US.msi"
 
           for f in "${AARCH64_FILE}.sig" "${X64_FILE}.sig" "${APPIMAGE_FILE}.sig" "${MSI_FILE}.sig"; do


### PR DESCRIPTION
## Problem
The v0.0.2 release built all binaries, but **`publish-updater-manifest`** failed:

```
::error::missing entracte_0.0.2_amd64.AppImage.sig
```

It hardcodes the AppImage as `entracte_<version>_amd64.AppImage` (lowercase), but the actual artifact is **`Entracte_0.0.2_amd64.AppImage`** (capital) — verified against both the v0.0.1 and v0.0.2 release assets. The `.sig`-existence check failed, so `latest.json` fell back to tauri-action's auto-generated one, which **omits `windows-x86_64`** — silently breaking **Windows auto-update** for v0.0.2 (v0.0.1's manifest had all four platforms).

## Fix
Resolve the AppImage basename by globbing `release-assets/*_amd64.AppImage` instead of hardcoding the name, so the job uses whatever the bundler actually produced. The `.sig`-existence check still errors clearly if the artifact is genuinely missing.

## v0.0.2
Already remediated out-of-band: a complete `latest.json` (all 4 platforms, real build signatures) was composed and uploaded to the v0.0.2 draft. This PR fixes the workflow so the next release doesn't need that manual step.

Pre-existing release infra — not from the v0.0.2 code changes.