### PR TITLE
refactor(scheduler): parameter structs instead of too_many_arguments suppressions

### DIFF
--- a/src-tauri/src/scheduler/commands/breaks.rs
+++ b/src-tauri/src/scheduler/commands/breaks.rs
@@ -11,7 +11,7 @@ use super::super::settings::{
     delivery_for, effective_long_hints, effective_micro_hints, is_windowed_mode, Settings,
 };
 use super::super::timers::{clear_last_break, postpone_counter, reset_postpone_counter};
-use super::super::types::{BreakKind, LastBreakInfo, PostponeState};
+use super::super::types::{BreakEvent, BreakKind, LastBreakInfo, PostponeState};
 use super::super::Scheduler;
 
 /// Pause the scheduler. `duration_secs = None` pauses indefinitely;
@@ -152,20 +152,22 @@ pub async fn trigger_break_from_cli<R: Runtime>(
     deliver_break(
         app,
         &scheduler.current_break,
-        delivery,
-        kind,
-        duration_secs,
-        enforceable,
-        s.monitor_placement,
-        manual_finish,
-        s.postpone_enabled && !s.strict_mode,
-        hints,
-        s.hint_rotate_seconds,
-        if s.break_health_enabled {
-            intensity
-        } else {
-            0.0
+        BreakEvent {
+            kind,
+            duration_secs,
+            enforceable,
+            manual_finish,
+            postpone_available: s.postpone_enabled && !s.strict_mode,
+            hints,
+            hint_rotate_seconds: s.hint_rotate_seconds,
+            health_intensity: if s.break_health_enabled {
+                intensity
+            } else {
+                0.0
+            },
         },
+        delivery,
+        s.monitor_placement,
     );
     hooks::run_hooks(
         &s,
@@ -532,20 +534,22 @@ pub async fn resume_last_break_impl<R: Runtime>(
     fire_break(
         app,
         &scheduler.current_break,
-        kind,
-        duration_secs,
-        enforceable,
+        BreakEvent {
+            kind,
+            duration_secs,
+            enforceable,
+            manual_finish,
+            postpone_available: s.postpone_enabled && !s.strict_mode,
+            hints,
+            hint_rotate_seconds: s.hint_rotate_seconds,
+            health_intensity: if s.break_health_enabled {
+                intensity
+            } else {
+                0.0
+            },
+        },
         s.monitor_placement,
         is_windowed_mode(kind, &s),
-        manual_finish,
-        s.postpone_enabled && !s.strict_mode,
-        hints,
-        s.hint_rotate_seconds,
-        if s.break_health_enabled {
-            intensity
-        } else {
-            0.0
-        },
     );
     scheduler.logger.log(EventPayload::BreakResumed { kind });
     hooks::run_hooks(

--- a/src-tauri/src/scheduler/overlay.rs
+++ b/src-tauri/src/scheduler/overlay.rs
@@ -163,69 +163,44 @@ fn select_overlay_monitors<R: Runtime>(
 /// Surface a break through whichever channel the active settings ask
 /// for: a system notification or the overlay (full-screen or windowed).
 /// `Notification` delivery short-circuits the overlay path entirely.
-#[allow(clippy::too_many_arguments)]
+///
+/// `event` carries the break content (kind, duration, hints, …); the
+/// `delivery` and `placement` decide *how* and *where* it surfaces.
 pub fn deliver_break<R: Runtime>(
     app: &AppHandle<R>,
     current_break: &Arc<std::sync::Mutex<Option<BreakEvent>>>,
+    event: BreakEvent,
     delivery: BreakDelivery,
-    kind: BreakKind,
-    duration_secs: u64,
-    enforceable: bool,
     placement: MonitorPlacement,
-    manual_finish: bool,
-    postpone_available: bool,
-    hints: Vec<String>,
-    hint_rotate_seconds: u64,
-    health_intensity: f32,
 ) {
     match delivery {
-        BreakDelivery::Notification => notify_break_now(app, kind, duration_secs),
+        BreakDelivery::Notification => notify_break_now(app, event.kind, event.duration_secs),
         BreakDelivery::Overlay | BreakDelivery::Windowed => fire_break(
             app,
             current_break,
-            kind,
-            duration_secs,
-            enforceable,
+            event,
             placement,
             matches!(delivery, BreakDelivery::Windowed),
-            manual_finish,
-            postpone_available,
-            hints,
-            hint_rotate_seconds,
-            health_intensity,
         ),
     }
 }
 
-/// Build a `BreakEvent`, stash it in `current_break`, position an
-/// overlay window on each selected monitor, and emit `break:start` to
-/// the renderer. Used directly for sleep/resume-last paths; normal
-/// scheduled breaks go through `deliver_break` instead.
-#[allow(clippy::too_many_arguments)]
+/// Stash the break `event` in `current_break`, position an overlay window
+/// on each selected monitor, and emit `break:start` to the renderer. Used
+/// directly for sleep/resume-last paths; normal scheduled breaks go
+/// through `deliver_break` instead.
+///
+/// `postpone_available` is forced off for enforceable breaks here, so
+/// callers can pass the user's raw intent without re-deriving it.
 pub fn fire_break<R: Runtime>(
     app: &AppHandle<R>,
     current_break: &Arc<std::sync::Mutex<Option<BreakEvent>>>,
-    kind: BreakKind,
-    duration_secs: u64,
-    enforceable: bool,
+    event: BreakEvent,
     placement: MonitorPlacement,
     windowed: bool,
-    manual_finish: bool,
-    postpone_available: bool,
-    hints: Vec<String>,
-    hint_rotate_seconds: u64,
-    health_intensity: f32,
 ) {
-    let payload = BreakEvent {
-        kind,
-        duration_secs,
-        enforceable,
-        manual_finish,
-        postpone_available: postpone_available && !enforceable,
-        hints,
-        hint_rotate_seconds,
-        health_intensity,
-    };
+    let mut payload = event;
+    payload.postpone_available = payload.postpone_available && !payload.enforceable;
     *super::lock_current_break(current_break) = Some(payload.clone());
 
     let monitors = select_overlay_monitors(app, placement);
@@ -261,10 +236,14 @@ pub fn fire_break<R: Runtime>(
     if shown == 0 {
         log::error!(
             "scheduler: break kind={kind:?} fired but NO overlay window could be shown \
-             ({count} monitor(s) targeted) — the break is invisible"
+             ({count} monitor(s) targeted) — the break is invisible",
+            kind = payload.kind
         );
     } else {
-        log::info!("scheduler: break kind={kind:?} shown on {shown}/{count} monitor(s)");
+        log::info!(
+            "scheduler: break kind={kind:?} shown on {shown}/{count} monitor(s)",
+            kind = payload.kind
+        );
     }
 
     // Close (not just hide) any overlays for monitors that disconnected since

--- a/src-tauri/src/scheduler/run_loop.rs
+++ b/src-tauri/src/scheduler/run_loop.rs
@@ -19,8 +19,9 @@ use super::settings::{delivery_for, effective_long_hints, effective_micro_hints,
 use super::timers::{
     current_minutes, decide_bedtime, in_window, interval_break_due, local_today_string, parse_hhmm,
     prebreak_warn_due, should_defer_for_typing, should_fire_fixed_now, BedtimeAction,
+    BedtimeWindow, PrebreakGate,
 };
-use super::types::{BreakDelivery, BreakKind, SuppressReason};
+use super::types::{BreakDelivery, BreakEvent, BreakKind, SuppressReason};
 use super::Scheduler;
 
 /// Cheap atomic-load check that the run loop reads at the top of
@@ -188,11 +189,13 @@ pub(super) async fn run_loop(app: AppHandle, sched: Scheduler) {
         let bedtime_decision = {
             let t = sched.timers.lock().await;
             decide_bedtime(
-                s.bedtime_enabled,
+                BedtimeWindow {
+                    enabled: s.bedtime_enabled,
+                    start_min: s.bedtime_start_minutes,
+                    end_min: s.bedtime_end_minutes,
+                    interval_secs: s.bedtime_interval_secs,
+                },
                 now_min,
-                s.bedtime_start_minutes,
-                s.bedtime_end_minutes,
-                s.bedtime_interval_secs,
                 t.last_sleep,
                 now,
                 resumed_from_suspend,
@@ -204,20 +207,22 @@ pub(super) async fn run_loop(app: AppHandle, sched: Scheduler) {
                 super::overlay::fire_break(
                     &app,
                     &sched.current_break,
-                    BreakKind::Sleep,
-                    s.bedtime_duration_secs,
-                    true,
+                    BreakEvent {
+                        kind: BreakKind::Sleep,
+                        duration_secs: s.bedtime_duration_secs,
+                        enforceable: true,
+                        manual_finish: false,
+                        postpone_available: false,
+                        hints: s.sleep_hints.clone(),
+                        hint_rotate_seconds: s.hint_rotate_seconds,
+                        health_intensity: if s.break_health_enabled {
+                            intensity
+                        } else {
+                            0.0
+                        },
+                    },
                     s.monitor_placement,
                     super::settings::is_windowed_mode(BreakKind::Sleep, &s),
-                    false,
-                    false,
-                    s.sleep_hints.clone(),
-                    s.hint_rotate_seconds,
-                    if s.break_health_enabled {
-                        intensity
-                    } else {
-                        0.0
-                    },
                 );
                 hooks::run_hooks(
                     &s,
@@ -349,20 +354,22 @@ pub(super) async fn run_loop(app: AppHandle, sched: Scheduler) {
                 deliver_break(
                     &app,
                     &sched.current_break,
-                    delivery,
-                    BreakKind::Long,
-                    s.long_duration_secs,
-                    enforceable,
-                    s.monitor_placement,
-                    s.long_manual_finish,
-                    s.postpone_enabled && !s.strict_mode,
-                    effective_long_hints(&s),
-                    s.hint_rotate_seconds,
-                    if s.break_health_enabled {
-                        intensity
-                    } else {
-                        0.0
+                    BreakEvent {
+                        kind: BreakKind::Long,
+                        duration_secs: s.long_duration_secs,
+                        enforceable,
+                        manual_finish: s.long_manual_finish,
+                        postpone_available: s.postpone_enabled && !s.strict_mode,
+                        hints: effective_long_hints(&s),
+                        hint_rotate_seconds: s.hint_rotate_seconds,
+                        health_intensity: if s.break_health_enabled {
+                            intensity
+                        } else {
+                            0.0
+                        },
                     },
+                    delivery,
+                    s.monitor_placement,
                 );
                 hooks::run_hooks(
                     &s,
@@ -394,20 +401,22 @@ pub(super) async fn run_loop(app: AppHandle, sched: Scheduler) {
                 deliver_break(
                     &app,
                     &sched.current_break,
-                    delivery,
-                    BreakKind::Micro,
-                    s.micro_duration_secs,
-                    enforceable,
-                    s.monitor_placement,
-                    s.micro_manual_finish,
-                    s.postpone_enabled && !s.strict_mode,
-                    effective_micro_hints(&s),
-                    s.hint_rotate_seconds,
-                    if s.break_health_enabled {
-                        intensity
-                    } else {
-                        0.0
+                    BreakEvent {
+                        kind: BreakKind::Micro,
+                        duration_secs: s.micro_duration_secs,
+                        enforceable,
+                        manual_finish: s.micro_manual_finish,
+                        postpone_available: s.postpone_enabled && !s.strict_mode,
+                        hints: effective_micro_hints(&s),
+                        hint_rotate_seconds: s.hint_rotate_seconds,
+                        health_intensity: if s.break_health_enabled {
+                            intensity
+                        } else {
+                            0.0
+                        },
                     },
+                    delivery,
+                    s.monitor_placement,
                 );
                 hooks::run_hooks(
                     &s,
@@ -460,26 +469,30 @@ pub(super) async fn run_loop(app: AppHandle, sched: Scheduler) {
         if s.prebreak_notification_enabled && s.prebreak_notification_seconds > 0 {
             let mut t = sched.timers.lock().await;
             if prebreak_warn_due(
-                s.long_enabled,
-                long_interval_active,
+                PrebreakGate {
+                    enabled: s.long_enabled,
+                    mode_includes_interval: long_interval_active,
+                    already_warned: t.long_warned,
+                    idle_suppressed: long_idle_suppressed,
+                },
                 t.last_long,
                 s.long_interval_secs,
                 s.prebreak_notification_seconds,
-                t.long_warned,
-                long_idle_suppressed,
                 tick_now,
             ) {
                 notify_break_coming(&app, BreakKind::Long, s.prebreak_notification_seconds);
                 t.long_warned = true;
             }
             if prebreak_warn_due(
-                s.micro_enabled,
-                micro_interval_active,
+                PrebreakGate {
+                    enabled: s.micro_enabled,
+                    mode_includes_interval: micro_interval_active,
+                    already_warned: t.micro_warned,
+                    idle_suppressed: micro_idle_suppressed,
+                },
                 t.last_micro,
                 s.micro_interval_secs,
                 s.prebreak_notification_seconds,
-                t.micro_warned,
-                micro_idle_suppressed,
                 tick_now,
             ) {
                 notify_break_coming(&app, BreakKind::Micro, s.prebreak_notification_seconds);
@@ -563,20 +576,22 @@ pub(super) async fn run_loop(app: AppHandle, sched: Scheduler) {
             deliver_break(
                 &app,
                 &sched.current_break,
-                delivery,
-                BreakKind::Long,
-                s.long_duration_secs,
-                enforceable,
-                s.monitor_placement,
-                s.long_manual_finish,
-                s.postpone_enabled && !s.strict_mode,
-                effective_long_hints(&s),
-                s.hint_rotate_seconds,
-                if s.break_health_enabled {
-                    intensity
-                } else {
-                    0.0
+                BreakEvent {
+                    kind: BreakKind::Long,
+                    duration_secs: s.long_duration_secs,
+                    enforceable,
+                    manual_finish: s.long_manual_finish,
+                    postpone_available: s.postpone_enabled && !s.strict_mode,
+                    hints: effective_long_hints(&s),
+                    hint_rotate_seconds: s.hint_rotate_seconds,
+                    health_intensity: if s.break_health_enabled {
+                        intensity
+                    } else {
+                        0.0
+                    },
                 },
+                delivery,
+                s.monitor_placement,
             );
             hooks::run_hooks(
                 &s,
@@ -605,20 +620,22 @@ pub(super) async fn run_loop(app: AppHandle, sched: Scheduler) {
             deliver_break(
                 &app,
                 &sched.current_break,
-                delivery,
-                BreakKind::Micro,
-                s.micro_duration_secs,
-                enforceable,
-                s.monitor_placement,
-                s.micro_manual_finish,
-                s.postpone_enabled && !s.strict_mode,
-                effective_micro_hints(&s),
-                s.hint_rotate_seconds,
-                if s.break_health_enabled {
-                    intensity
-                } else {
-                    0.0
+                BreakEvent {
+                    kind: BreakKind::Micro,
+                    duration_secs: s.micro_duration_secs,
+                    enforceable,
+                    manual_finish: s.micro_manual_finish,
+                    postpone_available: s.postpone_enabled && !s.strict_mode,
+                    hints: effective_micro_hints(&s),
+                    hint_rotate_seconds: s.hint_rotate_seconds,
+                    health_intensity: if s.break_health_enabled {
+                        intensity
+                    } else {
+                        0.0
+                    },
                 },
+                delivery,
+                s.monitor_placement,
             );
             hooks::run_hooks(
                 &s,

--- a/src-tauri/src/scheduler/timers.rs
+++ b/src-tauri/src/scheduler/timers.rs
@@ -167,26 +167,36 @@ pub fn interval_break_due(
         && now.saturating_duration_since(last_fire) >= Duration::from_secs(interval_secs)
 }
 
+/// The four conditions that gate a pre-break warning before any timing
+/// is considered: the feature must be on, the schedule must include
+/// interval breaks, the user must not be idle-suppressed, and we must not
+/// have already warned this cycle. Grouped so each is set by name.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PrebreakGate {
+    pub enabled: bool,
+    pub mode_includes_interval: bool,
+    pub already_warned: bool,
+    pub idle_suppressed: bool,
+}
+
 /// True iff the pre-break notification for this kind should fire now —
 /// i.e. we're inside the lead window before a due interval break, and
 /// we haven't already shown the notification for this cycle.
 ///
-/// Pure analogue of the inline check in `run_loop`. The arg list is
-/// wide because the function is deliberately decoupled from `Scheduler`
-/// state so it can be driven by tests with synthetic instants — a
-/// wrapper struct would just shuffle the same fields around.
-#[allow(clippy::too_many_arguments)]
+/// Pure analogue of the inline check in `run_loop`. Decoupled from
+/// `Scheduler` state so tests can drive it with synthetic instants. The
+/// four short-circuit conditions are grouped into [`PrebreakGate`] so
+/// call sites set each by name instead of passing a run of positional
+/// booleans.
 pub fn prebreak_warn_due(
-    enabled: bool,
-    mode_includes_interval: bool,
+    gate: PrebreakGate,
     last_fire: Instant,
     interval_secs: u64,
     lead_secs: u64,
-    already_warned: bool,
-    idle_suppressed: bool,
     now: Instant,
 ) -> bool {
-    if !enabled || !mode_includes_interval || idle_suppressed || already_warned {
+    if !gate.enabled || !gate.mode_includes_interval || gate.idle_suppressed || gate.already_warned
+    {
         return false;
     }
     let interval = Duration::from_secs(interval_secs);
@@ -211,6 +221,18 @@ pub enum BedtimeAction {
     NotInWindow,
 }
 
+/// The configured bedtime window: whether the feature is on, its
+/// start/end minute-of-day bounds, and the per-window re-prompt interval.
+/// Grouped so `decide_bedtime`'s call sites set each field by name rather
+/// than passing four positional values that are easy to transpose.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BedtimeWindow {
+    pub enabled: bool,
+    pub start_min: u32,
+    pub end_min: u32,
+    pub interval_secs: u64,
+}
+
 /// Pure bedtime decision: combine the time-of-day window, the per-window
 /// interval, and the `last_sleep` anchor into one of three actions.
 ///
@@ -226,23 +248,19 @@ pub enum BedtimeAction {
 /// `ResetTimersOnly` so opening the laptop mid-window stays quiet. A
 /// first entry into the window (`last_sleep` is `None`, e.g. the laptop
 /// was closed before bedtime and opened inside it) still fires normally.
-#[allow(clippy::too_many_arguments)]
 pub fn decide_bedtime(
-    enabled: bool,
+    window: BedtimeWindow,
     now_min: u32,
-    start_min: u32,
-    end_min: u32,
-    interval_secs: u64,
     last_sleep_fire: Option<Instant>,
     now: Instant,
     resumed_from_suspend: bool,
 ) -> BedtimeAction {
-    if !enabled || !in_window(now_min, start_min, end_min) {
+    if !window.enabled || !in_window(now_min, window.start_min, window.end_min) {
         return BedtimeAction::NotInWindow;
     }
     let should_fire = match last_sleep_fire {
         None => true,
-        Some(t) => now.saturating_duration_since(t) >= Duration::from_secs(interval_secs),
+        Some(t) => now.saturating_duration_since(t) >= Duration::from_secs(window.interval_secs),
     };
     if should_fire {
         if resumed_from_suspend && last_sleep_fire.is_some() {
@@ -617,14 +635,24 @@ mod tests {
     // band before the break itself. The `already_warned` flag is the
     // dedupe gate.
 
+    /// The "would warn if timing is right" gate: feature on, interval
+    /// mode, not yet warned, not idle. Variants flip one field via
+    /// struct-update syntax (`PrebreakGate { enabled: false, ..warn_gate() }`).
+    fn warn_gate() -> PrebreakGate {
+        PrebreakGate {
+            enabled: true,
+            mode_includes_interval: true,
+            already_warned: false,
+            idle_suppressed: false,
+        }
+    }
+
     #[test]
     fn prebreak_warn_fires_inside_lead_window() {
         // 50s before a 1200s break, lead is 60s → in the warn band.
         let last = Instant::now();
         let now = last + Duration::from_secs(1150);
-        assert!(prebreak_warn_due(
-            true, true, last, 1200, 60, false, false, now
-        ));
+        assert!(prebreak_warn_due(warn_gate(), last, 1200, 60, now));
     }
 
     #[test]
@@ -632,9 +660,7 @@ mod tests {
         // 100s before a 1200s break, lead is 60s → outside warn band.
         let last = Instant::now();
         let now = last + Duration::from_secs(1100);
-        assert!(!prebreak_warn_due(
-            true, true, last, 1200, 60, false, false, now
-        ));
+        assert!(!prebreak_warn_due(warn_gate(), last, 1200, 60, now));
     }
 
     #[test]
@@ -643,13 +669,15 @@ mod tests {
         // shouldn't re-fire post-interval.
         let last = Instant::now();
         let now = last + Duration::from_secs(1200);
-        assert!(!prebreak_warn_due(
-            true, true, last, 1200, 60, false, false, now
-        ));
+        assert!(!prebreak_warn_due(warn_gate(), last, 1200, 60, now));
         let way_late = Instant::now();
         let later_now = way_late + Duration::from_secs(1250);
         assert!(!prebreak_warn_due(
-            true, true, way_late, 1200, 60, false, false, later_now
+            warn_gate(),
+            way_late,
+            1200,
+            60,
+            later_now
         ));
     }
 
@@ -658,7 +686,14 @@ mod tests {
         let last = Instant::now();
         let now = last + Duration::from_secs(1150);
         assert!(!prebreak_warn_due(
-            true, true, last, 1200, 60, true, false, now
+            PrebreakGate {
+                already_warned: true,
+                ..warn_gate()
+            },
+            last,
+            1200,
+            60,
+            now,
         ));
     }
 
@@ -667,13 +702,34 @@ mod tests {
         let last = Instant::now();
         let now = last + Duration::from_secs(1150);
         assert!(!prebreak_warn_due(
-            false, true, last, 1200, 60, false, false, now
+            PrebreakGate {
+                enabled: false,
+                ..warn_gate()
+            },
+            last,
+            1200,
+            60,
+            now,
         ));
         assert!(!prebreak_warn_due(
-            true, false, last, 1200, 60, false, false, now
+            PrebreakGate {
+                mode_includes_interval: false,
+                ..warn_gate()
+            },
+            last,
+            1200,
+            60,
+            now,
         ));
         assert!(!prebreak_warn_due(
-            true, true, last, 1200, 60, false, true, now
+            PrebreakGate {
+                idle_suppressed: true,
+                ..warn_gate()
+            },
+            last,
+            1200,
+            60,
+            now,
         ));
     }
 
@@ -684,21 +740,39 @@ mod tests {
         // not panic or warn forever.
         let last = Instant::now();
         let now = last + Duration::from_secs(10);
-        assert!(prebreak_warn_due(
-            true, true, last, 60, 600, false, false, now
-        ));
+        assert!(prebreak_warn_due(warn_gate(), last, 60, 600, now));
     }
 
     // `decide_bedtime` — three-way decision combining window membership
     // and per-window interval. The first tick of the window always
     // fires (`None` last_sleep).
 
+    /// 22:00–06:00 window, 30-min re-prompt — the bulk of these cases.
+    fn window_2206() -> BedtimeWindow {
+        BedtimeWindow {
+            enabled: true,
+            start_min: 22 * 60,
+            end_min: 6 * 60,
+            interval_secs: 1800,
+        }
+    }
+
+    /// 22:00–09:00 window, 5-min re-prompt — the resume-from-suspend cases.
+    fn window_2209() -> BedtimeWindow {
+        BedtimeWindow {
+            enabled: true,
+            start_min: 22 * 60,
+            end_min: 9 * 60,
+            interval_secs: 300,
+        }
+    }
+
     #[test]
     fn bedtime_not_in_window_returns_not_in_window() {
         let now = Instant::now();
         // 12:00, window 22:00–06:00
         assert_eq!(
-            decide_bedtime(true, 12 * 60, 22 * 60, 6 * 60, 1800, None, now, false),
+            decide_bedtime(window_2206(), 12 * 60, None, now, false),
             BedtimeAction::NotInWindow
         );
     }
@@ -707,7 +781,16 @@ mod tests {
     fn bedtime_disabled_returns_not_in_window_even_in_range() {
         let now = Instant::now();
         assert_eq!(
-            decide_bedtime(false, 23 * 60, 22 * 60, 6 * 60, 1800, None, now, false),
+            decide_bedtime(
+                BedtimeWindow {
+                    enabled: false,
+                    ..window_2206()
+                },
+                23 * 60,
+                None,
+                now,
+                false,
+            ),
             BedtimeAction::NotInWindow
         );
     }
@@ -716,7 +799,7 @@ mod tests {
     fn bedtime_first_tick_of_window_fires() {
         let now = Instant::now();
         assert_eq!(
-            decide_bedtime(true, 23 * 60, 22 * 60, 6 * 60, 1800, None, now, false),
+            decide_bedtime(window_2206(), 23 * 60, None, now, false),
             BedtimeAction::Fire
         );
     }
@@ -726,7 +809,7 @@ mod tests {
         let last = Instant::now();
         let now = last + Duration::from_secs(1800);
         assert_eq!(
-            decide_bedtime(true, 23 * 60, 22 * 60, 6 * 60, 1800, Some(last), now, false),
+            decide_bedtime(window_2206(), 23 * 60, Some(last), now, false),
             BedtimeAction::Fire
         );
     }
@@ -737,7 +820,7 @@ mod tests {
         let last = Instant::now();
         let now = last + Duration::from_secs(900);
         assert_eq!(
-            decide_bedtime(true, 23 * 60, 22 * 60, 6 * 60, 1800, Some(last), now, false),
+            decide_bedtime(window_2206(), 23 * 60, Some(last), now, false),
             BedtimeAction::ResetTimersOnly
         );
     }
@@ -747,7 +830,7 @@ mod tests {
         let now = Instant::now();
         // 02:00 should still be in window 22:00–06:00
         assert_eq!(
-            decide_bedtime(true, 2 * 60, 22 * 60, 6 * 60, 1800, None, now, false),
+            decide_bedtime(window_2206(), 2 * 60, None, now, false),
             BedtimeAction::Fire
         );
     }
@@ -759,16 +842,7 @@ mod tests {
         let now = Instant::now();
         let future = now + Duration::from_secs(60);
         assert_eq!(
-            decide_bedtime(
-                true,
-                23 * 60,
-                22 * 60,
-                6 * 60,
-                1800,
-                Some(future),
-                now,
-                false
-            ),
+            decide_bedtime(window_2206(), 23 * 60, Some(future), now, false),
             BedtimeAction::ResetTimersOnly
         );
     }
@@ -782,13 +856,13 @@ mod tests {
         let last = Instant::now();
         let now = last + Duration::from_secs(8 * 3600);
         assert_eq!(
-            decide_bedtime(true, 8 * 60, 22 * 60, 9 * 60, 300, Some(last), now, true),
+            decide_bedtime(window_2209(), 8 * 60, Some(last), now, true),
             BedtimeAction::ResetTimersOnly
         );
         // Without the resume flag the same inputs would (wrongly, for the
         // user) re-fire — proving the flag is what suppresses it.
         assert_eq!(
-            decide_bedtime(true, 8 * 60, 22 * 60, 9 * 60, 300, Some(last), now, false),
+            decide_bedtime(window_2209(), 8 * 60, Some(last), now, false),
             BedtimeAction::Fire
         );
     }
@@ -800,7 +874,7 @@ mod tests {
         // should fire the first reminder.
         let now = Instant::now();
         assert_eq!(
-            decide_bedtime(true, 23 * 60, 22 * 60, 9 * 60, 300, None, now, true),
+            decide_bedtime(window_2209(), 23 * 60, None, now, true),
             BedtimeAction::Fire
         );
     }
@@ -810,7 +884,7 @@ mod tests {
         // A wake well outside the window is still just NotInWindow.
         let now = Instant::now();
         assert_eq!(
-            decide_bedtime(true, 12 * 60, 22 * 60, 9 * 60, 300, Some(now), now, true),
+            decide_bedtime(window_2209(), 12 * 60, Some(now), now, true),
             BedtimeAction::NotInWindow
         );
     }


### PR DESCRIPTION
Closes #69.

Replaces all four `#[allow(clippy::too_many_arguments)]` suppressions in `src-tauri/src/scheduler/` with named parameter structs, so call sites set fields by name instead of passing runs of positional `bool`/`u64` that are easy to transpose (the exact smell that motivated the issue — the bedtime `resumed_from_suspend` flag pushed `decide_bedtime` to 8 positional args).

## Changes
- **`decide_bedtime`** → takes `BedtimeWindow { enabled, start_min, end_min, interval_secs }` + the runtime inputs.
- **`prebreak_warn_due`** → takes `PrebreakGate { enabled, mode_includes_interval, already_warned, idle_suppressed }` (the four short-circuit booleans) + timing args.
- **`deliver_break` / `fire_break`** → take a `BreakEvent` (the break *content*) plus `delivery`/`placement`/`windowed`, instead of rebuilding the event from ~12 loose params. `fire_break` still forces `postpone_available` off for enforceable breaks, so callers pass raw intent unchanged.

Decision functions stay pure/unit-testable; tests construct the structs (with small `warn_gate()` / `window_2206()` helpers + struct-update syntax for variants).

## Acceptance criteria
- [x] No `#[allow(clippy::too_many_arguments)]` remain in `src-tauri/src/scheduler/` (none remain in the whole crate).
- [x] `cargo clippy --all-targets` clean without the suppressions.
- [x] All existing scheduler tests pass (613 total).

No behaviour change.