### PR TITLE
ci(lychee): harden against flaky external links

### DIFF
--- a/.github/audit/lychee.toml
+++ b/.github/audit/lychee.toml
@@ -5,6 +5,10 @@ accept = ["200", "206", "429"]
 max_concurrency = 8
 timeout = 20
 retry_wait_time = 2
+# Retry transient failures (connection resets, momentary 5xx) a few times
+# before failing the merge-blocking gate, so a single network blip on one
+# of ~300 external links doesn't red the whole run.
+max_retries = 5
 fallback_extensions = ["md", "html"]
 
 exclude_loopback = true
@@ -21,6 +25,16 @@ exclude = [
   # rationale as the publishers above — exclude rather than accept 403
   # globally, which would mask real auth failures elsewhere.
   '^https?://(.*\.)?freesound\.org',
+  # Canonical attribution / boilerplate links that are stable in a browser
+  # but intermittently 5xx or reset the connection against the checker:
+  #   - claude.com/claude-code: the Claude Code attribution in README / PR
+  #     bodies — returned HTTP 500 on consecutive runs (likely rejecting the
+  #     runner IP).
+  #   - contributor-covenant.org: the CoC source links — reset mid-request.
+  # Same rationale as the publishers above: exclude these canonical URLs
+  # rather than accept 500 globally, which would mask real failures.
+  '^https?://(www\.)?claude\.com',
+  '^https?://(www\.)?contributor-covenant\.org',
   # rustdoc / TypeDoc output: generated into the built site at /api/{rust,ts}/,
   # not present in source.
   '/api/(rust|ts)/',


### PR DESCRIPTION
## Summary

The merge-blocking `advisory` → lychee link-check intermittently fails on **pre-existing external links it doesn't own**, red-lining unrelated PRs:

- `https://claude.com/claude-code` (Claude Code attribution in README / PR bodies) — returned **HTTP 500** on consecutive runs (likely rejecting the runner IP). Seen on #88.
- `https://www.contributor-covenant.org/translations` (CoC source links) — **connection reset** mid-request. Seen on #89.

Both are canonical, browser-stable URLs that intermittently bot-block or 5xx the checker — exactly the category the config already excludes for DOI / academic publishers / freesound.

## Changes

- Exclude `claude.com` and `contributor-covenant.org` (with a comment explaining the rationale, matching the existing publisher/freesound excludes). Excluding canonical URLs beats `accept`-ing `500` globally, which would mask genuinely broken links elsewhere.
- Add `max_retries = 5` so a single transient blip on any of the ~300 checked links no longer fails the whole run.

## Test plan

- Ran lychee locally with the updated config against `README.md` + `CODE_OF_CONDUCT.md`: **0 errors** (previously 1 error per run on the links above).
- No source/docs content changed — config only.

Unblocks the `advisory` check on #88 and #89.

🤖 Generated with [Claude Code](https://claude.com/claude-code)