### PR TITLE
feat(dnd): detect Do Not Disturb on Linux (GNOME + KDE)

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -84,12 +84,12 @@ Helper components in [src/views/settings/components/rows.tsx](../src/views/setti
 
 ## Per-OS detection
 
-| Feature | macOS                                                         | Windows                                                 | Linux                                                    |
-| ------- | ------------------------------------------------------------- | ------------------------------------------------------- | -------------------------------------------------------- |
-| DnD     | `~/Library/DoNotDisturb/DB/Assertions.json` poll              | WNF `NtQueryWnfStateData` (state `0xA3BC1875_A3BC0875`) | not implemented                                          |
-| Camera  | `log stream` event-driven                                     | `HKCU\…\ConsentStore\webcam` poll (2s)                  | walk `/proc/<pid>/fd/*` for `/dev/video*` (2s)           |
-| Idle    | `user-idle` crate (CGEventSourceSeconds…)                     | `user-idle` (GetLastInputInfo)                          | `user-idle` X11; Wayland is unreliable                   |
-| Video   | `pmset -g assertions` `PreventUserIdleDisplaySleep` poll (2s) | `powercfg /requests` DISPLAY section poll (2s)          | `systemd-inhibit --list` poll (2s), match WHAT == `idle` |
+| Feature | macOS                                                         | Windows                                                 | Linux                                                                                   |
+| ------- | ------------------------------------------------------------- | ------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| DnD     | `~/Library/DoNotDisturb/DB/Assertions.json` poll              | WNF `NtQueryWnfStateData` (state `0xA3BC1875_A3BC0875`) | GNOME `gsettings … show-banners` (inverted), else KDE `Inhibited` DBus prop via `gdbus` |
+| Camera  | `log stream` event-driven                                     | `HKCU\…\ConsentStore\webcam` poll (2s)                  | walk `/proc/<pid>/fd/*` for `/dev/video*` (2s)                                          |
+| Idle    | `user-idle` crate (CGEventSourceSeconds…)                     | `user-idle` (GetLastInputInfo)                          | `user-idle` X11; Wayland is unreliable                                                  |
+| Video   | `pmset -g assertions` `PreventUserIdleDisplaySleep` poll (2s) | `powercfg /requests` DISPLAY section poll (2s)          | `systemd-inhibit --list` poll (2s), match WHAT == `idle`                                |
 
 The Windows WNF state name is the part most likely to need empirical verification — if Focus Assist toggling doesn't pause breaks on a Windows build, that constant is the first thing to check.
 
@@ -223,7 +223,7 @@ Configure these to enable signed/notarized builds. The workflow runs without the
 ## Known gaps / next moves
 
 - **Auto-installing updater**: [updater.rs](../src-tauri/src/updater.rs) is a manual GitHub-releases version check, not the Tauri auto-updater plugin. Notarization (macOS) and signed-updater wiring is the remaining work.
-- **Linux DnD**: would need per-DE handling (GNOME `gsettings`, KDE DBus). Currently the checkbox is greyed with `(macOS/Windows only)`.
+- **Linux DnD**: implemented for GNOME (`gsettings get org.gnome.desktop.notifications show-banners`, inverted) and KDE (the `Inhibited` DBus property on `org.freedesktop.Notifications`, read via `gdbus`). Other desktops fall through to "off" — no portable cross-DE DnD signal exists, so they fail safe. Both probes shell out and feed pure parsers (`parse_gnome_show_banners_dnd`, `parse_kde_inhibited`) that are unit-tested on every OS.
 - **Wayland idle detection**: known flaky; X11-only Linux support may be the practical limit short-term.
 
 ## Things that have bitten me

--- a/.github/audit/cspell/project-words.txt
+++ b/.github/audit/cspell/project-words.txt
@@ -54,6 +54,7 @@ Lemon
 appimage
 AppImage
 gsettings
+gdbus
 WebKit
 WebView
 webview

--- a/src-tauri/src/dnd.rs
+++ b/src-tauri/src/dnd.rs
@@ -3,7 +3,9 @@ pub fn is_active() -> bool {
     return macos::check();
     #[cfg(target_os = "windows")]
     return windows::check();
-    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    #[cfg(target_os = "linux")]
+    return linux::check();
+    #[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
     return false;
 }
 
@@ -31,6 +33,34 @@ pub(crate) fn parse_assertions_active(json: &str) -> bool {
             })
         })
         .unwrap_or(false)
+}
+
+/// GNOME exposes "Do Not Disturb" as the *inverse* of
+/// `org.gnome.desktop.notifications show-banners`: when banners are
+/// turned off, DnD is on. `gsettings get` prints the GVariant literal
+/// `true` / `false` (with a trailing newline). Anything we can't parse as
+/// an explicit `false` is treated as "banners on" → DnD off, so a missing
+/// key or unexpected output fails safe (breaks keep firing).
+///
+/// Un-gated so it's unit-tested on every OS; only `linux::check` calls it
+/// in a non-test build.
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+pub(crate) fn parse_gnome_show_banners_dnd(gsettings_output: &str) -> bool {
+    gsettings_output.trim() == "false"
+}
+
+/// KDE Plasma exposes DnD as the boolean `Inhibited` property on
+/// `org.freedesktop.Notifications`. Read via
+/// `gdbus call … org.freedesktop.DBus.Properties.Get`, the reply is a
+/// GVariant tuple wrapping a variant, e.g. `(<true>,)` or `(<false>,)`.
+/// True only when the wrapped value is `true`; any other / unparseable
+/// output fails safe to `false`.
+///
+/// Un-gated so it's unit-tested on every OS; only `linux::check` calls it
+/// in a non-test build.
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+pub(crate) fn parse_kde_inhibited(gdbus_output: &str) -> bool {
+    gdbus_output.contains("<true>") || gdbus_output.trim() == "(true,)"
 }
 
 #[cfg(target_os = "macos")]
@@ -145,6 +175,71 @@ mod windows {
     }
 }
 
+#[cfg(target_os = "linux")]
+mod linux {
+    use std::process::Command;
+
+    use super::{parse_gnome_show_banners_dnd, parse_kde_inhibited};
+
+    // Absolute paths so a planted `gsettings` / `gdbus` earlier in `$PATH`
+    // can't intercept the probe. These are the canonical locations on the
+    // distros we target; if a session ships them elsewhere the command
+    // simply fails and we fail safe to "DnD off".
+    pub(super) const GSETTINGS_BIN: &str = "/usr/bin/gsettings";
+    pub(super) const GDBUS_BIN: &str = "/usr/bin/gdbus";
+
+    // GNOME is the most common case, so try it first; fall through to the
+    // KDE property only if GNOME didn't report DnD on. Either probe failing
+    // (tool missing, not that desktop) just yields `false` — there's no
+    // portable cross-desktop DnD signal, so unknown environments fail safe.
+    pub fn check() -> bool {
+        gnome_dnd_active() || kde_dnd_active()
+    }
+
+    fn gnome_dnd_active() -> bool {
+        let Ok(output) = Command::new(GSETTINGS_BIN)
+            .args(["get", "org.gnome.desktop.notifications", "show-banners"])
+            .output()
+        else {
+            return false;
+        };
+        if !output.status.success() {
+            return false;
+        }
+        let Ok(text) = std::str::from_utf8(&output.stdout) else {
+            return false;
+        };
+        parse_gnome_show_banners_dnd(text)
+    }
+
+    fn kde_dnd_active() -> bool {
+        let Ok(output) = Command::new(GDBUS_BIN)
+            .args([
+                "call",
+                "--session",
+                "--dest",
+                "org.freedesktop.Notifications",
+                "--object-path",
+                "/org/freedesktop/Notifications",
+                "--method",
+                "org.freedesktop.DBus.Properties.Get",
+                "org.freedesktop.Notifications",
+                "Inhibited",
+            ])
+            .output()
+        else {
+            return false;
+        };
+        if !output.status.success() {
+            return false;
+        }
+        let Ok(text) = std::str::from_utf8(&output.stdout) else {
+            return false;
+        };
+        parse_kde_inhibited(text)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::parse_assertions_active;
@@ -184,5 +279,59 @@ mod tests {
     fn malformed_json_means_inactive() {
         assert!(!parse_assertions_active("not json at all"));
         assert!(!parse_assertions_active(""));
+    }
+
+    use super::{parse_gnome_show_banners_dnd, parse_kde_inhibited};
+
+    #[test]
+    fn gnome_banners_false_means_dnd_on() {
+        // gsettings prints the GVariant literal with a trailing newline.
+        assert!(parse_gnome_show_banners_dnd("false\n"));
+        assert!(parse_gnome_show_banners_dnd("false"));
+    }
+
+    #[test]
+    fn gnome_banners_true_means_dnd_off() {
+        assert!(!parse_gnome_show_banners_dnd("true\n"));
+    }
+
+    #[test]
+    fn gnome_unexpected_output_fails_safe_to_off() {
+        assert!(!parse_gnome_show_banners_dnd(""));
+        assert!(!parse_gnome_show_banners_dnd(
+            "No such key 'show-banners'\n"
+        ));
+    }
+
+    #[test]
+    fn kde_inhibited_true_means_dnd_on() {
+        // gdbus reply for the Properties.Get of a boolean property.
+        assert!(parse_kde_inhibited("(<true>,)\n"));
+    }
+
+    #[test]
+    fn kde_inhibited_false_means_dnd_off() {
+        assert!(!parse_kde_inhibited("(<false>,)\n"));
+    }
+
+    #[test]
+    fn kde_unexpected_output_fails_safe_to_off() {
+        assert!(!parse_kde_inhibited(""));
+        assert!(!parse_kde_inhibited("Error: no such property\n"));
+    }
+}
+
+// Absolute-path sanity for the Linux probe binaries. Gated because the
+// consts only exist on Linux (mirrors the *_bin_tests in camera/video).
+#[cfg(all(test, target_os = "linux"))]
+mod linux_bin_tests {
+    use super::linux::{GDBUS_BIN, GSETTINGS_BIN};
+
+    #[test]
+    fn probe_bins_are_absolute_and_non_empty() {
+        for bin in [GSETTINGS_BIN, GDBUS_BIN] {
+            assert!(!bin.is_empty());
+            assert!(bin.starts_with('/'), "expected absolute path, got {bin}");
+        }
     }
 }

--- a/src/views/settings/tabs/quiet-tab.tsx
+++ b/src/views/settings/tabs/quiet-tab.tsx
@@ -42,8 +42,7 @@ export function QuietTab({
           label="Do Not Disturb is on"
           value={settings.pause_during_dnd}
           onChange={(v) => update("pause_during_dnd", v)}
-          onlyOn={["macos", "windows"]}
-          tip="Reads your OS-level DnD / Focus state. When on, scheduled breaks are suppressed until DnD turns off."
+          tip="Reads your OS-level DnD / Focus state (macOS, Windows, and GNOME/KDE on Linux). When on, scheduled breaks are suppressed until DnD turns off."
         />
         <CheckboxRow
           label="Camera is in use"


### PR DESCRIPTION
## Why

Linux was the one platform where **Do Not Disturb detection didn't exist** — `dnd::is_active()` returned a hardcoded `false`, and the "Do Not Disturb is on" setting row was greyed out with `(macOS/Windows only)`. This closes that documented gap so the suppression feature works on all three first-class platforms.

## What

`dnd::is_active()` now routes Linux to a new `linux::check()` that probes two desktops, in order:

| Desktop    | Signal                                                  | How                                                                               |
| ---------- | ------------------------------------------------------- | --------------------------------------------------------------------------------- |
| GNOME      | `org.gnome.desktop.notifications show-banners`          | `gsettings get …` — DnD is the **inverse** of show-banners (banners off → DnD on) |
| KDE Plasma | `Inhibited` property on `org.freedesktop.Notifications` | `gdbus call … org.freedesktop.DBus.Properties.Get`                                |

GNOME is tried first (most common); if it doesn't report DnD on, the KDE property is checked. **Every failure path fails safe to "DnD off"** — tool missing, wrong desktop, non-zero exit, malformed output. There's no portable cross-DE DnD signal, so unknown environments are simply never suppressed (breaks keep firing) rather than guessing.

Both probes shell out (matching the existing `camera.rs` / `video.rs` pattern — no new dependency) and hand their stdout to two pure, un-gated parsers:

- `parse_gnome_show_banners_dnd(&str) -> bool`
- `parse_kde_inhibited(&str) -> bool`

Per the parser-cross-testing convention (PR #81), both live at module level with `#[cfg_attr(not(target_os = "linux"), allow(dead_code))]`, so they compile and are unit-tested on **every** OS, not just Linux.

## Scope

- `src-tauri/src/dnd.rs` — Linux module + two parsers + 6 parser unit tests (GNOME true/false/garbage, KDE true/false/garbage) + a Linux-gated absolute-path check for the `gsettings`/`gdbus` binaries.
- `src/views/settings/tabs/quiet-tab.tsx` — the "Do Not Disturb is on" row drops its `onlyOn={["macos","windows"]}` gate (now all three platforms) and the tip names the supported desktops.
- `.github/AGENTS.md` — per-OS table + known-gaps updated to reflect the implementation.
- `.github/audit/cspell/project-words.txt` — add `gdbus`.

**Depends on #81** (the parser-extraction refactor) — this branch is stacked on it. Base will retarget to `main` automatically once #81 merges.

## Verification

On macOS: `cargo fmt --check`, `cargo clippy --all-targets -D warnings`, `cargo doc -D warnings`, and `cargo test --lib` (646 pass, incl. the 6 new DnD parser tests which run cross-OS) all clean; `tsc --noEmit` clean; `npm run audit:spell` clean.

**Cannot verify from a macOS dev machine** — needs a real Linux session: that `linux::check()` actually flips with a live GNOME DnD toggle and a live KDE Plasma DnD toggle. The pure parsers are tested against captured `gsettings`/`gdbus` output; the live shell-out glue is exercised only on the target desktop. Please confirm on both a GNOME and a KDE box if you can (or I can validate in a UTM Ubuntu VM as a follow-up).

> **Coverage note:** the `linux::check`/probe call sites are uncoverable in headless CI (no live `gsettings`/`gdbus`), so `codecov/patch` will flag them — admin-bypass per the gate policy, same as the other per-OS call sites. The parser bodies themselves are fully covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
