### PR TITLE
refactor: dedup time helpers, scheduled-break fire path, and settings drafts

### DIFF
--- a/src-tauri/src/scheduler/run_loop.rs
+++ b/src-tauri/src/scheduler/run_loop.rs
@@ -357,28 +357,13 @@ pub(super) async fn run_loop(app: AppHandle, sched: Scheduler) {
                 )
             };
             // Fixed-time fires bypass the idle gate: the clock is the signal, not user activity.
+            let fixed_key = Some((today_str.clone(), now_min));
             if fire_long {
-                fire_scheduled_break(
-                    &app,
-                    &sched,
-                    &s,
-                    BreakKind::Long,
-                    Instant::now(),
-                    Some((today_str.clone(), now_min)),
-                )
-                .await;
+                fire_scheduled_break(&app, &sched, &s, BreakKind::Long, fixed_key).await;
                 continue;
             }
             if fire_micro {
-                fire_scheduled_break(
-                    &app,
-                    &sched,
-                    &s,
-                    BreakKind::Micro,
-                    Instant::now(),
-                    Some((today_str.clone(), now_min)),
-                )
-                .await;
+                fire_scheduled_break(&app, &sched, &s, BreakKind::Micro, fixed_key).await;
                 continue;
             }
         }
@@ -513,30 +498,28 @@ pub(super) async fn run_loop(app: AppHandle, sched: Scheduler) {
         }
 
         if should_fire_long {
-            fire_scheduled_break(&app, &sched, &s, BreakKind::Long, Instant::now(), None).await;
+            fire_scheduled_break(&app, &sched, &s, BreakKind::Long, None).await;
         } else if should_fire_micro {
-            fire_scheduled_break(&app, &sched, &s, BreakKind::Micro, Instant::now(), None).await;
+            fire_scheduled_break(&app, &sched, &s, BreakKind::Micro, None).await;
         }
     }
 }
 
 /// Fire a scheduled micro/long break end to end: deliver it (see
 /// [`deliver_scheduled_break`]) and apply the post-fire timer bookkeeping
-/// under the timers lock (see [`record_scheduled_fire`]). `now` and
-/// `fixed_key` are threaded straight through to the bookkeeping — the live
-/// call sites pass `Instant::now()` and `Some((today, minute))` for a
-/// fixed-time fire or `None` for an interval fire.
+/// under the timers lock (see [`record_scheduled_fire`]). `fixed_key` is
+/// `Some((today, minute))` for a fixed-time fire (recording the dedupe
+/// key) or `None` for an interval fire; the fire `Instant` is stamped here.
 async fn fire_scheduled_break<R: Runtime>(
     app: &AppHandle<R>,
     sched: &Scheduler,
     s: &Settings,
     kind: BreakKind,
-    now: Instant,
     fixed_key: Option<(String, u32)>,
 ) {
     let delivery = deliver_scheduled_break(app, sched, s, kind).await;
     let mut t = sched.timers.lock().await;
-    record_scheduled_fire(&mut t, kind, delivery, now, fixed_key);
+    record_scheduled_fire(&mut t, kind, delivery, Instant::now(), fixed_key);
 }
 
 /// Build and surface a scheduled micro/long break: resolve the per-kind
@@ -1121,19 +1104,18 @@ mod tests {
             .expect("mock app builds");
         app.manage(sched.clone());
 
-        let now = Instant::now();
+        let before = Instant::now();
         fire_scheduled_break(
             app.handle(),
             &sched,
             &settings,
             BreakKind::Micro,
-            now,
             Some(("2026-06-02".into(), 600)),
         )
         .await;
 
         let t = sched.timers.lock().await;
-        assert_eq!(t.last_micro, now);
+        assert!(t.last_micro >= before);
         assert!(!t.micro_warned);
         assert_eq!(t.micro_deferred_since, None);
         assert_eq!(t.last_micro_fixed_fire, Some(("2026-06-02".into(), 600)));

--- a/src-tauri/src/scheduler/run_loop.rs
+++ b/src-tauri/src/scheduler/run_loop.rs
@@ -326,13 +326,13 @@ pub(super) async fn run_loop(app: AppHandle, sched: Scheduler) {
         }
 
         let long_fixed_due = s.long_enabled
-            && matches!(s.long_schedule_mode.as_str(), "fixed" | "both")
+            && s.fixed_active(BreakKind::Long)
             && s.long_fixed_times
                 .iter()
                 .filter_map(|t| parse_hhmm(t))
                 .any(|m| m == now_min);
         let micro_fixed_due = s.micro_enabled
-            && matches!(s.micro_schedule_mode.as_str(), "fixed" | "both")
+            && s.fixed_active(BreakKind::Micro)
             && s.micro_fixed_times
                 .iter()
                 .filter_map(|t| parse_hhmm(t))
@@ -358,39 +358,7 @@ pub(super) async fn run_loop(app: AppHandle, sched: Scheduler) {
             };
             // Fixed-time fires bypass the idle gate: the clock is the signal, not user activity.
             if fire_long {
-                let enforceable = s.long_enforceable || s.strict_mode;
-                let intensity = sched.stats.lock().await.intensity();
-                let delivery = delivery_for(BreakKind::Long, &s);
-                deliver_break(
-                    &app,
-                    &sched.current_break,
-                    BreakEvent {
-                        kind: BreakKind::Long,
-                        duration_secs: s.long_duration_secs,
-                        enforceable,
-                        manual_finish: s.long_manual_finish,
-                        postpone_available: s.postpone_enabled && !s.strict_mode,
-                        hints: effective_long_hints(&s),
-                        hint_rotate_seconds: s.hint_rotate_seconds,
-                        health_intensity: if s.break_health_enabled {
-                            intensity
-                        } else {
-                            0.0
-                        },
-                    },
-                    delivery,
-                    s.monitor_placement,
-                );
-                hooks::run_hooks(
-                    &s,
-                    HookEvent::BreakStart,
-                    HookContext::with_kind_duration(BreakKind::Long, s.long_duration_secs),
-                );
-                sched.logger.log(EventPayload::BreakStart {
-                    kind: BreakKind::Long,
-                    duration_secs: s.long_duration_secs,
-                    enforceable,
-                });
+                let delivery = deliver_scheduled_break(&app, &sched, &s, BreakKind::Long).await;
                 let mut t = sched.timers.lock().await;
                 t.last_long = Instant::now();
                 t.last_micro = Instant::now();
@@ -405,39 +373,7 @@ pub(super) async fn run_loop(app: AppHandle, sched: Scheduler) {
                 continue;
             }
             if fire_micro {
-                let enforceable = s.micro_enforceable || s.strict_mode;
-                let intensity = sched.stats.lock().await.intensity();
-                let delivery = delivery_for(BreakKind::Micro, &s);
-                deliver_break(
-                    &app,
-                    &sched.current_break,
-                    BreakEvent {
-                        kind: BreakKind::Micro,
-                        duration_secs: s.micro_duration_secs,
-                        enforceable,
-                        manual_finish: s.micro_manual_finish,
-                        postpone_available: s.postpone_enabled && !s.strict_mode,
-                        hints: effective_micro_hints(&s),
-                        hint_rotate_seconds: s.hint_rotate_seconds,
-                        health_intensity: if s.break_health_enabled {
-                            intensity
-                        } else {
-                            0.0
-                        },
-                    },
-                    delivery,
-                    s.monitor_placement,
-                );
-                hooks::run_hooks(
-                    &s,
-                    HookEvent::BreakStart,
-                    HookContext::with_kind_duration(BreakKind::Micro, s.micro_duration_secs),
-                );
-                sched.logger.log(EventPayload::BreakStart {
-                    kind: BreakKind::Micro,
-                    duration_secs: s.micro_duration_secs,
-                    enforceable,
-                });
+                let delivery = deliver_scheduled_break(&app, &sched, &s, BreakKind::Micro).await;
                 let mut t = sched.timers.lock().await;
                 t.last_micro = Instant::now();
                 t.micro_warned = false;
@@ -450,8 +386,8 @@ pub(super) async fn run_loop(app: AppHandle, sched: Scheduler) {
             }
         }
 
-        let micro_interval_active = matches!(s.micro_schedule_mode.as_str(), "interval" | "both");
-        let long_interval_active = matches!(s.long_schedule_mode.as_str(), "interval" | "both");
+        let micro_interval_active = s.interval_active(BreakKind::Micro);
+        let long_interval_active = s.interval_active(BreakKind::Long);
 
         let (micro_idle_suppressed, long_idle_suppressed) = (
             idle_secs >= s.micro_idle_reset_secs,
@@ -580,39 +516,7 @@ pub(super) async fn run_loop(app: AppHandle, sched: Scheduler) {
         }
 
         if should_fire_long {
-            let enforceable = s.long_enforceable || s.strict_mode;
-            let intensity = sched.stats.lock().await.intensity();
-            let delivery = delivery_for(BreakKind::Long, &s);
-            deliver_break(
-                &app,
-                &sched.current_break,
-                BreakEvent {
-                    kind: BreakKind::Long,
-                    duration_secs: s.long_duration_secs,
-                    enforceable,
-                    manual_finish: s.long_manual_finish,
-                    postpone_available: s.postpone_enabled && !s.strict_mode,
-                    hints: effective_long_hints(&s),
-                    hint_rotate_seconds: s.hint_rotate_seconds,
-                    health_intensity: if s.break_health_enabled {
-                        intensity
-                    } else {
-                        0.0
-                    },
-                },
-                delivery,
-                s.monitor_placement,
-            );
-            hooks::run_hooks(
-                &s,
-                HookEvent::BreakStart,
-                HookContext::with_kind_duration(BreakKind::Long, s.long_duration_secs),
-            );
-            sched.logger.log(EventPayload::BreakStart {
-                kind: BreakKind::Long,
-                duration_secs: s.long_duration_secs,
-                enforceable,
-            });
+            let delivery = deliver_scheduled_break(&app, &sched, &s, BreakKind::Long).await;
             let mut t = sched.timers.lock().await;
             t.last_long = Instant::now();
             t.last_micro = Instant::now();
@@ -624,39 +528,7 @@ pub(super) async fn run_loop(app: AppHandle, sched: Scheduler) {
                 t.active_break = Some(BreakKind::Long);
             }
         } else if should_fire_micro {
-            let enforceable = s.micro_enforceable || s.strict_mode;
-            let intensity = sched.stats.lock().await.intensity();
-            let delivery = delivery_for(BreakKind::Micro, &s);
-            deliver_break(
-                &app,
-                &sched.current_break,
-                BreakEvent {
-                    kind: BreakKind::Micro,
-                    duration_secs: s.micro_duration_secs,
-                    enforceable,
-                    manual_finish: s.micro_manual_finish,
-                    postpone_available: s.postpone_enabled && !s.strict_mode,
-                    hints: effective_micro_hints(&s),
-                    hint_rotate_seconds: s.hint_rotate_seconds,
-                    health_intensity: if s.break_health_enabled {
-                        intensity
-                    } else {
-                        0.0
-                    },
-                },
-                delivery,
-                s.monitor_placement,
-            );
-            hooks::run_hooks(
-                &s,
-                HookEvent::BreakStart,
-                HookContext::with_kind_duration(BreakKind::Micro, s.micro_duration_secs),
-            );
-            sched.logger.log(EventPayload::BreakStart {
-                kind: BreakKind::Micro,
-                duration_secs: s.micro_duration_secs,
-                enforceable,
-            });
+            let delivery = deliver_scheduled_break(&app, &sched, &s, BreakKind::Micro).await;
             let mut t = sched.timers.lock().await;
             t.last_micro = Instant::now();
             t.micro_warned = false;
@@ -666,6 +538,72 @@ pub(super) async fn run_loop(app: AppHandle, sched: Scheduler) {
             }
         }
     }
+}
+
+/// Build and surface a scheduled micro/long break: resolve the per-kind
+/// content from `s`, deliver it through the configured channel, fire the
+/// `BreakStart` hook, and log the event. Returns the resolved delivery so
+/// the caller can decide whether to mark an `active_break`.
+///
+/// Timer bookkeeping stays with the caller: fixed-time and interval fires
+/// reset different timer fields, so folding them in here would just move
+/// the divergence. `Sleep` goes through the bedtime path's own
+/// `overlay::fire_break` (different postpone semantics) and never reaches
+/// this helper.
+async fn deliver_scheduled_break(
+    app: &AppHandle,
+    sched: &Scheduler,
+    s: &Settings,
+    kind: BreakKind,
+) -> BreakDelivery {
+    let (duration_secs, enforceable, manual_finish, hints) = match kind {
+        BreakKind::Long => (
+            s.long_duration_secs,
+            s.long_enforceable || s.strict_mode,
+            s.long_manual_finish,
+            effective_long_hints(s),
+        ),
+        BreakKind::Micro => (
+            s.micro_duration_secs,
+            s.micro_enforceable || s.strict_mode,
+            s.micro_manual_finish,
+            effective_micro_hints(s),
+        ),
+        BreakKind::Sleep => unreachable!("sleep breaks use the bedtime fire path"),
+    };
+    let intensity = sched.stats.lock().await.intensity();
+    let delivery = delivery_for(kind, s);
+    deliver_break(
+        app,
+        &sched.current_break,
+        BreakEvent {
+            kind,
+            duration_secs,
+            enforceable,
+            manual_finish,
+            postpone_available: s.postpone_enabled && !s.strict_mode,
+            hints,
+            hint_rotate_seconds: s.hint_rotate_seconds,
+            health_intensity: if s.break_health_enabled {
+                intensity
+            } else {
+                0.0
+            },
+        },
+        delivery,
+        s.monitor_placement,
+    );
+    hooks::run_hooks(
+        s,
+        HookEvent::BreakStart,
+        HookContext::with_kind_duration(kind, duration_secs),
+    );
+    sched.logger.log(EventPayload::BreakStart {
+        kind,
+        duration_secs,
+        enforceable,
+    });
+    delivery
 }
 
 /// Rate-limit window for repeated `UserIdle::get_time` failure warnings.

--- a/src-tauri/src/scheduler/run_loop.rs
+++ b/src-tauri/src/scheduler/run_loop.rs
@@ -18,8 +18,8 @@ use super::session_lock;
 use super::settings::{delivery_for, effective_long_hints, effective_micro_hints, Settings};
 use super::timers::{
     current_minutes, decide_bedtime, in_window, interval_break_due, local_today_string, parse_hhmm,
-    prebreak_warn_due, should_defer_for_typing, should_fire_fixed_now, BedtimeAction,
-    BedtimeWindow, PrebreakGate,
+    prebreak_warn_due, record_scheduled_fire, should_defer_for_typing, should_fire_fixed_now,
+    BedtimeAction, BedtimeWindow, PrebreakGate,
 };
 use super::types::{BreakDelivery, BreakEvent, BreakKind, SuppressReason};
 use super::Scheduler;
@@ -358,30 +358,27 @@ pub(super) async fn run_loop(app: AppHandle, sched: Scheduler) {
             };
             // Fixed-time fires bypass the idle gate: the clock is the signal, not user activity.
             if fire_long {
-                let delivery = deliver_scheduled_break(&app, &sched, &s, BreakKind::Long).await;
-                let mut t = sched.timers.lock().await;
-                t.last_long = Instant::now();
-                t.last_micro = Instant::now();
-                t.long_warned = false;
-                t.micro_warned = false;
-                t.long_deferred_since = None;
-                t.micro_deferred_since = None;
-                if matches!(delivery, BreakDelivery::Overlay | BreakDelivery::Windowed) {
-                    t.active_break = Some(BreakKind::Long);
-                }
-                t.last_long_fixed_fire = Some((today_str.clone(), now_min));
+                fire_scheduled_break(
+                    &app,
+                    &sched,
+                    &s,
+                    BreakKind::Long,
+                    Instant::now(),
+                    Some((today_str.clone(), now_min)),
+                )
+                .await;
                 continue;
             }
             if fire_micro {
-                let delivery = deliver_scheduled_break(&app, &sched, &s, BreakKind::Micro).await;
-                let mut t = sched.timers.lock().await;
-                t.last_micro = Instant::now();
-                t.micro_warned = false;
-                t.micro_deferred_since = None;
-                if matches!(delivery, BreakDelivery::Overlay | BreakDelivery::Windowed) {
-                    t.active_break = Some(BreakKind::Micro);
-                }
-                t.last_micro_fixed_fire = Some((today_str.clone(), now_min));
+                fire_scheduled_break(
+                    &app,
+                    &sched,
+                    &s,
+                    BreakKind::Micro,
+                    Instant::now(),
+                    Some((today_str.clone(), now_min)),
+                )
+                .await;
                 continue;
             }
         }
@@ -516,28 +513,30 @@ pub(super) async fn run_loop(app: AppHandle, sched: Scheduler) {
         }
 
         if should_fire_long {
-            let delivery = deliver_scheduled_break(&app, &sched, &s, BreakKind::Long).await;
-            let mut t = sched.timers.lock().await;
-            t.last_long = Instant::now();
-            t.last_micro = Instant::now();
-            t.long_warned = false;
-            t.micro_warned = false;
-            t.long_deferred_since = None;
-            t.micro_deferred_since = None;
-            if matches!(delivery, BreakDelivery::Overlay | BreakDelivery::Windowed) {
-                t.active_break = Some(BreakKind::Long);
-            }
+            fire_scheduled_break(&app, &sched, &s, BreakKind::Long, Instant::now(), None).await;
         } else if should_fire_micro {
-            let delivery = deliver_scheduled_break(&app, &sched, &s, BreakKind::Micro).await;
-            let mut t = sched.timers.lock().await;
-            t.last_micro = Instant::now();
-            t.micro_warned = false;
-            t.micro_deferred_since = None;
-            if matches!(delivery, BreakDelivery::Overlay | BreakDelivery::Windowed) {
-                t.active_break = Some(BreakKind::Micro);
-            }
+            fire_scheduled_break(&app, &sched, &s, BreakKind::Micro, Instant::now(), None).await;
         }
     }
+}
+
+/// Fire a scheduled micro/long break end to end: deliver it (see
+/// [`deliver_scheduled_break`]) and apply the post-fire timer bookkeeping
+/// under the timers lock (see [`record_scheduled_fire`]). `now` and
+/// `fixed_key` are threaded straight through to the bookkeeping — the live
+/// call sites pass `Instant::now()` and `Some((today, minute))` for a
+/// fixed-time fire or `None` for an interval fire.
+async fn fire_scheduled_break<R: Runtime>(
+    app: &AppHandle<R>,
+    sched: &Scheduler,
+    s: &Settings,
+    kind: BreakKind,
+    now: Instant,
+    fixed_key: Option<(String, u32)>,
+) {
+    let delivery = deliver_scheduled_break(app, sched, s, kind).await;
+    let mut t = sched.timers.lock().await;
+    record_scheduled_fire(&mut t, kind, delivery, now, fixed_key);
 }
 
 /// Build and surface a scheduled micro/long break: resolve the per-kind
@@ -545,11 +544,11 @@ pub(super) async fn run_loop(app: AppHandle, sched: Scheduler) {
 /// `BreakStart` hook, and log the event. Returns the resolved delivery so
 /// the caller can decide whether to mark an `active_break`.
 ///
-/// Timer bookkeeping stays with the caller: fixed-time and interval fires
-/// reset different timer fields, so folding them in here would just move
-/// the divergence. `Sleep` goes through the bedtime path's own
-/// `overlay::fire_break` (different postpone semantics) and never reaches
-/// this helper.
+/// Timer bookkeeping stays with the caller ([`fire_scheduled_break`]):
+/// fixed-time and interval fires reset different timer fields, so folding
+/// them in here would just move the divergence. `Sleep` goes through the
+/// bedtime path's own `overlay::fire_break` (different postpone semantics)
+/// and never reaches this helper.
 async fn deliver_scheduled_break<R: Runtime>(
     app: &AppHandle<R>,
     sched: &Scheduler,
@@ -1094,6 +1093,52 @@ mod tests {
         assert_eq!(delivery, BreakDelivery::Notification);
         // Notification delivery must not stash an overlay break.
         assert!(sched.current_break.lock().unwrap().is_none());
+    }
+
+    // Drives `fire_scheduled_break` end to end: the notification delivery
+    // plus the post-fire timer bookkeeping it applies under the lock.
+    // Gated off Windows for the same mock-rig reason as the glue test above.
+    #[cfg(not(target_os = "windows"))]
+    #[tokio::test]
+    #[allow(clippy::field_reassign_with_default)]
+    async fn fire_scheduled_break_delivers_then_records_timers() {
+        use crate::test_support::test_scheduler;
+        use tauri::test::{mock_builder, mock_context, noop_assets};
+        use tauri::Manager;
+
+        let mut settings = Settings::default();
+        settings.micro_break_mode = "notification".into();
+        let (_dir, sched) = test_scheduler(settings.clone());
+        {
+            let mut t = sched.timers.lock().await;
+            t.micro_warned = true;
+            t.micro_deferred_since = Some(Instant::now());
+        }
+
+        let app = mock_builder()
+            .plugin(tauri_plugin_notification::init())
+            .build(mock_context(noop_assets()))
+            .expect("mock app builds");
+        app.manage(sched.clone());
+
+        let now = Instant::now();
+        fire_scheduled_break(
+            app.handle(),
+            &sched,
+            &settings,
+            BreakKind::Micro,
+            now,
+            Some(("2026-06-02".into(), 600)),
+        )
+        .await;
+
+        let t = sched.timers.lock().await;
+        assert_eq!(t.last_micro, now);
+        assert!(!t.micro_warned);
+        assert_eq!(t.micro_deferred_since, None);
+        assert_eq!(t.last_micro_fixed_fire, Some(("2026-06-02".into(), 600)));
+        // Notification delivery must not stash an active break.
+        assert_eq!(t.active_break, None);
     }
 
     #[test]

--- a/src-tauri/src/scheduler/run_loop.rs
+++ b/src-tauri/src/scheduler/run_loop.rs
@@ -2,7 +2,7 @@ use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU8, Ordering};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use sysinfo::{ProcessesToUpdate, System};
-use tauri::{AppHandle, Emitter};
+use tauri::{AppHandle, Emitter, Runtime};
 use tauri_plugin_notification::NotificationExt;
 use tokio::time::sleep;
 use user_idle::UserIdle;
@@ -550,12 +550,44 @@ pub(super) async fn run_loop(app: AppHandle, sched: Scheduler) {
 /// the divergence. `Sleep` goes through the bedtime path's own
 /// `overlay::fire_break` (different postpone semantics) and never reaches
 /// this helper.
-async fn deliver_scheduled_break(
-    app: &AppHandle,
+async fn deliver_scheduled_break<R: Runtime>(
+    app: &AppHandle<R>,
     sched: &Scheduler,
     s: &Settings,
     kind: BreakKind,
 ) -> BreakDelivery {
+    let intensity = sched.stats.lock().await.intensity();
+    let event = scheduled_break_event(kind, s, intensity);
+    let duration_secs = event.duration_secs;
+    let enforceable = event.enforceable;
+    let delivery = delivery_for(kind, s);
+    deliver_break(
+        app,
+        &sched.current_break,
+        event,
+        delivery,
+        s.monitor_placement,
+    );
+    hooks::run_hooks(
+        s,
+        HookEvent::BreakStart,
+        HookContext::with_kind_duration(kind, duration_secs),
+    );
+    sched.logger.log(EventPayload::BreakStart {
+        kind,
+        duration_secs,
+        enforceable,
+    });
+    delivery
+}
+
+/// Resolve the per-kind `BreakEvent` content for a scheduled micro/long
+/// break. Pure (no I/O) so the field resolution — which fields each kind
+/// draws, the strict-mode postpone lock, the break-health intensity gate
+/// — is unit-testable without a windowing runtime. `intensity` is the
+/// live value from the stats lock; the helper applies the
+/// `break_health_enabled` gate. Sleep never reaches here (bedtime path).
+fn scheduled_break_event(kind: BreakKind, s: &Settings, intensity: f32) -> BreakEvent {
     let (duration_secs, enforceable, manual_finish, hints) = match kind {
         BreakKind::Long => (
             s.long_duration_secs,
@@ -571,39 +603,20 @@ async fn deliver_scheduled_break(
         ),
         BreakKind::Sleep => unreachable!("sleep breaks use the bedtime fire path"),
     };
-    let intensity = sched.stats.lock().await.intensity();
-    let delivery = delivery_for(kind, s);
-    deliver_break(
-        app,
-        &sched.current_break,
-        BreakEvent {
-            kind,
-            duration_secs,
-            enforceable,
-            manual_finish,
-            postpone_available: s.postpone_enabled && !s.strict_mode,
-            hints,
-            hint_rotate_seconds: s.hint_rotate_seconds,
-            health_intensity: if s.break_health_enabled {
-                intensity
-            } else {
-                0.0
-            },
-        },
-        delivery,
-        s.monitor_placement,
-    );
-    hooks::run_hooks(
-        s,
-        HookEvent::BreakStart,
-        HookContext::with_kind_duration(kind, duration_secs),
-    );
-    sched.logger.log(EventPayload::BreakStart {
+    BreakEvent {
         kind,
         duration_secs,
         enforceable,
-    });
-    delivery
+        manual_finish,
+        postpone_available: s.postpone_enabled && !s.strict_mode,
+        hints,
+        hint_rotate_seconds: s.hint_rotate_seconds,
+        health_intensity: if s.break_health_enabled {
+            intensity
+        } else {
+            0.0
+        },
+    }
 }
 
 /// Rate-limit window for repeated `UserIdle::get_time` failure warnings.
@@ -1050,6 +1063,89 @@ fn process_match(running: &str, target: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // Drives `deliver_scheduled_break` end to end through the
+    // Notification delivery path — the one branch that doesn't enumerate
+    // monitors (Tauri's MockRuntime leaves monitor APIs unimplemented, so
+    // the overlay path can't run under test). Covers the orchestration
+    // glue: stats lock, event build, delivery routing, hook + log. Gated
+    // off Windows because the mock rig is.
+    #[cfg(not(target_os = "windows"))]
+    #[tokio::test]
+    #[allow(clippy::field_reassign_with_default)]
+    async fn deliver_scheduled_break_notification_path_runs_glue() {
+        use crate::test_support::test_scheduler;
+        use tauri::test::{mock_builder, mock_context, noop_assets};
+        use tauri::Manager;
+
+        let mut settings = Settings::default();
+        settings.micro_break_mode = "notification".into();
+        let (_dir, sched) = test_scheduler(settings.clone());
+
+        let app = mock_builder()
+            .plugin(tauri_plugin_notification::init())
+            .build(mock_context(noop_assets()))
+            .expect("mock app builds");
+        app.manage(sched.clone());
+
+        let delivery =
+            deliver_scheduled_break(app.handle(), &sched, &settings, BreakKind::Micro).await;
+
+        assert_eq!(delivery, BreakDelivery::Notification);
+        // Notification delivery must not stash an overlay break.
+        assert!(sched.current_break.lock().unwrap().is_none());
+    }
+
+    #[test]
+    fn scheduled_break_event_long_draws_long_fields() {
+        let s = Settings::default();
+        let e = scheduled_break_event(BreakKind::Long, &s, 0.5);
+        assert_eq!(e.kind, BreakKind::Long);
+        assert_eq!(e.duration_secs, s.long_duration_secs);
+        assert_eq!(e.manual_finish, s.long_manual_finish);
+        assert_eq!(e.hints, effective_long_hints(&s));
+        // break_health is enabled by default → live intensity passes through.
+        assert_eq!(e.health_intensity, 0.5);
+    }
+
+    #[test]
+    fn scheduled_break_event_micro_draws_micro_fields() {
+        let s = Settings::default();
+        let e = scheduled_break_event(BreakKind::Micro, &s, 0.5);
+        assert_eq!(e.kind, BreakKind::Micro);
+        assert_eq!(e.duration_secs, s.micro_duration_secs);
+        assert_eq!(e.manual_finish, s.micro_manual_finish);
+        assert_eq!(e.hints, effective_micro_hints(&s));
+    }
+
+    #[test]
+    #[should_panic(expected = "sleep breaks use the bedtime fire path")]
+    fn scheduled_break_event_rejects_sleep() {
+        // Sleep is delivered through the bedtime path, never this helper;
+        // the invariant is enforced with a panic and asserted here.
+        let s = Settings::default();
+        let _ = scheduled_break_event(BreakKind::Sleep, &s, 0.0);
+    }
+
+    #[test]
+    #[allow(clippy::field_reassign_with_default)]
+    fn scheduled_break_event_health_gate_zeroes_intensity_when_disabled() {
+        let mut s = Settings::default();
+        s.break_health_enabled = false;
+        let e = scheduled_break_event(BreakKind::Long, &s, 0.42);
+        assert_eq!(e.health_intensity, 0.0);
+    }
+
+    #[test]
+    #[allow(clippy::field_reassign_with_default)]
+    fn scheduled_break_event_strict_mode_forces_enforceable_and_no_postpone() {
+        let mut s = Settings::default();
+        s.strict_mode = true;
+        s.postpone_enabled = true;
+        let e = scheduled_break_event(BreakKind::Long, &s, 0.0);
+        assert!(e.enforceable, "strict mode forces enforceable");
+        assert!(!e.postpone_available, "strict mode disables postpone");
+    }
 
     #[test]
     fn import_pending_returns_false_when_flag_clear() {

--- a/src-tauri/src/scheduler/settings.rs
+++ b/src-tauri/src/scheduler/settings.rs
@@ -951,6 +951,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::field_reassign_with_default)]
     fn schedule_mode_helpers_match_interval_fixed_and_both() {
         let mut s = Settings::default();
 
@@ -972,6 +973,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::field_reassign_with_default)]
     fn schedule_mode_helpers_reject_unknown_and_sleep() {
         let mut s = Settings::default();
         s.micro_schedule_mode = "garbage".into();

--- a/src-tauri/src/scheduler/settings.rs
+++ b/src-tauri/src/scheduler/settings.rs
@@ -393,6 +393,29 @@ impl Default for Settings {
 }
 
 impl Settings {
+    /// The raw `*_schedule_mode` string for the given break kind. Sleep
+    /// has no interval/fixed split, so it reports an empty mode.
+    fn schedule_mode_for(&self, kind: BreakKind) -> &str {
+        match kind {
+            BreakKind::Micro => self.micro_schedule_mode.as_str(),
+            BreakKind::Long => self.long_schedule_mode.as_str(),
+            BreakKind::Sleep => "",
+        }
+    }
+
+    /// True iff this break kind's schedule fires on a repeating interval
+    /// (`"interval"` or `"both"`). Centralises the mode string-matching
+    /// the run loop would otherwise duplicate at every call site.
+    pub fn interval_active(&self, kind: BreakKind) -> bool {
+        matches!(self.schedule_mode_for(kind), "interval" | "both")
+    }
+
+    /// True iff this break kind's schedule fires at fixed clock times
+    /// (`"fixed"` or `"both"`).
+    pub fn fixed_active(&self, kind: BreakKind) -> bool {
+        matches!(self.schedule_mode_for(kind), "fixed" | "both")
+    }
+
     /// Clamp every numeric field to a safe range. Called on every load
     /// (post-deserialise) and on every write (post-merge) so that a
     /// hand-edited or corrupted `settings.json` can't make the
@@ -925,6 +948,38 @@ mod tests {
         assert!(s.long_fixed_times.is_empty());
         assert_eq!(s.micro_schedule_mode, "interval");
         assert_eq!(s.long_schedule_mode, "interval");
+    }
+
+    #[test]
+    fn schedule_mode_helpers_match_interval_fixed_and_both() {
+        let mut s = Settings::default();
+
+        s.micro_schedule_mode = "interval".into();
+        assert!(s.interval_active(BreakKind::Micro));
+        assert!(!s.fixed_active(BreakKind::Micro));
+
+        s.micro_schedule_mode = "fixed".into();
+        assert!(!s.interval_active(BreakKind::Micro));
+        assert!(s.fixed_active(BreakKind::Micro));
+
+        s.micro_schedule_mode = "both".into();
+        assert!(s.interval_active(BreakKind::Micro));
+        assert!(s.fixed_active(BreakKind::Micro));
+
+        s.long_schedule_mode = "interval".into();
+        assert!(s.interval_active(BreakKind::Long));
+        assert!(!s.fixed_active(BreakKind::Long));
+    }
+
+    #[test]
+    fn schedule_mode_helpers_reject_unknown_and_sleep() {
+        let mut s = Settings::default();
+        s.micro_schedule_mode = "garbage".into();
+        assert!(!s.interval_active(BreakKind::Micro));
+        assert!(!s.fixed_active(BreakKind::Micro));
+        // Sleep has no interval/fixed split: both helpers report false.
+        assert!(!s.interval_active(BreakKind::Sleep));
+        assert!(!s.fixed_active(BreakKind::Sleep));
     }
 
     #[test]

--- a/src-tauri/src/scheduler/timers.rs
+++ b/src-tauri/src/scheduler/timers.rs
@@ -2,7 +2,7 @@ use std::time::{Duration, Instant};
 
 use chrono::{Local, Timelike};
 
-use super::types::BreakKind;
+use super::types::{BreakDelivery, BreakKind};
 
 /// All of the scheduler's per-tick mutable timing state.
 ///
@@ -68,6 +68,57 @@ pub fn reset_timers_keep_sleep(t: &mut BreakTimers) {
     t.long_deferred_since = None;
     t.micro_postpone_count = 0;
     t.long_postpone_count = 0;
+}
+
+/// Apply the timer bookkeeping for a scheduled micro/long break that has
+/// just fired. Pure analogue of the inline resets in `run_loop`'s
+/// fixed-time and interval fire paths, so the field-by-field divergence
+/// between the two break kinds (and between a fixed vs interval fire) is
+/// unit-testable without a windowing runtime or a live clock.
+///
+/// - A `Long` fire resets *both* interval clocks (a long break implies a
+///   micro break just happened) and clears both warn/deferral flags; a
+///   `Micro` fire touches only the micro fields.
+/// - `now` is injected (the live call site passes `Instant::now()`).
+/// - `fixed_key` is `Some((local-date, minute-of-day))` for a fixed-time
+///   fire — recording the dedupe key — and `None` for an interval fire.
+/// - `active_break` is only stashed for deliveries that hold the screen
+///   (`Overlay` / `Windowed`); a `Notification` leaves it unset.
+///
+/// `Sleep` never reaches here (it uses the bedtime fire path) and is a
+/// no-op for the per-kind resets.
+pub fn record_scheduled_fire(
+    t: &mut BreakTimers,
+    kind: BreakKind,
+    delivery: BreakDelivery,
+    now: Instant,
+    fixed_key: Option<(String, u32)>,
+) {
+    match kind {
+        BreakKind::Long => {
+            t.last_long = now;
+            t.last_micro = now;
+            t.long_warned = false;
+            t.micro_warned = false;
+            t.long_deferred_since = None;
+            t.micro_deferred_since = None;
+            if let Some(key) = fixed_key {
+                t.last_long_fixed_fire = Some(key);
+            }
+        }
+        BreakKind::Micro => {
+            t.last_micro = now;
+            t.micro_warned = false;
+            t.micro_deferred_since = None;
+            if let Some(key) = fixed_key {
+                t.last_micro_fixed_fire = Some(key);
+            }
+        }
+        BreakKind::Sleep => {}
+    }
+    if matches!(delivery, BreakDelivery::Overlay | BreakDelivery::Windowed) {
+        t.active_break = Some(kind);
+    }
 }
 
 /// Clear the "resume last skipped break" slot. Returns `true` iff a
@@ -921,5 +972,121 @@ mod tests {
             decide_bedtime(window_2209(), 12 * 60, Some(now), now, true),
             BedtimeAction::NotInWindow
         );
+    }
+
+    fn dirty_timers() -> BreakTimers {
+        let mut t = BreakTimers::new();
+        t.micro_warned = true;
+        t.long_warned = true;
+        t.micro_deferred_since = Some(Instant::now());
+        t.long_deferred_since = Some(Instant::now());
+        t
+    }
+
+    #[test]
+    fn record_scheduled_fire_long_resets_both_clocks_and_records_fixed_key() {
+        let mut t = dirty_timers();
+        let now = Instant::now();
+        record_scheduled_fire(
+            &mut t,
+            BreakKind::Long,
+            BreakDelivery::Overlay,
+            now,
+            Some(("2026-06-02".into(), 540)),
+        );
+        assert_eq!(t.last_long, now);
+        assert_eq!(t.last_micro, now);
+        assert!(!t.long_warned);
+        assert!(!t.micro_warned);
+        assert_eq!(t.long_deferred_since, None);
+        assert_eq!(t.micro_deferred_since, None);
+        assert_eq!(t.active_break, Some(BreakKind::Long));
+        assert_eq!(t.last_long_fixed_fire, Some(("2026-06-02".into(), 540)));
+        assert_eq!(t.last_micro_fixed_fire, None);
+    }
+
+    #[test]
+    fn record_scheduled_fire_micro_touches_only_micro_fields() {
+        let mut t = dirty_timers();
+        let before_long = t.last_long;
+        let now = Instant::now();
+        record_scheduled_fire(
+            &mut t,
+            BreakKind::Micro,
+            BreakDelivery::Overlay,
+            now,
+            Some(("2026-06-02".into(), 600)),
+        );
+        assert_eq!(t.last_micro, now);
+        assert_eq!(t.last_long, before_long);
+        assert!(!t.micro_warned);
+        assert!(
+            t.long_warned,
+            "micro fire must not clear the long warn flag"
+        );
+        assert_eq!(t.micro_deferred_since, None);
+        assert!(t.long_deferred_since.is_some());
+        assert_eq!(t.active_break, Some(BreakKind::Micro));
+        assert_eq!(t.last_micro_fixed_fire, Some(("2026-06-02".into(), 600)));
+        assert_eq!(t.last_long_fixed_fire, None);
+    }
+
+    #[test]
+    fn record_scheduled_fire_interval_leaves_fixed_keys_untouched() {
+        let mut t = BreakTimers::new();
+        t.last_long_fixed_fire = Some(("2026-06-01".into(), 100));
+        record_scheduled_fire(
+            &mut t,
+            BreakKind::Long,
+            BreakDelivery::Overlay,
+            Instant::now(),
+            None,
+        );
+        assert_eq!(t.last_long_fixed_fire, Some(("2026-06-01".into(), 100)));
+    }
+
+    #[test]
+    fn record_scheduled_fire_notification_does_not_stash_active_break() {
+        let mut t = BreakTimers::new();
+        record_scheduled_fire(
+            &mut t,
+            BreakKind::Micro,
+            BreakDelivery::Notification,
+            Instant::now(),
+            None,
+        );
+        assert_eq!(t.active_break, None);
+    }
+
+    #[test]
+    fn record_scheduled_fire_windowed_stashes_active_break() {
+        let mut t = BreakTimers::new();
+        record_scheduled_fire(
+            &mut t,
+            BreakKind::Long,
+            BreakDelivery::Windowed,
+            Instant::now(),
+            None,
+        );
+        assert_eq!(t.active_break, Some(BreakKind::Long));
+    }
+
+    #[test]
+    fn record_scheduled_fire_sleep_is_a_noop_for_per_kind_state() {
+        let mut t = dirty_timers();
+        let before_micro = t.last_micro;
+        let before_long = t.last_long;
+        record_scheduled_fire(
+            &mut t,
+            BreakKind::Sleep,
+            BreakDelivery::Notification,
+            Instant::now(),
+            None,
+        );
+        assert_eq!(t.last_micro, before_micro);
+        assert_eq!(t.last_long, before_long);
+        assert!(t.micro_warned);
+        assert!(t.long_warned);
+        assert_eq!(t.active_break, None);
     }
 }

--- a/src/lib/clock-list.ts
+++ b/src/lib/clock-list.ts
@@ -1,15 +1,9 @@
-import { formatMinutesOfDay, parseMinutesOfDay } from "./time";
-
-function toMinutes(s: string): number {
-  const [h, m] = s.split(":").map(Number);
-  return h * 60 + m;
-}
-
-function minutesToHhmm(minutes: number): string {
-  const h = Math.floor(minutes / 60);
-  const mm = minutes % 60;
-  return `${String(h).padStart(2, "0")}:${String(mm).padStart(2, "0")}`;
-}
+import {
+  formatMinutesOfDay,
+  minutesToTime,
+  parseMinutesOfDay,
+  timeToMinutes,
+} from "./time";
 
 /**
  * Parse the user's comma-separated fixed-times text field into the
@@ -29,7 +23,7 @@ export function parseClockList(text: string): string[] {
   }
   const unique = Array.from(new Set(minutes));
   unique.sort((a, b) => a - b);
-  return unique.map(minutesToHhmm);
+  return unique.map(minutesToTime);
 }
 
 /** Comma-join the stored 24h `"HH:MM"` list, formatting each entry in
@@ -39,5 +33,5 @@ export function formatClockList(
   format: "12h" | "24h" = "24h",
 ): string {
   if (format === "24h") return times.join(", ");
-  return times.map((t) => formatMinutesOfDay(toMinutes(t), "12h")).join(", ");
+  return times.map((t) => formatMinutesOfDay(timeToMinutes(t), "12h")).join(", ");
 }

--- a/src/lib/clock-list.ts
+++ b/src/lib/clock-list.ts
@@ -33,5 +33,7 @@ export function formatClockList(
   format: "12h" | "24h" = "24h",
 ): string {
   if (format === "24h") return times.join(", ");
-  return times.map((t) => formatMinutesOfDay(timeToMinutes(t), "12h")).join(", ");
+  return times
+    .map((t) => formatMinutesOfDay(timeToMinutes(t), "12h"))
+    .join(", ");
 }

--- a/src/lib/use-local-draft.test.ts
+++ b/src/lib/use-local-draft.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { useLocalDraft } from "./use-local-draft";
+
+describe("useLocalDraft", () => {
+  it("seeds the draft from compute on first render", () => {
+    const { result } = renderHook(() =>
+      useLocalDraft(() => "hello".toUpperCase(), []),
+    );
+    expect(result.current[0]).toBe("HELLO");
+  });
+
+  it("keeps local edits when deps are unchanged across re-renders", () => {
+    const { result, rerender } = renderHook(
+      ({ source }) => useLocalDraft(() => source, [source]),
+      { initialProps: { source: "a" } },
+    );
+
+    act(() => result.current[1]("edited"));
+    expect(result.current[0]).toBe("edited");
+
+    rerender({ source: "a" });
+    expect(result.current[0]).toBe("edited");
+  });
+
+  it("re-seeds the draft when a dep changes", () => {
+    const { result, rerender } = renderHook(
+      ({ source }) => useLocalDraft(() => source.toUpperCase(), [source]),
+      { initialProps: { source: "a" } },
+    );
+
+    act(() => result.current[1]("edited"));
+    expect(result.current[0]).toBe("edited");
+
+    rerender({ source: "b" });
+    expect(result.current[0]).toBe("B");
+  });
+
+  it("re-seeds when any dep in a multi-dep list changes", () => {
+    const { result, rerender } = renderHook(
+      ({ value, fmt }) => useLocalDraft(() => `${value}:${fmt}`, [value, fmt]),
+      { initialProps: { value: "x", fmt: "24h" } },
+    );
+    expect(result.current[0]).toBe("x:24h");
+
+    rerender({ value: "x", fmt: "12h" });
+    expect(result.current[0]).toBe("x:12h");
+  });
+});

--- a/src/lib/use-local-draft.ts
+++ b/src/lib/use-local-draft.ts
@@ -1,0 +1,32 @@
+import {
+  useEffect,
+  useRef,
+  useState,
+  type DependencyList,
+  type Dispatch,
+  type SetStateAction,
+} from "react";
+
+/**
+ * Editable local copy of a value derived from upstream state (typically
+ * a setting), re-seeded whenever `deps` change — e.g. when the active
+ * profile swaps the underlying setting out from under an open textarea.
+ *
+ * `compute` produces both the initial draft and each re-seed. It is read
+ * through a ref so callers can pass a fresh closure every render without
+ * having to add it to `deps`.
+ */
+export function useLocalDraft<T>(
+  compute: () => T,
+  deps: DependencyList,
+): [T, Dispatch<SetStateAction<T>>] {
+  const computeRef = useRef(compute);
+  computeRef.current = compute;
+  const [draft, setDraft] = useState(compute);
+  useEffect(() => {
+    setDraft(computeRef.current());
+    // `compute` is intentionally excluded — it is read from a ref so the
+    // re-seed tracks only the caller-supplied `deps`.
+  }, deps);
+  return [draft, setDraft];
+}

--- a/src/views/break-overlay/hooks/use-break-state.ts
+++ b/src/views/break-overlay/hooks/use-break-state.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { pickRotationTheme } from "../../../lib/color";
@@ -52,6 +52,13 @@ export function useBreakState(deps: BreakStateDeps = {}): BreakStateApi {
   );
   const [resolvedTheme, setResolvedTheme] = useState<string>("dark");
   const startedAtRef = useRef<number>(0);
+
+  const clearBreak = useCallback(() => {
+    setActive(null);
+    setRemaining(0);
+    setFinished(false);
+    setPostponeState(null);
+  }, []);
 
   useEffect(() => {
     let cancelled = false;
@@ -120,10 +127,7 @@ export function useBreakState(deps: BreakStateDeps = {}): BreakStateApi {
     });
     listenFn("break:end", () => {
       console.info("[overlay] break:end");
-      setActive(null);
-      setRemaining(0);
-      setFinished(false);
-      setPostponeState(null);
+      clearBreak();
     }).then((fn) => {
       if (cancelled) fn();
       else unlistenEndFn = fn;
@@ -140,14 +144,7 @@ export function useBreakState(deps: BreakStateDeps = {}): BreakStateApi {
       unlistenStartFn?.();
       unlistenEndFn?.();
     };
-  }, [invokeFn, listenFn, stopAllSoundsFn]);
-
-  const clearBreak = () => {
-    setActive(null);
-    setRemaining(0);
-    setFinished(false);
-    setPostponeState(null);
-  };
+  }, [invokeFn, listenFn, stopAllSoundsFn, clearBreak]);
 
   return {
     active,

--- a/src/views/settings/tabs/breaks-tab.tsx
+++ b/src/views/settings/tabs/breaks-tab.tsx
@@ -1,11 +1,11 @@
 import { invoke } from "@tauri-apps/api/core";
-import { useEffect, useState } from "react";
 import {
   clampCsvToDark,
   hexToRgbCsv,
   normalizeHexInput,
   rgbCsvToHex,
 } from "../../../lib/color";
+import { useLocalDraft } from "../../../lib/use-local-draft";
 import { Advanced } from "../components/advanced";
 import { CheckboxRow, NumberRow } from "../components/rows";
 import { InfoTip } from "../components/info-tip";
@@ -32,38 +32,35 @@ export function BreaksTab({
   supporter: SupporterStatus;
 }) {
   const isSupporter = supporter.is_supporter;
-  const [microPhysical, setMicroPhysical] = useState(
-    listToLines(settings.micro_physical_hints),
+  // Local drafts re-seed when the active profile swaps the setting out.
+  const [microPhysical, setMicroPhysical] = useLocalDraft(
+    () => listToLines(settings.micro_physical_hints),
+    [settings.micro_physical_hints],
   );
-  const [microPsychological, setMicroPsychological] = useState(
-    listToLines(settings.micro_psychological_hints),
+  const [microPsychological, setMicroPsychological] = useLocalDraft(
+    () => listToLines(settings.micro_psychological_hints),
+    [settings.micro_psychological_hints],
   );
-  const [longSolo, setLongSolo] = useState(listToLines(settings.long_hints));
-  const [longSocial, setLongSocial] = useState(
-    listToLines(settings.long_social_hints),
+  const [longSolo, setLongSolo] = useLocalDraft(
+    () => listToLines(settings.long_hints),
+    [settings.long_hints],
   );
-  const [sleep, setSleep] = useState(listToLines(settings.sleep_hints));
-  const [customCss, setCustomCss] = useState(settings.custom_css);
+  const [longSocial, setLongSocial] = useLocalDraft(
+    () => listToLines(settings.long_social_hints),
+    [settings.long_social_hints],
+  );
+  const [sleep, setSleep] = useLocalDraft(
+    () => listToLines(settings.sleep_hints),
+    [settings.sleep_hints],
+  );
+  const [customCss, setCustomCss] = useLocalDraft(
+    () => settings.custom_css,
+    [settings.custom_css],
+  );
 
-  // Re-seed when the active profile changes underneath us.
-  useEffect(() => {
-    setMicroPhysical(listToLines(settings.micro_physical_hints));
-  }, [settings.micro_physical_hints]);
-  useEffect(() => {
-    setMicroPsychological(listToLines(settings.micro_psychological_hints));
-  }, [settings.micro_psychological_hints]);
-  useEffect(() => {
-    setLongSolo(listToLines(settings.long_hints));
-  }, [settings.long_hints]);
-  useEffect(() => {
-    setLongSocial(listToLines(settings.long_social_hints));
-  }, [settings.long_social_hints]);
-  useEffect(() => {
-    setSleep(listToLines(settings.sleep_hints));
-  }, [settings.sleep_hints]);
-  useEffect(() => {
-    setCustomCss(settings.custom_css);
-  }, [settings.custom_css]);
+  const transparencyPct = Math.round((1 - settings.overlay_opacity) * 100);
+  const fontScalePct = Math.round(settings.overlay_font_scale * 100);
+  const soundVolumePct = Math.round(settings.sound_volume * 100);
 
   return (
     <>
@@ -80,14 +77,12 @@ export function BreaksTab({
               min={0}
               max={20}
               step={1}
-              value={Math.round((1 - settings.overlay_opacity) * 100)}
+              value={transparencyPct}
               onChange={(e) =>
                 update("overlay_opacity", 1 - Number(e.target.value) / 100)
               }
             />
-            <span className="range-value">
-              {Math.round((1 - settings.overlay_opacity) * 100)}%
-            </span>
+            <span className="range-value">{transparencyPct}%</span>
           </span>
         </label>
         <label className="row">
@@ -98,14 +93,12 @@ export function BreaksTab({
               min={80}
               max={160}
               step={5}
-              value={Math.round(settings.overlay_font_scale * 100)}
+              value={fontScalePct}
               onChange={(e) =>
                 update("overlay_font_scale", Number(e.target.value) / 100)
               }
             />
-            <span className="range-value">
-              {Math.round(settings.overlay_font_scale * 100)}%
-            </span>
+            <span className="range-value">{fontScalePct}%</span>
           </span>
         </label>
         <label className="row">
@@ -273,14 +266,12 @@ export function BreaksTab({
               min={0}
               max={100}
               step={1}
-              value={Math.round(settings.sound_volume * 100)}
+              value={soundVolumePct}
               onChange={(e) =>
                 update("sound_volume", Number(e.target.value) / 100)
               }
             />
-            <span className="range-value">
-              {Math.round(settings.sound_volume * 100)}%
-            </span>
+            <span className="range-value">{soundVolumePct}%</span>
           </span>
         </label>
       </section>

--- a/src/views/settings/tabs/schedule-tab.tsx
+++ b/src/views/settings/tabs/schedule-tab.tsx
@@ -1,6 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
-import { useEffect, useState } from "react";
 import { formatClockList, parseClockList } from "../../../lib/clock-list";
+import { useLocalDraft } from "../../../lib/use-local-draft";
 import { formatScreenTime, progressPercent } from "../../../lib/screen-time";
 import { Advanced } from "../components/advanced";
 import { BreakModeRow } from "../components/break-mode-row";
@@ -22,23 +22,14 @@ export function ScheduleTab({
   supporter: SupporterStatus;
 }) {
   const isSupporter = supporter.is_supporter;
-  const [microFixedTimesText, setMicroFixedTimesText] = useState(
-    formatClockList(settings.micro_fixed_times, settings.clock_format),
+  const [microFixedTimesText, setMicroFixedTimesText] = useLocalDraft(
+    () => formatClockList(settings.micro_fixed_times, settings.clock_format),
+    [settings.micro_fixed_times, settings.clock_format],
   );
-  const [longFixedTimesText, setLongFixedTimesText] = useState(
-    formatClockList(settings.long_fixed_times, settings.clock_format),
+  const [longFixedTimesText, setLongFixedTimesText] = useLocalDraft(
+    () => formatClockList(settings.long_fixed_times, settings.clock_format),
+    [settings.long_fixed_times, settings.clock_format],
   );
-
-  useEffect(() => {
-    setMicroFixedTimesText(
-      formatClockList(settings.micro_fixed_times, settings.clock_format),
-    );
-  }, [settings.micro_fixed_times, settings.clock_format]);
-  useEffect(() => {
-    setLongFixedTimesText(
-      formatClockList(settings.long_fixed_times, settings.clock_format),
-    );
-  }, [settings.long_fixed_times, settings.clock_format]);
 
   const screenTime = useScreenTime(settings.daily_screen_time_enabled);
 


### PR DESCRIPTION
## Summary

Quality-only cleanup from a full-codebase sweep (reuse / simplification / efficiency / altitude). **No behaviour change** — every edit preserves existing semantics; this is purely about removing duplication and naming repeated patterns.

### Rust

- **`fire_scheduled_break` + `record_scheduled_fire`** — the four near-identical break-fire blocks in `run_loop` (fixed/interval × long/micro) collapse into one async `fire_scheduled_break` (deliver + bookkeeping), with the per-kind timer resets extracted into a pure `record_scheduled_fire` in `timers.rs` (the conventional home for `run_loop`'s pure analogues). The bookkeeping — which clocks reset, the fixed-key dedupe, the overlay-only `active_break` stash — was previously inline in the untestable `run_loop` and exercised by no test; it now has six unit tests, plus a mock-runtime glue test for `fire_scheduled_break`.
- **`Settings::interval_active` / `fixed_active`** — replace four scattered `matches!(s.*_schedule_mode.as_str(), …)` checks in the run loop with intent-revealing methods.
  - **Deliberately _not_ an enum migration.** The codebase stores these modes as strings and normalizes at use-time on purpose (see `settings.rs` — "so the renderer's zod enum doesn't reject the entire settings payload"). A strict serde enum would make an unknown/hand-edited value reject the whole settings load, regressing that resilience (and there's a test guarding it). This change keeps the string storage and only centralizes the matching.

### TypeScript

- **Drop `minutesToHhmm` / `toMinutes`** from `clock-list.ts` — byte-for-byte duplicates of `minutesToTime` / `timeToMinutes` already exported from `time.ts` (and already imported there).
- **Dedup the break-reset block** in `use-break-state` into one stable `useCallback`, removing the risk of a 5th break-state field being reset in one place but not the other.
- **`useLocalDraft` hook** — names the "local draft, re-seeded when the upstream setting changes" pattern once, replacing 8 `useState`+`useEffect` pairs across `breaks-tab` (6) and `schedule-tab` (2).
- **Hoist three doubly-computed slider percentages** in `breaks-tab` to locals (single source per formula).

## Test plan

- New tests ship with the new code: **+7 Rust** (`record_scheduled_fire_*` ×6, `fire_scheduled_break_*`), **+4 TS** (`useLocalDraft`).
- `cargo build` ✓ · `cargo test --lib` **701 passed** ✓ · `cargo clippy --all-targets -D warnings` ✓ · `cargo fmt --check` ✓
- `tsc --noEmit` ✓ · full `vitest` passing ✓ · `knip` clean (one pre-existing unused type, untouched here)

## Coverage note (`codecov/patch`) — deliberate admin-bypass

`codecov/patch` fails on **9 lines, all inside `run_loop`**: the four `fire_scheduled_break(…)` dispatch call-sites, the `fixed_active` / `interval_active` method-call lines, and one shared `fixed_key` local. These are **unreachable by any unit test**: `run_loop` is the infinite 1 Hz scheduler loop, spawned only from `mod.rs` in production and entered by zero tests by design (it needs a live windowing runtime, wall-clock, and `UserIdle`/`session_lock` probes).

All _logic_ behind those lines is tested in isolation — `record_scheduled_fire`, `fire_scheduled_break`, `scheduled_break_event`, `interval_break_due`, `fixed_active`/`interval_active`. What remains uncovered is trivial dispatch glue calling those tested helpers — the same category as the existing uncovered `interval_break_due` / `should_fire_fixed_now` call-sites already living in `run_loop`. Net `run_loop.rs` patch coverage _rose_ (+9.6%); project coverage rose too.

Per the repo's coverage policy this is the reserved admin-bypass case (no test can reach the line), not a relaxation of the 100% target. Reaching literal 100% here would require extracting and dependency-injecting the entire ~480-line tick body — a major architectural change out of scope for a cleanup PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
