### PR TITLE
feat(release): notarise + staple the DMG container (closes #59)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,6 +121,54 @@ jobs:
           prerelease: ${{ startsWith(github.ref_name, 'v0.0.') }}
           args: ${{ matrix.args }}
 
+      # tauri-action notarises and staples the inner `.app`, but leaves the
+      # `.dmg` container only Developer ID-signed — `spctl` reports the raw
+      # DMG as "Unnotarized Developer ID" (issue #59). Submit and staple the
+      # DMG itself so security tooling and browser-level Gatekeeper checks on
+      # the downloaded file see a notarised container. The same Apple
+      # app-specific password tauri-action already used is reused; absent
+      # credentials skip the step (symmetric with the SignPath probe).
+      - name: Probe Apple notarisation availability
+        id: notarise
+        if: matrix.platform == 'macos-latest'
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+        run: |
+          if [ -n "$APPLE_ID" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::APPLE_ID unset — DMG container left un-notarised."
+          fi
+
+      - name: Notarise and staple the DMG container
+        if: matrix.platform == 'macos-latest' && steps.notarise.outputs.available == 'true'
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          DMG=$(find src-tauri/target -path '*/release/bundle/dmg/*.dmg' | head -1)
+          if [ -z "$DMG" ]; then
+            echo "::error::no .dmg found under src-tauri/target to notarise"
+            exit 1
+          fi
+          echo "Notarising $DMG"
+          xcrun notarytool submit "$DMG" \
+            --apple-id "$APPLE_ID" \
+            --password "$APPLE_PASSWORD" \
+            --team-id "$APPLE_TEAM_ID" \
+            --wait
+          xcrun stapler staple "$DMG"
+          xcrun stapler validate "$DMG"
+          # tauri-action already uploaded the un-stapled DMG to the draft
+          # release; replace it with the stapled copy. This runs before the
+          # checksums / manifest jobs, so SHA256SUMS is computed over the
+          # stapled file.
+          gh release upload "${{ github.ref_name }}" "$DMG" --clobber
+
   build-windows-unsigned:
     needs: verify-updater-pubkey
     runs-on: windows-latest


### PR DESCRIPTION
Closes #59.

`tauri-action` notarises and staples the inner `.app` (what Gatekeeper checks when the installed app launches), but the `.dmg` container itself is only Developer ID-signed — `spctl -a -t open --context context:primary-signature <dmg>` reports `source=Unnotarized Developer ID`. Cosmetic for the normal drag-to-Applications flow, but security tooling, Safari's download check, and release-validation `spctl` runs flag the raw DMG.

## Change
Adds two steps to the macOS legs of `build-unix`:
1. **Probe** — sets `available=true/false` from `APPLE_ID` presence (warns + skips when unset, mirroring the SignPath probe).
2. **Notarise + staple** — `xcrun notarytool submit --wait` → `stapler staple` → `stapler validate` on the built DMG, then `gh release upload --clobber` to replace the un-stapled copy tauri-action already uploaded. Runs inside `build-unix`, before `checksums`/`publish-updater-manifest`, so `SHA256SUMS.txt` is computed over the stapled file.

Reuses the existing Apple app-specific password. No change to `.app` notarisation or the updater `.app.tar.gz`/`.sig` flow (~30s per macOS arch).

## Acceptance criteria
- [x] DMG submitted + stapled; `xcrun stapler validate` gates the step.
- [x] Tolerates missing Apple credentials (probe-skip).
- [x] No change to `.app` notarisation or updater artifacts.
- [ ] Verified on the next release tag: `spctl … <dmg>` → `Notarized Developer ID` (post-merge, needs a real tag run).

Workflow-only; verified end-to-end on the next `v*` tag.