### PR TITLE
chore(release): prep v0.0.3 — version bump + CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Versions on the `0.0.X` line are public beta releases; `0.1.X` and onwards will 
 
 ## [Unreleased]
 
+## [0.0.3] — 2026-06-01
+
+Linux-focused beta: breaks now show on Wayland, the logs are far quieter, and an optional "pause media during breaks" lands on every platform.
+
 ### Added
 
 - **Pause media while a break is showing.** A new opt-in toggle (Quiet times → During breaks) quiets whatever is playing when a break starts and resumes it when the break ends. On Linux this targets your media players precisely over MPRIS; on macOS and Windows it sends a play/pause media key as a best-effort. Off by default. ([#77](https://github.com/drmowinckels/entracte/issues/77))

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "entracte-desktop",
   "private": true,
-  "version": "0.0.2",
+  "version": "0.0.3",
   "type": "module",
   "engines": {
     "node": ">=20"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1154,7 +1154,7 @@ checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
 
 [[package]]
 name = "entracte"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "entracte"
-version = "0.0.2"
+version = "0.0.3"
 description = "Cross-platform break reminder"
 authors = ["Athanasia Mowinckel"]
 license = "Apache-2.0"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Entracte",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "identifier": "io.drmowinckels.entracte",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary

Prep for the **v0.0.3** beta. Bumps `package.json`, `Cargo.toml`, `tauri.conf.json`, and `Cargo.lock` to `0.0.3` and dates the CHANGELOG section.

What's in 0.0.3:
- **Breaks now show on Wayland** — fall back to the first available monitor when the compositor reports no primary ([#91](https://github.com/drmowinckels/entracte/pull/91), closes the main symptom of #67).
- **Much quieter logs** — idle probe ([#88](https://github.com/drmowinckels/entracte/pull/88)) and `loginctl` lock probe ([#92](https://github.com/drmowinckels/entracte/pull/92)) now back off and log once instead of every second/minute.
- **Pause media while a break is showing** — opt-in, off by default ([#89](https://github.com/drmowinckels/entracte/pull/89)).
- CI: lychee link-check hardened against flaky external links ([#90](https://github.com/drmowinckels/entracte/pull/90)).

## Test plan

- `cargo check --lib` green at `v0.0.3` (Cargo.lock ↔ Cargo.toml consistent).
- No code change — version + CHANGELOG only. Once merged, tag `v0.0.3` triggers the release build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)