### PR TITLE
fix(overlay): show breaks on Wayland when there's no primary monitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Versions on the `0.0.X` line are public beta releases; `0.1.X` and onwards will 
 
 ### Fixed
 
+- **Breaks now appear on Wayland.** With the default `Primary` (or `Active`) monitor placement, breaks were invisible on Wayland: the compositor reports no "primary" monitor, so the overlay was targeted at an empty monitor list and no window was ever built. Entracte now falls back to the first available monitor in that case. ([#67](https://github.com/drmowinckels/entracte/issues/67))
 - **Idle-detection no longer floods the log on X11 servers without the screensaver extension.** When the windowing-system idle probe keeps failing (e.g. an X11 display with no `MIT-SCREEN-SAVER` extension, which made libX11 print a warning roughly once a second), Entracte now backs off exponentially — up to one attempt every five minutes — instead of re-querying the missing extension every tick. Idle detection still recovers automatically if the extension reappears. ([#67](https://github.com/drmowinckels/entracte/issues/67))
 
 ## [0.0.2] — 2026-05-29

--- a/src-tauri/src/scheduler/overlay.rs
+++ b/src-tauri/src/scheduler/overlay.rs
@@ -117,18 +117,31 @@ fn ensure_overlay<R: Runtime>(app: &AppHandle<R>, idx: usize) -> Option<tauri::W
     }
 }
 
+/// Pick the monitor(s) to cover for a `Primary`/`Active`-fallback break,
+/// given what the windowing system reports as the primary monitor and the
+/// full available list. Wayland has no concept of a "primary" monitor, so
+/// `tao`/Tauri returns `None` there even when `available_monitors()` lists
+/// several — without a fallback that produces an *empty* target list, so
+/// no overlay window is ever built and the break is invisible (#67). Fall
+/// back to the first available monitor in that case. Generic + pure so the
+/// fallback is unit-testable without a windowing system.
+fn primary_or_first<T: Clone>(primary: Option<T>, available: &[T]) -> Vec<T> {
+    match primary {
+        Some(m) => vec![m],
+        None => available.first().cloned().into_iter().collect(),
+    }
+}
+
 fn select_overlay_monitors<R: Runtime>(
     app: &AppHandle<R>,
     placement: MonitorPlacement,
 ) -> Vec<tauri::Monitor> {
     match placement {
         MonitorPlacement::All => app.available_monitors().unwrap_or_default(),
-        MonitorPlacement::Primary => app
-            .primary_monitor()
-            .ok()
-            .flatten()
-            .into_iter()
-            .collect::<Vec<_>>(),
+        MonitorPlacement::Primary => primary_or_first(
+            app.primary_monitor().ok().flatten(),
+            &app.available_monitors().unwrap_or_default(),
+        ),
         MonitorPlacement::Active => {
             let all = app.available_monitors().unwrap_or_default();
             if all.is_empty() {
@@ -149,12 +162,7 @@ fn select_overlay_monitors<R: Runtime>(
             };
             match idx {
                 Some(i) => vec![all[i].clone()],
-                None => app
-                    .primary_monitor()
-                    .ok()
-                    .flatten()
-                    .into_iter()
-                    .collect::<Vec<_>>(),
+                None => primary_or_first(app.primary_monitor().ok().flatten(), &all),
             }
         }
     }
@@ -314,6 +322,32 @@ mod tests {
     #[test]
     fn pick_active_monitor_returns_none_for_empty_list() {
         assert_eq!(pick_active_monitor(0.0, 0.0, &[]), None);
+    }
+
+    #[test]
+    fn primary_or_first_uses_primary_when_present() {
+        // When the platform reports a primary monitor, target exactly it
+        // — never widen to the whole list.
+        assert_eq!(
+            primary_or_first(Some("HDMI-1"), &["HDMI-1", "DP-2"]),
+            vec!["HDMI-1"]
+        );
+    }
+
+    #[test]
+    fn primary_or_first_falls_back_to_first_available_on_wayland() {
+        // The #67 case: Wayland reports no primary, but monitors exist.
+        // Must fall back to the first so an overlay still appears.
+        assert_eq!(primary_or_first(None, &["DP-2", "HDMI-1"]), vec!["DP-2"]);
+    }
+
+    #[test]
+    fn primary_or_first_empty_when_no_monitors_at_all() {
+        // No primary and no available monitors (headless / all unplugged)
+        // — nothing to target, and the caller logs the invisible-break
+        // error rather than crashing.
+        let none: Option<&str> = None;
+        assert!(primary_or_first(none, &[] as &[&str]).is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes the core symptom of #67: **breaks fire but are invisible on Wayland.**

The expanded v0.0.2 diagnostics from the reporter were decisive:

```
startup: … display=Wayland | monitors=2 …
break kind=Micro fired but NO overlay window could be shown (1 monitor(s) targeted)
```

No `failed to create break window` error appears, and it reports "1 monitor(s) targeted" despite `monitors=2` — meaning `ensure_overlay` was never called because the monitor list was **empty**. Root cause: with the default `Primary` (or `Active`) placement, `select_overlay_monitors` calls `app.primary_monitor()`, which returns `None` on Wayland (no "primary monitor" concept). The list collapsed to empty → `count = 0.max(1) = 1` → no overlay window built → invisible break. Only `All` placement worked, because it uses `available_monitors()`.

## Fix

Fall back to the first available monitor when `primary_monitor()` is `None`, via a pure generic helper:

```rust
fn primary_or_first<T: Clone>(primary: Option<T>, available: &[T]) -> Vec<T>
```

Used by both the `Primary` placement and the `Active` no-cursor fallback (Wayland also doesn't expose a global cursor position, so `Active` lands on the same fallback).

## Test plan

- 3 new unit tests on `primary_or_first` (uses primary when present; falls back to first on Wayland; empty when no monitors at all).
- `cargo test --lib` green (674), `cargo clippy --all-targets -D warnings` clean, `cargo fmt` applied.
- **Manual verification needed on a real Wayland session** (the reporter's GNOME/Wayland on Ubuntu 24.04): trigger a break / Preview and confirm the overlay now appears. The `select_overlay_monitors` wrapper itself calls Tauri windowing APIs that can't be exercised in unit tests; the decision logic is covered.

Refs #67 (the `MIT-SCREEN-SAVER` log-spam half was addressed in #88; this is the missing-overlay half).

🤖 Generated with [Claude Code](https://claude.com/claude-code)