### PR TITLE
fix: HiDPI Wayland overlay, idle-defer stall, and sound preview UX (#67)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Versions on the `0.0.X` line are public beta releases; `0.1.X` and onwards will 
 
 ## [Unreleased]
 
+### Changed
+
+- **Break sounds now audition the moment you pick them.** Choosing a track (or switching the sound mode, or picking a custom file) plays it straight away, instead of hiding the preview behind a separate "Preview" button that gave no visible feedback. ([#67](https://github.com/drmowinckels/entracte/issues/67))
+
 ### Fixed
 
 - **Break overlay no longer overflows the screen on HiDPI Wayland.** With a scaled display (e.g. a 4K monitor at 200%), GNOME/Wayland reports each monitor's size already multiplied by the scale factor, so the overlay was built roughly twice the monitor size — it spilled onto the neighbouring monitor and pushed the hint text and Skip control off the bottom of the screen. The overlay geometry is now corrected back to true physical pixels on Wayland; X11 and macOS are unaffected. ([#67](https://github.com/drmowinckels/entracte/issues/67))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Versions on the `0.0.X` line are public beta releases; `0.1.X` and onwards will 
 
 - **Break overlay no longer overflows the screen on HiDPI Wayland.** With a scaled display (e.g. a 4K monitor at 200%), GNOME/Wayland reports each monitor's size already multiplied by the scale factor, so the overlay was built roughly twice the monitor size — it spilled onto the neighbouring monitor and pushed the hint text and Skip control off the bottom of the screen. The overlay geometry is now corrected back to true physical pixels on Wayland; X11 and macOS are unaffected. ([#67](https://github.com/drmowinckels/entracte/issues/67))
 - **Breaks no longer appear up to a minute late when idle detection is unavailable.** Where the windowing system exposes no idle query (common on Wayland), the "delay break while typing" heuristic read the missing idle value as "actively typing" and held every break for the full deferral cap before showing it. When idle can't be measured, Entracte no longer defers — the break fires on schedule. ([#67](https://github.com/drmowinckels/entracte/issues/67))
+- **Breaks cover every monitor on Wayland.** With the default `Primary` placement, Wayland reports no primary monitor, so the break previously appeared on a single screen and left the others usable. "Primary" can't be honoured on Wayland, so the break now covers all connected monitors there — the same screens an enforceable break needs to hold. ([#67](https://github.com/drmowinckels/entracte/issues/67))
 
 ## [0.0.3] — 2026-06-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ Versions on the `0.0.X` line are public beta releases; `0.1.X` and onwards will 
 
 ## [Unreleased]
 
+### Fixed
+
+- **Break overlay no longer overflows the screen on HiDPI Wayland.** With a scaled display (e.g. a 4K monitor at 200%), GNOME/Wayland reports each monitor's size already multiplied by the scale factor, so the overlay was built roughly twice the monitor size — it spilled onto the neighbouring monitor and pushed the hint text and Skip control off the bottom of the screen. The overlay geometry is now corrected back to true physical pixels on Wayland; X11 and macOS are unaffected. ([#67](https://github.com/drmowinckels/entracte/issues/67))
+- **Breaks no longer appear up to a minute late when idle detection is unavailable.** Where the windowing system exposes no idle query (common on Wayland), the "delay break while typing" heuristic read the missing idle value as "actively typing" and held every break for the full deferral cap before showing it. When idle can't be measured, Entracte no longer defers — the break fires on schedule. ([#67](https://github.com/drmowinckels/entracte/issues/67))
+
 ## [0.0.3] — 2026-06-01
 
 Linux-focused beta: breaks now show on Wayland, the logs are far quieter, and an optional "pause media during breaks" lands on every platform.

--- a/src-tauri/src/scheduler/overlay.rs
+++ b/src-tauri/src/scheduler/overlay.rs
@@ -44,15 +44,21 @@ pub fn centered_windowed_rect(monitor: MonitorRect, fraction: f64) -> MonitorRec
     }
 }
 
+/// Pure Wayland-session test over the two relevant env signals, split out
+/// so the decision is unit-testable without mutating process env.
+fn wayland_session_from_env(session_type: Option<&str>, wayland_display: bool) -> bool {
+    session_type.is_some_and(|s| s.eq_ignore_ascii_case("wayland")) || wayland_display
+}
+
 /// Whether this is a Wayland session. Used to decide if the overlay
 /// geometry needs the HiDPI scale correction below (#67). Mirrors the
 /// probe in `video.rs`; kept local so the overlay path stays
 /// self-contained.
 fn is_wayland_session() -> bool {
-    std::env::var("XDG_SESSION_TYPE")
-        .map(|s| s.eq_ignore_ascii_case("wayland"))
-        .unwrap_or(false)
-        || std::env::var("WAYLAND_DISPLAY").is_ok()
+    wayland_session_from_env(
+        std::env::var("XDG_SESSION_TYPE").ok().as_deref(),
+        std::env::var("WAYLAND_DISPLAY").is_ok(),
+    )
 }
 
 /// Correct a monitor's reported geometry for the GNOME/Wayland HiDPI
@@ -168,13 +174,28 @@ fn primary_or_first<T: Clone>(primary: Option<T>, available: &[T]) -> Vec<T> {
     }
 }
 
+/// Monitors to cover for the `Primary` placement. When the windowing
+/// system names a primary monitor we cover exactly it. When it can't
+/// (Wayland has no "primary" concept) we cover *every* monitor instead of
+/// just the first: "the primary screen" is meaningless there, and leaving
+/// the other monitors uncovered lets the user dodge an enforceable break
+/// by glancing at the next screen (#67, Steffi's dual-monitor setup).
+/// Generic + pure so the fallback is unit-testable without a windowing
+/// system.
+fn primary_or_all<T: Clone>(primary: Option<T>, available: &[T]) -> Vec<T> {
+    match primary {
+        Some(m) => vec![m],
+        None => available.to_vec(),
+    }
+}
+
 fn select_overlay_monitors<R: Runtime>(
     app: &AppHandle<R>,
     placement: MonitorPlacement,
 ) -> Vec<tauri::Monitor> {
     match placement {
         MonitorPlacement::All => app.available_monitors().unwrap_or_default(),
-        MonitorPlacement::Primary => primary_or_first(
+        MonitorPlacement::Primary => primary_or_all(
             app.primary_monitor().ok().flatten(),
             &app.available_monitors().unwrap_or_default(),
         ),
@@ -380,6 +401,40 @@ mod tests {
         // The #67 case: Wayland reports no primary, but monitors exist.
         // Must fall back to the first so an overlay still appears.
         assert_eq!(primary_or_first(None, &["DP-2", "HDMI-1"]), vec!["DP-2"]);
+    }
+
+    #[test]
+    fn primary_or_all_uses_primary_when_present() {
+        // A named primary is honoured exactly — never widened.
+        assert_eq!(
+            primary_or_all(Some("HDMI-1"), &["HDMI-1", "DP-2"]),
+            vec!["HDMI-1"]
+        );
+    }
+
+    #[test]
+    fn primary_or_all_covers_every_monitor_on_wayland() {
+        // No primary (Wayland): cover all monitors so a break can't be
+        // dodged on the second screen (#67).
+        assert_eq!(
+            primary_or_all(None, &["DP-2", "HDMI-1"]),
+            vec!["DP-2", "HDMI-1"]
+        );
+    }
+
+    #[test]
+    fn primary_or_all_empty_when_no_monitors_at_all() {
+        let none: Option<&str> = None;
+        assert!(primary_or_all(none, &[] as &[&str]).is_empty());
+    }
+
+    #[test]
+    fn wayland_session_from_env_detects_session_type_and_display() {
+        assert!(wayland_session_from_env(Some("wayland"), false));
+        assert!(wayland_session_from_env(Some("WAYLAND"), false));
+        assert!(wayland_session_from_env(None, true));
+        assert!(!wayland_session_from_env(Some("x11"), false));
+        assert!(!wayland_session_from_env(None, false));
     }
 
     #[test]

--- a/src-tauri/src/scheduler/overlay.rs
+++ b/src-tauri/src/scheduler/overlay.rs
@@ -44,6 +44,42 @@ pub fn centered_windowed_rect(monitor: MonitorRect, fraction: f64) -> MonitorRec
     }
 }
 
+/// Whether this is a Wayland session. Used to decide if the overlay
+/// geometry needs the HiDPI scale correction below (#67). Mirrors the
+/// probe in `video.rs`; kept local so the overlay path stays
+/// self-contained.
+fn is_wayland_session() -> bool {
+    std::env::var("XDG_SESSION_TYPE")
+        .map(|s| s.eq_ignore_ascii_case("wayland"))
+        .unwrap_or(false)
+        || std::env::var("WAYLAND_DISPLAY").is_ok()
+}
+
+/// Correct a monitor's reported geometry for the GNOME/Wayland HiDPI
+/// quirk where `tao` returns `monitor.size()` and `position()` already
+/// multiplied by the scale factor. Feeding those straight into
+/// `set_size`/`set_position` (which divide by the window's scale factor
+/// again) builds an overlay `scale`× too large in each axis — it spills
+/// onto the neighbouring monitor and pushes the hint and Skip controls
+/// off the bottom of the screen (#67, Steffi's 2×4K @ 200% report). On
+/// Wayland with a >1 scale we divide back out to the true physical
+/// geometry; on X11 and macOS `monitor.size()` is already true physical,
+/// so it's a no-op. Pure so the correction is unit-testable without a
+/// windowing system.
+fn scale_corrected_rect(rect: MonitorRect, scale: f64, wayland: bool) -> MonitorRect {
+    if !wayland || scale <= 1.0 {
+        return rect;
+    }
+    let div_i = |v: i32| (v as f64 / scale).round() as i32;
+    let div_u = |v: u32| ((v as f64 / scale).round() as u32).max(1);
+    MonitorRect {
+        x: div_i(rect.x),
+        y: div_i(rect.y),
+        width: div_u(rect.width),
+        height: div_u(rect.height),
+    }
+}
+
 /// Human-friendly break duration for notifications (e.g. `"20 seconds"`,
 /// `"5 minutes"`, `"1m 30s"`). Drops the seconds part when the
 /// duration is a whole-minute multiple.
@@ -219,15 +255,20 @@ pub fn fire_break<R: Runtime>(
     let monitors = select_overlay_monitors(app, placement);
     let count = monitors.len().max(1);
     let mut shown = 0usize;
+    let wayland = is_wayland_session();
 
     for (idx, monitor) in monitors.iter().enumerate() {
         if let Some(window) = ensure_overlay(app, idx) {
-            let monitor_rect = MonitorRect {
-                x: monitor.position().x,
-                y: monitor.position().y,
-                width: monitor.size().width,
-                height: monitor.size().height,
-            };
+            let monitor_rect = scale_corrected_rect(
+                MonitorRect {
+                    x: monitor.position().x,
+                    y: monitor.position().y,
+                    width: monitor.size().width,
+                    height: monitor.size().height,
+                },
+                monitor.scale_factor(),
+                wayland,
+            );
             let rect = if windowed {
                 centered_windowed_rect(monitor_rect, 0.8)
             } else {
@@ -348,6 +389,39 @@ mod tests {
         // error rather than crashing.
         let none: Option<&str> = None;
         assert!(primary_or_first(none, &[] as &[&str]).is_empty());
+    }
+
+    #[test]
+    fn scale_corrected_rect_divides_out_doubled_wayland_geometry() {
+        // Steffi's #67 case: a 4K panel at 200% is reported as 7680×4320
+        // (physical × scale). Dividing by the scale recovers true physical
+        // 3840×2160, so the overlay covers exactly one monitor instead of
+        // 2× spilling onto the neighbour.
+        let reported = rect(7680, 0, 7680, 4320);
+        let r = scale_corrected_rect(reported, 2.0, true);
+        assert_eq!(r, rect(3840, 0, 3840, 2160));
+    }
+
+    #[test]
+    fn scale_corrected_rect_noop_off_wayland() {
+        // X11 / macOS report true physical already — never halve them.
+        let reported = rect(0, 0, 3840, 2160);
+        assert_eq!(scale_corrected_rect(reported, 2.0, false), reported);
+    }
+
+    #[test]
+    fn scale_corrected_rect_noop_at_unity_scale() {
+        // Wayland without HiDPI scaling: nothing to correct.
+        let reported = rect(1920, 0, 1920, 1080);
+        assert_eq!(scale_corrected_rect(reported, 1.0, true), reported);
+    }
+
+    #[test]
+    fn scale_corrected_rect_handles_fractional_scale() {
+        // 150% scaling rounds to the nearest physical pixel and never
+        // collapses a dimension to zero.
+        let r = scale_corrected_rect(rect(0, 0, 2880, 1620), 1.5, true);
+        assert_eq!(r, rect(0, 0, 1920, 1080));
     }
 
     #[test]

--- a/src-tauri/src/scheduler/overlay.rs
+++ b/src-tauri/src/scheduler/overlay.rs
@@ -72,6 +72,13 @@ fn is_wayland_session() -> bool {
 /// geometry; on X11 and macOS `monitor.size()` is already true physical,
 /// so it's a no-op. Pure so the correction is unit-testable without a
 /// windowing system.
+///
+/// Assumes a uniform scale across monitors: each rect's *position* is
+/// divided by that monitor's own scale, which only stays globally
+/// coherent when every monitor shares one factor (the common case). A
+/// mixed-DPI Wayland layout would need a shared coordinate basis — not
+/// handled here, since the whole correction is a workaround for the tao
+/// reporting quirk rather than a general geometry layer.
 fn scale_corrected_rect(rect: MonitorRect, scale: f64, wayland: bool) -> MonitorRect {
     if !wayland || scale <= 1.0 {
         return rect;
@@ -280,21 +287,35 @@ pub fn fire_break<R: Runtime>(
 
     for (idx, monitor) in monitors.iter().enumerate() {
         if let Some(window) = ensure_overlay(app, idx) {
-            let monitor_rect = scale_corrected_rect(
-                MonitorRect {
-                    x: monitor.position().x,
-                    y: monitor.position().y,
-                    width: monitor.size().width,
-                    height: monitor.size().height,
-                },
-                monitor.scale_factor(),
-                wayland,
-            );
+            let scale = monitor.scale_factor();
+            let reported = MonitorRect {
+                x: monitor.position().x,
+                y: monitor.position().y,
+                width: monitor.size().width,
+                height: monitor.size().height,
+            };
+            let monitor_rect = scale_corrected_rect(reported, scale, wayland);
             let rect = if windowed {
                 centered_windowed_rect(monitor_rect, 0.8)
             } else {
                 monitor_rect
             };
+            // The geometry, scale, and Wayland flag in one line so a
+            // diagnostics report can confirm the overlay was sized to the
+            // monitor (and flag the inverse of #67 — a too-small overlay
+            // if some compositor reports true physical despite scaling).
+            log::debug!(
+                "overlay-{idx}: wayland={wayland} scale={scale:.2} reported={rw}x{rh}@({rx},{ry}) \
+                 -> set {w}x{h}@({x},{y})",
+                rw = reported.width,
+                rh = reported.height,
+                rx = reported.x,
+                ry = reported.y,
+                w = rect.width,
+                h = rect.height,
+                x = rect.x,
+                y = rect.y,
+            );
             let _ = window.set_position(tauri::PhysicalPosition::new(rect.x, rect.y));
             let _ = window.set_size(tauri::PhysicalSize::new(rect.width, rect.height));
             let _ = window.set_always_on_top(true);

--- a/src-tauri/src/scheduler/run_loop.rs
+++ b/src-tauri/src/scheduler/run_loop.rs
@@ -139,11 +139,15 @@ pub(super) async fn run_loop(app: AppHandle, sched: Scheduler) {
         // reuse for screen-time, idle-suppression, and the typing-defer check.
         // The closure is the only platform-bound part; `resolve_idle_secs`
         // holds the (unit-tested) back-off / fallback decision.
-        let raw_idle_secs = resolve_idle_secs(&mut idle_backoff, || {
+        let idle_reading = resolve_idle_secs(&mut idle_backoff, || {
             UserIdle::get_time()
                 .map(|i| i.as_seconds())
                 .map_err(|e| e.to_string())
         });
+        // Unknown idle maps to 0 ("active") for screen-time and
+        // suppression; the typing-defer path below keeps the `Option` so
+        // it can tell "active" apart from "couldn't measure" (#67).
+        let raw_idle_secs = idle_reading.unwrap_or(0);
         // A locked screen is a stronger AFK signal than HIDIdleTime —
         // `caffeinate -u`, Zoom meetings, and synthetic-input utilities
         // can keep the HID counter at zero while the human is gone, but
@@ -151,7 +155,9 @@ pub(super) async fn run_loop(app: AppHandle, sched: Scheduler) {
         // session as locked, promote `idle_secs` past both thresholds
         // so the screen-time, suppression, and typing-defer paths
         // below all treat the user as idle.
-        let idle_secs = promote_idle_for_lock(raw_idle_secs, session_lock::screen_locked(), &s);
+        let locked = session_lock::screen_locked();
+        let idle_secs = promote_idle_for_lock(raw_idle_secs, locked, &s);
+        let idle_for_typing = idle_for_typing_defer(idle_reading, idle_secs, locked);
         let is_active = idle_secs < s.micro_idle_reset_secs;
         let today_str = local_today_string();
         let budget_secs = s.daily_screen_time_budget_minutes.saturating_mul(60);
@@ -540,7 +546,7 @@ pub(super) async fn run_loop(app: AppHandle, sched: Scheduler) {
             };
             let defer = should_defer_for_typing(
                 s.delay_break_if_typing,
-                idle_secs,
+                idle_for_typing,
                 s.typing_grace_secs,
                 deferred_since,
                 s.typing_max_deferral_secs,
@@ -953,28 +959,50 @@ pub(super) fn promote_idle_for_lock_with_cell(
 /// caller keeps platform-bound is `probe` itself, so this decision logic
 /// is unit-testable without a windowing system.
 ///
-/// A failed *or* skipped (in-cooldown) probe reports `0` — i.e. "active",
-/// the conservative default that keeps screen-time and typing-defer from
-/// silently suppressing breaks rather than guessing the user is idle.
+/// A failed *or* skipped (in-cooldown) probe reports `None` — idle is
+/// unknown this tick. Callers map that to `0` ("active") for screen-time
+/// and idle-suppression (the conservative default that never silently
+/// suppresses a break), but the typing-defer path treats `None` as "can't
+/// tell" and fires rather than stalling every break for the cap (#67).
 fn resolve_idle_secs(
     backoff: &mut IdleProbeBackoff,
     probe: impl FnOnce() -> Result<u64, String>,
-) -> u64 {
+) -> Option<u64> {
     if !backoff.should_probe() {
         // In a back-off cooldown: the probe is known-broken, so skip it
         // entirely rather than re-triggering the libX11 spam.
-        return 0;
+        return None;
     }
     match probe() {
         Ok(secs) => {
             backoff.record_success();
-            secs
+            Some(secs)
         }
         Err(err) => {
             let backoff_secs = backoff.record_failure();
             warn_user_idle_failure(&err, backoff_secs);
-            0
+            None
         }
+    }
+}
+
+/// Idle seconds the typing-defer check should see. `Some` only when we
+/// can affirmatively judge activity — a real HID reading this tick, or a
+/// locked session (the user is definitely away). `None` when idle
+/// detection is unavailable *and* the lock state is unknown/unlocked, so
+/// the caller skips deferral rather than stalling every break for the
+/// full cap (#67). `promoted_idle_secs` already folds in the lock
+/// promotion, so the `Some` branch carries the value the rest of the
+/// scheduler sees. Pure so the unavailable-on-Wayland case is testable.
+pub(super) fn idle_for_typing_defer(
+    reading: Option<u64>,
+    promoted_idle_secs: u64,
+    locked: Option<bool>,
+) -> Option<u64> {
+    if reading.is_some() || matches!(locked, Some(true)) {
+        Some(promoted_idle_secs)
+    } else {
+        None
     }
 }
 
@@ -1292,19 +1320,19 @@ mod tests {
     #[test]
     fn resolve_idle_secs_returns_probe_value_on_success() {
         let mut b = IdleProbeBackoff::new();
-        assert_eq!(resolve_idle_secs(&mut b, || Ok(42)), 42);
+        assert_eq!(resolve_idle_secs(&mut b, || Ok(42)), Some(42));
         // Success keeps probing every tick.
         assert!(b.should_probe());
     }
 
     #[test]
-    fn resolve_idle_secs_failure_reports_active_and_backs_off() {
+    fn resolve_idle_secs_failure_reports_unknown_and_backs_off() {
         let mut b = IdleProbeBackoff::new();
-        // A failing probe reports 0 ("active") and arms the cooldown, so
-        // the next tick skips the probe.
+        // A failing probe reports `None` (idle unknown) and arms the
+        // cooldown, so the next tick skips the probe.
         assert_eq!(
             resolve_idle_secs(&mut b, || Err("no screensaver".into())),
-            0
+            None
         );
         assert!(!b.should_probe());
     }
@@ -1313,10 +1341,32 @@ mod tests {
     fn resolve_idle_secs_skips_probe_during_cooldown() {
         let mut b = IdleProbeBackoff::new();
         // Arm a cooldown via one failure...
-        assert_eq!(resolve_idle_secs(&mut b, || Err("boom".into())), 0);
+        assert_eq!(resolve_idle_secs(&mut b, || Err("boom".into())), None);
         // ...then the next call must NOT invoke the probe at all.
         let result = resolve_idle_secs(&mut b, || panic!("probe must not run in cooldown"));
-        assert_eq!(result, 0);
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn idle_for_typing_defer_passes_real_reading_through() {
+        // A successful probe (even 0 = active) is a usable signal.
+        assert_eq!(idle_for_typing_defer(Some(0), 0, Some(false)), Some(0));
+        assert_eq!(idle_for_typing_defer(Some(5), 5, None), Some(5));
+    }
+
+    #[test]
+    fn idle_for_typing_defer_unknown_idle_is_none() {
+        // Wayland (#67): no reading and not locked → can't judge typing,
+        // so the defer check must see `None` and fire the break.
+        assert_eq!(idle_for_typing_defer(None, 0, None), None);
+        assert_eq!(idle_for_typing_defer(None, 0, Some(false)), None);
+    }
+
+    #[test]
+    fn idle_for_typing_defer_locked_session_is_known_away() {
+        // No HID reading, but the session is locked: the user is
+        // definitely away, so surface the lock-promoted idle value.
+        assert_eq!(idle_for_typing_defer(None, 900, Some(true)), Some(900));
     }
 
     #[test]

--- a/src-tauri/src/scheduler/timers.rs
+++ b/src-tauri/src/scheduler/timers.rs
@@ -277,11 +277,17 @@ pub fn decide_bedtime(
 /// `false` once either the user has paused typing OR the deferral cap
 /// has been reached (so we don't postpone indefinitely).
 ///
+/// `idle_secs` is `None` when idle detection is unavailable this tick
+/// (e.g. Wayland exposes no portable HID-idle query, so the probe keeps
+/// failing). We can't tell whether the user is typing then, so we don't
+/// defer — otherwise the "is the user idle?" proxy is permanently 0 and
+/// every break stalls for the full deferral cap before appearing (#67).
+///
 /// `deferred_since` is the instant the current defer-streak started,
 /// or `None` if this is the first tick of the streak.
 pub fn should_defer_for_typing(
     enabled: bool,
-    idle_secs: u64,
+    idle_secs: Option<u64>,
     grace_secs: u64,
     deferred_since: Option<Instant>,
     max_deferral_secs: u64,
@@ -290,6 +296,9 @@ pub fn should_defer_for_typing(
     if !enabled || grace_secs == 0 {
         return false;
     }
+    let Some(idle_secs) = idle_secs else {
+        return false;
+    };
     if idle_secs >= grace_secs {
         return false;
     }
@@ -454,26 +463,44 @@ mod tests {
     #[test]
     fn typing_defer_disabled_returns_false() {
         let now = Instant::now();
-        assert!(!should_defer_for_typing(false, 0, 10, None, 60, now));
+        assert!(!should_defer_for_typing(false, Some(0), 10, None, 60, now));
     }
 
     #[test]
     fn typing_defer_zero_grace_returns_false() {
         let now = Instant::now();
-        assert!(!should_defer_for_typing(true, 0, 0, None, 60, now));
+        assert!(!should_defer_for_typing(true, Some(0), 0, None, 60, now));
+    }
+
+    #[test]
+    fn typing_defer_idle_unavailable_does_not_defer() {
+        // Wayland (#67): no idle reading this tick. We can't tell the
+        // user is typing, so we must fire rather than stall for the cap.
+        let now = Instant::now();
+        assert!(!should_defer_for_typing(true, None, 10, None, 60, now));
+        // Even mid-streak, an unavailable reading releases the defer.
+        let started = Instant::now();
+        assert!(!should_defer_for_typing(
+            true,
+            None,
+            10,
+            Some(started),
+            60,
+            started + Duration::from_secs(5)
+        ));
     }
 
     #[test]
     fn typing_defer_when_actively_typing_first_tick() {
         let now = Instant::now();
-        assert!(should_defer_for_typing(true, 1, 10, None, 60, now));
+        assert!(should_defer_for_typing(true, Some(1), 10, None, 60, now));
     }
 
     #[test]
     fn typing_defer_idle_above_grace_does_not_defer() {
         let now = Instant::now();
-        assert!(!should_defer_for_typing(true, 10, 10, None, 60, now));
-        assert!(!should_defer_for_typing(true, 30, 10, None, 60, now));
+        assert!(!should_defer_for_typing(true, Some(10), 10, None, 60, now));
+        assert!(!should_defer_for_typing(true, Some(30), 10, None, 60, now));
     }
 
     #[test]
@@ -483,7 +510,14 @@ mod tests {
         // monotonic clock is younger than the offset).
         let started = Instant::now();
         let now = started + Duration::from_secs(30);
-        assert!(should_defer_for_typing(true, 1, 10, Some(started), 60, now));
+        assert!(should_defer_for_typing(
+            true,
+            Some(1),
+            10,
+            Some(started),
+            60,
+            now
+        ));
     }
 
     #[test]
@@ -492,7 +526,7 @@ mod tests {
         let now = started + Duration::from_secs(60);
         assert!(!should_defer_for_typing(
             true,
-            1,
+            Some(1),
             10,
             Some(started),
             60,
@@ -502,7 +536,7 @@ mod tests {
         let now_later = older + Duration::from_secs(120);
         assert!(!should_defer_for_typing(
             true,
-            1,
+            Some(1),
             10,
             Some(older),
             60,

--- a/src/views/settings/components/sound-controls.test.tsx
+++ b/src/views/settings/components/sound-controls.test.tsx
@@ -1,6 +1,12 @@
 // @vitest-environment happy-dom
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 
 import type { BreakSound } from "../../../lib/break-sound";
 
@@ -92,6 +98,26 @@ describe("SoundControls", () => {
       target: { value: "ambient" },
     });
     expect(previewAmbient).toHaveBeenCalledTimes(1);
+  });
+
+  it("auditions a custom file right after it's picked", async () => {
+    openMock.mockResolvedValueOnce("/music/rain.mp3");
+    const onChange = vi.fn();
+    render(
+      <SoundControls
+        sound={{ mode: "ambient", sound_id: "custom", custom_path: "" }}
+        volume={0.5}
+        onChange={onChange}
+        isSupporter
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /choose file|replace/i }));
+    await waitFor(() =>
+      expect(previewCustomAmbient).toHaveBeenCalledWith("/music/rain.mp3", 0.5),
+    );
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ custom_path: "/music/rain.mp3" }),
+    );
   });
 
   it("never plays while muted (volume 0) or off", () => {

--- a/src/views/settings/components/sound-controls.test.tsx
+++ b/src/views/settings/components/sound-controls.test.tsx
@@ -1,0 +1,111 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+import type { BreakSound } from "../../../lib/break-sound";
+
+const playSound = vi.fn();
+const playCustomSound = vi.fn();
+const ambientStop = vi.fn();
+const customStop = vi.fn();
+const previewAmbient = vi.fn((..._a: unknown[]) => ({ stop: ambientStop }));
+const previewCustomAmbient = vi.fn((..._a: unknown[]) => ({ stop: customStop }));
+const openMock = vi.fn();
+
+vi.mock("../../../lib/sounds", () => ({
+  playSound: (...a: unknown[]) => playSound(...a),
+  playCustomSound: (...a: unknown[]) => playCustomSound(...a),
+  previewAmbient: (...a: unknown[]) => previewAmbient(...a),
+  previewCustomAmbient: (...a: unknown[]) => previewCustomAmbient(...a),
+  soundDisplayName: (s: { id: string }) => s.id,
+  soundsForMode: (mode: string) =>
+    mode === "end_chime"
+      ? [
+          { id: "chime-a", category: "chime" },
+          { id: "chime-b", category: "bowl" },
+        ]
+      : [
+          { id: "amb-a", category: "ambient" },
+          { id: "amb-b", category: "noise" },
+        ],
+}));
+
+vi.mock("@tauri-apps/plugin-dialog", () => ({
+  open: (...a: unknown[]) => openMock(...a),
+}));
+
+const { SoundControls } = await import("./sound-controls");
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+function renderControls(sound: BreakSound, volume = 0.5) {
+  const onChange = vi.fn();
+  render(<SoundControls sound={sound} volume={volume} onChange={onChange} />);
+  return { onChange };
+}
+
+describe("SoundControls", () => {
+  it("does not render a separate Preview button — selection auditions instead", () => {
+    renderControls({ mode: "end_chime", sound_id: "chime-a" });
+    expect(screen.queryByRole("button", { name: /preview/i })).toBeNull();
+  });
+
+  it("auditions an end-chime track the moment it's selected", () => {
+    const { onChange } = renderControls({ mode: "end_chime", sound_id: "chime-a" });
+    fireEvent.change(screen.getByRole("combobox", { name: /track/i }), {
+      target: { value: "chime-b" },
+    });
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ sound_id: "chime-b" }),
+    );
+    expect(playSound).toHaveBeenCalledWith("chime-b", 0.5);
+    expect(previewAmbient).not.toHaveBeenCalled();
+  });
+
+  it("loops an ambient track on selection", () => {
+    const { onChange } = renderControls({ mode: "ambient", sound_id: "amb-a" });
+    fireEvent.change(screen.getByRole("combobox", { name: /track/i }), {
+      target: { value: "amb-b" },
+    });
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ sound_id: "amb-b" }),
+    );
+    expect(previewAmbient).toHaveBeenCalledWith("amb-b", 0.5);
+    expect(playSound).not.toHaveBeenCalled();
+  });
+
+  it("stops the previous ambient preview before starting the next", () => {
+    renderControls({ mode: "ambient", sound_id: "amb-a" });
+    const track = screen.getByRole("combobox", { name: /track/i });
+    fireEvent.change(track, { target: { value: "amb-b" } });
+    fireEvent.change(track, { target: { value: "amb-a" } });
+    expect(ambientStop).toHaveBeenCalled();
+    expect(previewAmbient).toHaveBeenCalledTimes(2);
+  });
+
+  it("auditions when switching mode to an audible one", () => {
+    renderControls({ mode: "end_chime", sound_id: "chime-a" });
+    fireEvent.change(screen.getByRole("combobox", { name: /sound/i }), {
+      target: { value: "ambient" },
+    });
+    expect(previewAmbient).toHaveBeenCalledTimes(1);
+  });
+
+  it("never plays while muted (volume 0) or off", () => {
+    const { onChange } = renderControls(
+      { mode: "end_chime", sound_id: "chime-a" },
+      0,
+    );
+    fireEvent.change(screen.getByRole("combobox", { name: /track/i }), {
+      target: { value: "chime-b" },
+    });
+    // Still records the choice, just doesn't make noise.
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ sound_id: "chime-b" }),
+    );
+    expect(playSound).not.toHaveBeenCalled();
+  });
+});

--- a/src/views/settings/components/sound-controls.tsx
+++ b/src/views/settings/components/sound-controls.tsx
@@ -48,6 +48,36 @@ export function SoundControls({
     previewRef.current = null;
   };
 
+  // Play the sound the user just picked, so selecting a track auditions
+  // it immediately (the common pattern) instead of behind a separate
+  // Preview button. Reads from `next` rather than the `sound` prop, since
+  // the parent's state update hasn't propagated back yet (#67).
+  const previewSound = (next: BreakSound) => {
+    stopPreview();
+    if (next.mode === "off" || volume <= 0) return;
+    if (next.sound_id === CUSTOM_SOUND_ID) {
+      const path = next.custom_path ?? "";
+      if (!path) return;
+      if (next.mode === "end_chime") {
+        void playCustomSound(path, volume);
+        return;
+      }
+      previewRef.current = previewCustomAmbient(path, volume);
+      return;
+    }
+    if (!next.sound_id) return;
+    if (next.mode === "end_chime") {
+      void playSound(next.sound_id, volume);
+      return;
+    }
+    previewRef.current = previewAmbient(next.sound_id, volume);
+  };
+
+  const apply = (next: BreakSound) => {
+    onChange(next);
+    previewSound(next);
+  };
+
   const isCustom = sound.sound_id === CUSTOM_SOUND_ID;
   const customPath = sound.custom_path ?? "";
 
@@ -65,7 +95,7 @@ export function SoundControls({
         ],
       });
       if (typeof selected !== "string") return;
-      onChange({
+      apply({
         ...sound,
         mode: sound.mode === "off" ? "end_chime" : sound.mode,
         sound_id: CUSTOM_SOUND_ID,
@@ -77,17 +107,17 @@ export function SoundControls({
   };
 
   const onModeChange = (mode: BreakSoundMode) => {
-    stopPreview();
     if (mode === "off") {
+      stopPreview();
       onChange({ ...sound, mode, sound_id: "" });
       return;
     }
     if (isCustom) {
-      onChange({ ...sound, mode });
+      apply({ ...sound, mode });
       return;
     }
     const stillValid = soundsForMode(mode).some((s) => s.id === sound.sound_id);
-    onChange({
+    apply({
       ...sound,
       mode,
       sound_id: stillValid ? sound.sound_id : defaultSoundIdFor(mode),
@@ -99,43 +129,17 @@ export function SoundControls({
       void pickCustomFile();
       return;
     }
-    stopPreview();
-    onChange({ ...sound, sound_id: id });
+    apply({ ...sound, sound_id: id });
   };
 
   const useBundled = () => {
-    stopPreview();
-    onChange({
+    apply({
       ...sound,
       sound_id: defaultSoundIdFor(sound.mode),
       custom_path: "",
     });
   };
 
-  const onPreview = () => {
-    stopPreview();
-    if (sound.mode === "off" || volume <= 0) return;
-    if (isCustom) {
-      if (!customPath) return;
-      if (sound.mode === "end_chime") {
-        playCustomSound(customPath, volume);
-        return;
-      }
-      previewRef.current = previewCustomAmbient(customPath, volume);
-      return;
-    }
-    if (!sound.sound_id) return;
-    if (sound.mode === "end_chime") {
-      playSound(sound.sound_id, volume);
-      return;
-    }
-    previewRef.current = previewAmbient(sound.sound_id, volume);
-  };
-
-  const previewDisabled =
-    sound.mode === "off" ||
-    volume <= 0 ||
-    (isCustom ? !customPath : !sound.sound_id);
   const options = sound.mode === "off" ? [] : soundsForMode(sound.mode);
 
   return (
@@ -191,17 +195,6 @@ export function SoundControls({
             </button>
           </span>
         </label>
-      )}
-      {sound.mode !== "off" && (
-        <div className="actions inline">
-          <button
-            className="secondary"
-            onClick={onPreview}
-            disabled={previewDisabled}
-          >
-            Preview
-          </button>
-        </div>
       )}
     </>
   );


### PR DESCRIPTION
## Summary

Follow-up to Steffi's v0.0.3 testing on issue #67 (dual 4K @ 200%, GNOME/Wayland). All four of her findings are addressed except the one that's a genuine OS limitation.

- **Overlay overflowed the screen on HiDPI Wayland.** `tao` reports `monitor.size()`/`position()` already multiplied by the scale factor on GNOME/Wayland (her 4K panels show as `7680×4320 @ 2.00`). Feeding those into `set_size`/`set_position` — which divide by scale again — built the overlay ~2× the monitor, spilling onto the neighbour and pushing the hint + Skip controls off the bottom. New pure `scale_corrected_rect()` divides back to true physical pixels, gated on `is_wayland_session() && scale > 1.0`, so X11/macOS are untouched.
- **Breaks fired up to 60s late when idle detection is unavailable.** `resolve_idle_secs` collapsed "couldn't measure" into `0` ("active"), so the typing-defer heuristic thought the user was always typing and held every break for the full deferral cap. It now returns `Option<u64>`; `idle_for_typing_defer` passes `None` through to `should_defer_for_typing`, which skips deferral when idle is unknown (still defers on a real reading; treats a locked session as away).
- **Breaks now cover every monitor on Wayland.** With default `Primary` placement Wayland reports no primary, so the break landed on one screen and left the others usable (dodgeable for enforceable breaks). New `primary_or_all` covers all monitors when there's no primary; a named primary (X11/macOS) is still honoured exactly.
- **Sound "Preview" gave no visible feedback.** Sounds now audition on selection (track change, mode change, custom-file pick, revert-to-bundled), stopping any prior ambient loop first. Standalone button removed.

### Not fixed here
- **Alt-Tab escapes an enforceable break on Wayland.** The compositor owns Alt-Tab and Wayland doesn't let an ordinary app grab the keyboard, so this can't be fixed from the app — to be documented as a known limitation.

## Reviews
- **critical-code-reviewer:** Approved; acted on its suggestions (geometry logging for diagnosability, documented the uniform-scale assumption, added the custom-file audition test).
- **security-review:** Clean — no new trust boundary or untrusted-input sink (env vars trusted, custom path is user-picked via OS dialog, geometry math is pure).

## Test plan
- `cargo test --lib` — 686 pass (new pure helpers fully covered: `scale_corrected_rect`, `idle_for_typing_defer`, `primary_or_all`, `wayland_session_from_env`, plus updated `should_defer_for_typing`/`resolve_idle_secs`).
- `cargo fmt` + `cargo clippy --all-targets` — clean.
- `npm test` — 522 pass (`sound-controls.test.tsx`, 7 cases). `npm run typecheck` — clean.

### codecov/patch exception
Patch coverage will be < 100%. Every line reachable by a unit test is covered; the remaining uncovered changed lines are **all inside `run_loop` / `fire_break` / `select_overlay_monitors`** — runtime functions with no unit coverage anywhere (they need the Tauri integration rig tracked in #10). The pure logic was deliberately extracted out of those functions specifically so it could be tested. This is the "truly unreachable until #10" case; merging with an admin override of the patch gate.

Needs a HiDPI-Wayland VM to confirm the overlay sizing end-to-end (CI can't reproduce the compositor). The new `overlay-N: ... reported=… -> set …` debug line makes the next report self-diagnosing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)