### PR TITLE
ci(audit): exclude freesound.org from lychee (fixes advisory failing on every PR)

### DIFF
--- a/.github/audit/lychee.toml
+++ b/.github/audit/lychee.toml
@@ -16,6 +16,11 @@ exclude = [
   # DOI is a canonical identifier; checking it adds no signal.
   '^https?://(dx\.)?doi\.org/',
   '^https?://(.*\.)?(wiley|tandfonline|sagepub|mdpi|apa|jstor|springer|frontiersin|elsevier|nature|sciencedirect)\.com',
+  # freesound.org (sound-attribution credits in docs) returns 403 to the
+  # link checker via bot protection but resolves fine in a browser. Same
+  # rationale as the publishers above — exclude rather than accept 403
+  # globally, which would mask real auth failures elsewhere.
+  '^https?://(.*\.)?freesound\.org',
   # rustdoc / TypeDoc output: generated into the built site at /api/{rust,ts}/,
   # not present in source.
   '/api/(rust|ts)/',


### PR DESCRIPTION
freesound.org now returns **403 Forbidden** to the lychee link checker (bot protection) for the ~25 sound-attribution credit URLs in `docs/`, while the links resolve fine in a browser. This started failing the **advisory** job on every PR (surfaced on #75).

Same situation as the academic-publisher domains already excluded — so this adds `^https?://(.*\.)?freesound\.org` to the lychee `exclude` list rather than adding `403` to the global `accept` (which would mask real auth/permission failures elsewhere).