### PR TITLE
chore(release): prep v0.0.4 — version bump + CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Versions on the `0.0.X` line are public beta releases; `0.1.X` and onwards will 
 
 ## [Unreleased]
 
+## [0.0.4] — 2026-06-01
+
+Follow-up Linux/Wayland beta from Steffi's dual-4K @ 200% testing (#67): the break overlay now sizes and places itself correctly on scaled Wayland displays, breaks fire on time when idle detection isn't available, and choosing a sound plays it straight away.
+
 ### Changed
 
 - **Break sounds now audition the moment you pick them.** Choosing a track (or switching the sound mode, or picking a custom file) plays it straight away, instead of hiding the preview behind a separate "Preview" button that gave no visible feedback. ([#67](https://github.com/drmowinckels/entracte/issues/67))

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "entracte-desktop",
   "private": true,
-  "version": "0.0.3",
+  "version": "0.0.4",
   "type": "module",
   "engines": {
     "node": ">=20"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1154,7 +1154,7 @@ checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
 
 [[package]]
 name = "entracte"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "entracte"
-version = "0.0.3"
+version = "0.0.4"
 description = "Cross-platform break reminder"
 authors = ["Athanasia Mowinckel"]
 license = "Apache-2.0"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Entracte",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "identifier": "io.drmowinckels.entracte",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Bumps `package.json`, `Cargo.toml`, `tauri.conf.json`, and `Cargo.lock` to **0.0.4** and dates the v0.0.4 CHANGELOG section.

Ships the fixes from #94 (Steffi's #67 dual-4K @ 200% Wayland testing):
- HiDPI Wayland overlay sizing corrected (no more spill/cut-off)
- Breaks fire on time when idle detection is unavailable
- All-monitor coverage under Primary placement on Wayland
- Break sounds audition on selection

Tagging `v0.0.4` after merge triggers the release build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)