### PR TITLE
refactor: backend-provided platform capability flags

### DIFF
--- a/scripts/audit-a11y.mjs
+++ b/scripts/audit-a11y.mjs
@@ -40,10 +40,7 @@ const SCHEMES = ["light", "dark"];
 
 const CONSOLE_LEVELS = new Set(["error", "warning"]);
 // Patterns that match known-benign messages we don't want to fail on.
-const CONSOLE_IGNORE = [
-  /react-devtools/i,
-  /download the react devtools/i,
-];
+const CONSOLE_IGNORE = [/react-devtools/i, /download the react devtools/i];
 
 const TAURI_SHIM = `
 (() => {
@@ -107,6 +104,11 @@ const TAURI_SHIM = `
     get_settings: DEFAULT_SETTINGS,
     update_settings: null,
     get_platform: "macos",
+    get_platform_capabilities: {
+      supportsDndRead: true,
+      mediaPauseGranular: false,
+      installerUnsignedWarning: false,
+    },
     get_pause_info: { paused: false, remaining_secs: null },
     get_break_stats: { taken: 8, skipped: 1, postponed: 2 },
     list_profiles: ["Default", "Deep work", "Light day"],
@@ -223,7 +225,11 @@ async function auditTab(page, tab) {
         target: n.target,
         html: n.html.slice(0, 240),
         failureSummary: n.failureSummary,
-        any: n.any?.map((a) => ({ id: a.id, message: a.message, data: a.data })),
+        any: n.any?.map((a) => ({
+          id: a.id,
+          message: a.message,
+          data: a.data,
+        })),
       })),
     }));
   });
@@ -286,14 +292,18 @@ async function main() {
   const totalTabs = TABS.length * SCHEMES.length;
 
   if (consoleNoise.length > 0) {
-    console.error(`\n✗ renderer console: ${consoleNoise.length} message(s) across ${totalTabs} audits`);
+    console.error(
+      `\n✗ renderer console: ${consoleNoise.length} message(s) across ${totalTabs} audits`,
+    );
     for (const m of consoleNoise) {
       console.error(`  [${m.scheme}] ${m.tab} (${m.type}): ${m.text}`);
     }
   }
 
   if (allViolations.length === 0 && consoleNoise.length === 0) {
-    console.log(`\n✓ axe a11y: clean across ${totalTabs} (tab × scheme) audits`);
+    console.log(
+      `\n✓ axe a11y: clean across ${totalTabs} (tab × scheme) audits`,
+    );
     console.log(`✓ renderer console: clean across ${totalTabs} audits`);
     process.exit(0);
   }
@@ -302,12 +312,16 @@ async function main() {
     process.exit(1);
   }
 
-  console.error(`\n✗ axe a11y: ${allViolations.length} violation(s) across ${totalTabs} audits\n`);
+  console.error(
+    `\n✗ axe a11y: ${allViolations.length} violation(s) across ${totalTabs} audits\n`,
+  );
   const grouped = new Map();
   for (const v of allViolations) {
     const key = `${v.id}|${v.impact}`;
     if (!grouped.has(key)) grouped.set(key, { ...v, occurrences: [] });
-    grouped.get(key).occurrences.push({ scheme: v.scheme, tab: v.tab, nodes: v.nodes });
+    grouped
+      .get(key)
+      .occurrences.push({ scheme: v.scheme, tab: v.tab, nodes: v.nodes });
   }
   for (const [, v] of grouped) {
     console.error(`  ▸ ${v.id} (${v.impact ?? "n/a"}): ${v.help}`);
@@ -324,10 +338,14 @@ async function main() {
               d.fgColor ? `fg=${d.fgColor}` : null,
               d.bgColor ? `bg=${d.bgColor}` : null,
               d.contrastRatio ? `ratio=${d.contrastRatio}` : null,
-              d.expectedContrastRatio ? `need=${d.expectedContrastRatio}` : null,
+              d.expectedContrastRatio
+                ? `need=${d.expectedContrastRatio}`
+                : null,
               d.fontSize ? `size=${d.fontSize}` : null,
               d.fontWeight ? `weight=${d.fontWeight}` : null,
-            ].filter(Boolean).join(" ");
+            ]
+              .filter(Boolean)
+              .join(" ");
             if (summary) console.error(`          ↳ ${summary}`);
           }
         }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -110,6 +110,7 @@ pub fn run() {
             updater::check_for_update,
             diagnostics::build_diagnostics_report,
             platform::get_platform,
+            platform::get_platform_capabilities,
             renderer_log::report_renderer_error,
             get_supporter_status,
             verify_supporter_key,

--- a/src-tauri/src/platform.rs
+++ b/src-tauri/src/platform.rs
@@ -6,6 +6,8 @@
 //! this module exposes it as a Tauri command and the renderer caches
 //! the result through its `usePlatform()` hook.
 
+use serde::Serialize;
+
 /// Return the host platform string as known to Rust:
 /// `"macos"`, `"linux"`, `"windows"`, etc. — the value of
 /// `std::env::consts::OS`. The renderer normalises this through
@@ -13,6 +15,42 @@
 #[tauri::command]
 pub fn get_platform() -> &'static str {
     std::env::consts::OS
+}
+
+/// Behavioural capability flags the renderer branches on, so each
+/// platform-gated feature is decided once here rather than re-derived
+/// from the raw platform string in every component.
+#[derive(Serialize)]
+pub struct PlatformCapabilities {
+    /// Whether the OS exposes a Do-Not-Disturb / Focus state the app
+    /// can read (macOS, Windows, GNOME/KDE on Linux).
+    pub supports_dnd_read: bool,
+    /// Whether media pause during breaks can target individual players
+    /// precisely (Linux via MPRIS) rather than firing a best-effort
+    /// play/pause media key (macOS, Windows).
+    pub media_pause_granular: bool,
+    /// Whether the installer is unsigned and the OS will show a
+    /// reputation warning (Windows SmartScreen) on update.
+    pub installer_unsigned_warning: bool,
+}
+
+/// Derive the capability flags for a given target-OS string. Kept pure
+/// and `os`-parameterised so every branch is unit-testable on a single
+/// host; the `#[tauri::command]` wrapper feeds it the real target.
+fn capabilities_for(os: &str) -> PlatformCapabilities {
+    PlatformCapabilities {
+        supports_dnd_read: matches!(os, "macos" | "windows" | "linux"),
+        media_pause_granular: os == "linux",
+        installer_unsigned_warning: os == "windows",
+    }
+}
+
+/// Return the host's platform capability flags, derived from the
+/// compile-time target OS. The renderer caches the result through its
+/// `usePlatformCapabilities()` hook.
+#[tauri::command]
+pub fn get_platform_capabilities() -> PlatformCapabilities {
+    capabilities_for(std::env::consts::OS)
 }
 
 #[cfg(test)]
@@ -28,6 +66,53 @@ mod tests {
         assert!(
             matches!(p, "macos" | "linux" | "windows"),
             "unexpected std::env::consts::OS = {p:?}",
+        );
+    }
+
+    #[test]
+    fn macos_capabilities() {
+        let c = capabilities_for("macos");
+        assert!(c.supports_dnd_read);
+        assert!(!c.media_pause_granular);
+        assert!(!c.installer_unsigned_warning);
+    }
+
+    #[test]
+    fn windows_capabilities() {
+        let c = capabilities_for("windows");
+        assert!(c.supports_dnd_read);
+        assert!(!c.media_pause_granular);
+        assert!(c.installer_unsigned_warning);
+    }
+
+    #[test]
+    fn linux_capabilities() {
+        let c = capabilities_for("linux");
+        assert!(c.supports_dnd_read);
+        assert!(c.media_pause_granular);
+        assert!(!c.installer_unsigned_warning);
+    }
+
+    #[test]
+    fn unknown_platform_gets_conservative_capabilities() {
+        // Anything outside the supported targets gets every flag off so
+        // the renderer hides platform-specific copy rather than showing
+        // a claim we can't back.
+        let c = capabilities_for("freebsd");
+        assert!(!c.supports_dnd_read);
+        assert!(!c.media_pause_granular);
+        assert!(!c.installer_unsigned_warning);
+    }
+
+    #[test]
+    fn command_matches_host_target() {
+        let c = get_platform_capabilities();
+        let expected = capabilities_for(std::env::consts::OS);
+        assert_eq!(c.supports_dnd_read, expected.supports_dnd_read);
+        assert_eq!(c.media_pause_granular, expected.media_pause_granular);
+        assert_eq!(
+            c.installer_unsigned_warning,
+            expected.installer_unsigned_warning
         );
     }
 }

--- a/src/lib/platform.test.ts
+++ b/src/lib/platform.test.ts
@@ -221,6 +221,27 @@ describe("usePlatformCapabilities", () => {
     expect(result.current.mediaPauseGranular).toBe(true);
   });
 
+  it("falls back to UA-derived capabilities when the invoke resolves null", async () => {
+    // The a11y audit shim answers unknown commands with `null` — a
+    // resolved value, not a rejection — so the hook must treat it as a
+    // fallback rather than publishing `null` to consumers.
+    Object.defineProperty(navigator, "userAgent", {
+      configurable: true,
+      value: "Mozilla/5.0 (X11; Linux x86_64)",
+    });
+    invokeMock.mockResolvedValueOnce(null);
+
+    const { usePlatformCapabilities } = await import("./platform");
+    const { result } = renderHook(() => usePlatformCapabilities());
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(result.current.supportsDndRead).toBe(true);
+    expect(result.current.mediaPauseGranular).toBe(true);
+    expect(result.current.installerUnsignedWarning).toBe(false);
+  });
+
   it("invokes get_platform_capabilities only once even when many components subscribe", async () => {
     invokeMock.mockResolvedValueOnce({
       supportsDndRead: true,

--- a/src/lib/platform.test.ts
+++ b/src/lib/platform.test.ts
@@ -156,3 +156,104 @@ describe("usePlatform", () => {
     await waitFor(() => expect(result.current).toBe("other"));
   });
 });
+
+// usePlatformCapabilities mirrors usePlatform: the UA-derived fallback
+// renders synchronously, then the authoritative Rust flags land once
+// `get_platform_capabilities` resolves. Same module-level cache, so each
+// test resets modules + the invoke mock.
+
+describe("usePlatformCapabilities", () => {
+  const invokeMock = vi.fn();
+
+  beforeEach(() => {
+    vi.resetModules();
+    invokeMock.mockReset();
+    vi.doMock("@tauri-apps/api/core", () => ({
+      invoke: (cmd: string) => invokeMock(cmd),
+    }));
+  });
+
+  afterEach(() => {
+    vi.doUnmock("@tauri-apps/api/core");
+  });
+
+  it("returns the UA-derived fallback synchronously, then upgrades to the Rust flags", async () => {
+    // UA says Windows (fallback flips installerUnsignedWarning on), but
+    // Rust reports a Linux-shaped capability set — the hook should publish
+    // the Rust answer once it lands.
+    Object.defineProperty(navigator, "userAgent", {
+      configurable: true,
+      value: "Mozilla/5.0 (Windows NT 10.0; Win64; x64)",
+    });
+    invokeMock.mockResolvedValueOnce({
+      supportsDndRead: true,
+      mediaPauseGranular: true,
+      installerUnsignedWarning: false,
+    });
+
+    const { usePlatformCapabilities } = await import("./platform");
+    const { result } = renderHook(() => usePlatformCapabilities());
+
+    expect(result.current.installerUnsignedWarning).toBe(true); // UA fallback
+    expect(result.current.mediaPauseGranular).toBe(false);
+    await waitFor(() => expect(result.current.mediaPauseGranular).toBe(true));
+    expect(result.current.installerUnsignedWarning).toBe(false);
+    expect(invokeMock).toHaveBeenCalledWith("get_platform_capabilities");
+  });
+
+  it("falls back to UA-derived capabilities when the Tauri invoke fails", async () => {
+    Object.defineProperty(navigator, "userAgent", {
+      configurable: true,
+      value: "Mozilla/5.0 (X11; Linux x86_64)",
+    });
+    invokeMock.mockRejectedValueOnce(new Error("tauri unavailable"));
+
+    const { usePlatformCapabilities } = await import("./platform");
+    const { result } = renderHook(() => usePlatformCapabilities());
+
+    // Linux fallback: DnD read + granular media pause, no installer warning.
+    expect(result.current.supportsDndRead).toBe(true);
+    expect(result.current.mediaPauseGranular).toBe(true);
+    expect(result.current.installerUnsignedWarning).toBe(false);
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(result.current.mediaPauseGranular).toBe(true);
+  });
+
+  it("invokes get_platform_capabilities only once even when many components subscribe", async () => {
+    invokeMock.mockResolvedValueOnce({
+      supportsDndRead: true,
+      mediaPauseGranular: false,
+      installerUnsignedWarning: false,
+    });
+    const { usePlatformCapabilities } = await import("./platform");
+
+    renderHook(() => usePlatformCapabilities());
+    renderHook(() => usePlatformCapabilities());
+    renderHook(() => usePlatformCapabilities());
+
+    await waitFor(() => {
+      expect(invokeMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("re-renders pick up the cached flags without re-invoking", async () => {
+    invokeMock.mockResolvedValueOnce({
+      supportsDndRead: true,
+      mediaPauseGranular: true,
+      installerUnsignedWarning: false,
+    });
+    const { usePlatformCapabilities } = await import("./platform");
+
+    const first = renderHook(() => usePlatformCapabilities());
+    await waitFor(() =>
+      expect(first.result.current.mediaPauseGranular).toBe(true),
+    );
+    expect(invokeMock).toHaveBeenCalledTimes(1);
+
+    const second = renderHook(() => usePlatformCapabilities());
+    expect(second.result.current.mediaPauseGranular).toBe(true); // from cache
+    expect(invokeMock).toHaveBeenCalledTimes(1); // not invoked again
+  });
+});

--- a/src/lib/platform.ts
+++ b/src/lib/platform.ts
@@ -85,3 +85,76 @@ export function usePlatform(): Platform {
   }, []);
   return platform;
 }
+
+/** Behavioural capability flags surfaced from the Rust
+ * `get_platform_capabilities` command. Components branch on these rather
+ * than on the raw {@link Platform} string, so a platform gaining a
+ * capability is one backend change instead of an audit of every
+ * `platform === "…"`. Mirrors `PlatformCapabilities` in
+ * `src-tauri/src/platform.rs`. */
+export interface PlatformCapabilities {
+  supportsDndRead: boolean;
+  mediaPauseGranular: boolean;
+  installerUnsignedWarning: boolean;
+}
+
+/** Derive the conservative fallback capabilities from a UA-guessed
+ * platform, used until the authoritative Rust answer resolves and when
+ * Tauri is unavailable. Unknown platforms get every flag off so we never
+ * show a platform claim we can't back. */
+function fallbackCapabilities(platform: Platform): PlatformCapabilities {
+  return {
+    supportsDndRead:
+      platform === "macos" || platform === "windows" || platform === "linux",
+    mediaPauseGranular: platform === "linux",
+    installerUnsignedWarning: platform === "windows",
+  };
+}
+
+// Same single-flight cache shape as the platform string above: exactly
+// one in-flight `get_platform_capabilities` request, shared across every
+// `usePlatformCapabilities()` consumer.
+let cachedCaps: PlatformCapabilities | null = null;
+let pendingCaps: Promise<PlatformCapabilities> | null = null;
+
+/** Resolve the authoritative capabilities from the Rust
+ * `get_platform_capabilities` command. Falls back to
+ * {@link fallbackCapabilities} from the UA guess if Tauri is unavailable
+ * (e.g. inside the a11y audit shim or unit tests). */
+function getPlatformCapabilities(): Promise<PlatformCapabilities> {
+  if (cachedCaps) return Promise.resolve(cachedCaps);
+  if (!pendingCaps) {
+    pendingCaps = invoke<PlatformCapabilities>("get_platform_capabilities")
+      .then((caps) => {
+        cachedCaps = caps;
+        return caps;
+      })
+      .catch(() => {
+        const caps = fallbackCapabilities(detectPlatform());
+        cachedCaps = caps;
+        return caps;
+      });
+  }
+  return pendingCaps;
+}
+
+/** React hook: returns the UA-derived capability fallback synchronously,
+ * then upgrades to the authoritative Rust-side flags once
+ * `get_platform_capabilities` resolves. Safe to call from any
+ * component. */
+export function usePlatformCapabilities(): PlatformCapabilities {
+  const [caps, setCaps] = useState<PlatformCapabilities>(
+    () => cachedCaps ?? fallbackCapabilities(detectPlatform()),
+  );
+  useEffect(() => {
+    if (cachedCaps) return;
+    let cancelled = false;
+    getPlatformCapabilities().then((c) => {
+      if (!cancelled) setCaps(c);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+  return caps;
+}

--- a/src/lib/platform.ts
+++ b/src/lib/platform.ts
@@ -124,10 +124,17 @@ let pendingCaps: Promise<PlatformCapabilities> | null = null;
 function getPlatformCapabilities(): Promise<PlatformCapabilities> {
   if (cachedCaps) return Promise.resolve(cachedCaps);
   if (!pendingCaps) {
-    pendingCaps = invoke<PlatformCapabilities>("get_platform_capabilities")
+    pendingCaps = invoke<PlatformCapabilities | null>(
+      "get_platform_capabilities",
+    )
       .then((caps) => {
-        cachedCaps = caps;
-        return caps;
+        // A shim or stale backend can resolve `null` (e.g. the a11y audit
+        // harness answers unknown commands with null). That's not a
+        // rejection, so `.catch` won't fire — guard it here or every
+        // consumer reads flags off `null` and crashes.
+        const resolved = caps ?? fallbackCapabilities(detectPlatform());
+        cachedCaps = resolved;
+        return resolved;
       })
       .catch(() => {
         const caps = fallbackCapabilities(detectPlatform());

--- a/src/views/settings/tabs/about-tab.test.tsx
+++ b/src/views/settings/tabs/about-tab.test.tsx
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-import type { Platform } from "../../../lib/platform";
+import type { PlatformCapabilities } from "../../../lib/platform";
 import type { UseSupporter } from "../hooks/use-supporter";
 import type { UseUpdateCheck } from "../hooks/use-update-check";
 import type { UpdateInfo, SupporterStatus } from "../types";
@@ -29,14 +29,18 @@ vi.mock("@tauri-apps/api/app", () => ({
   getVersion: () => getVersionMock(),
 }));
 
-let currentPlatform: Platform = "macos";
+let currentCaps: PlatformCapabilities = {
+  supportsDndRead: true,
+  mediaPauseGranular: false,
+  installerUnsignedWarning: false,
+};
 vi.mock("../../../lib/platform", async () => {
   const actual = await vi.importActual<typeof import("../../../lib/platform")>(
     "../../../lib/platform",
   );
   return {
     ...actual,
-    usePlatform: () => currentPlatform,
+    usePlatformCapabilities: () => currentCaps,
   };
 });
 
@@ -80,7 +84,11 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.clearAllMocks();
-  currentPlatform = "macos";
+  currentCaps = {
+    supportsDndRead: true,
+    mediaPauseGranular: false,
+    installerUnsignedWarning: false,
+  };
   mockUpdate = {
     info: null,
     checking: false,
@@ -90,29 +98,22 @@ afterEach(() => {
 });
 
 describe("AboutTab — Windows SmartScreen advisory", () => {
-  it("shows the SmartScreen warning paragraph only when platform is windows AND an update is available", () => {
-    currentPlatform = "windows";
+  it("shows the SmartScreen warning paragraph only when installerUnsignedWarning is set AND an update is available", () => {
+    currentCaps = { ...currentCaps, installerUnsignedWarning: true };
     mockUpdate = { ...mockUpdate, info: updateAvailable };
     render(<AboutTab supporter={supporterStub()} />);
     expect(screen.getByText(/SmartScreen will warn/i)).toBeTruthy();
   });
 
-  it("hides the SmartScreen warning on macOS even when an update is available", () => {
-    currentPlatform = "macos";
+  it("hides the SmartScreen warning when the installer is signed even with an update available", () => {
+    currentCaps = { ...currentCaps, installerUnsignedWarning: false };
     mockUpdate = { ...mockUpdate, info: updateAvailable };
     render(<AboutTab supporter={supporterStub()} />);
     expect(screen.queryByText(/SmartScreen will warn/i)).toBeNull();
   });
 
-  it("hides the SmartScreen warning on linux even when an update is available", () => {
-    currentPlatform = "linux";
-    mockUpdate = { ...mockUpdate, info: updateAvailable };
-    render(<AboutTab supporter={supporterStub()} />);
-    expect(screen.queryByText(/SmartScreen will warn/i)).toBeNull();
-  });
-
-  it("hides the SmartScreen warning on windows when no update is available", () => {
-    currentPlatform = "windows";
+  it("hides the SmartScreen warning when installerUnsignedWarning is set but no update is available", () => {
+    currentCaps = { ...currentCaps, installerUnsignedWarning: true };
     mockUpdate = {
       ...mockUpdate,
       info: {

--- a/src/views/settings/tabs/about-tab.tsx
+++ b/src/views/settings/tabs/about-tab.tsx
@@ -4,7 +4,7 @@ import { openUrl } from "@tauri-apps/plugin-opener";
 import { getVersion } from "@tauri-apps/api/app";
 import { useUpdateCheck } from "../hooks/use-update-check";
 import type { UseSupporter } from "../hooks/use-supporter";
-import { usePlatform } from "../../../lib/platform";
+import { usePlatformCapabilities } from "../../../lib/platform";
 import { writeToClipboard } from "../utils";
 
 const TOAST_MS = 3000;
@@ -16,7 +16,7 @@ export function AboutTab({ supporter }: { supporter: UseSupporter }) {
   const [diagnosticsStatus, setDiagnosticsStatus] = useState("");
   const [licenseInput, setLicenseInput] = useState("");
   const update = useUpdateCheck();
-  const platform = usePlatform();
+  const caps = usePlatformCapabilities();
 
   const onVerify = async () => {
     const trimmed = licenseInput.trim();
@@ -80,7 +80,7 @@ export function AboutTab({ supporter }: { supporter: UseSupporter }) {
                 Open release page
               </button>
             </p>
-            {platform === "windows" && (
+            {caps.installerUnsignedWarning && (
               <p className="about-meta">
                 The Windows installer isn't Authenticode-signed yet, so
                 SmartScreen will warn — click <em>More info → Run anyway</em> to

--- a/src/views/settings/tabs/quiet-tab.tsx
+++ b/src/views/settings/tabs/quiet-tab.tsx
@@ -5,7 +5,7 @@ import {
   suggestionsForPlatform,
   tokenFor,
 } from "../../../lib/app-suggestions";
-import { usePlatform } from "../../../lib/platform";
+import { usePlatform, usePlatformCapabilities } from "../../../lib/platform";
 import { formatRemaining } from "../../../lib/time";
 import { CheckboxRow } from "../components/rows";
 import type { UseSettings } from "../hooks/use-settings";
@@ -22,6 +22,7 @@ export function QuietTab({
   pauseInfo: PauseInfo;
 }) {
   const platform = usePlatform();
+  const caps = usePlatformCapabilities();
   const [appPauseText, setAppPauseText] = useState(
     listToLines(settings.app_pause_list),
   );
@@ -42,7 +43,11 @@ export function QuietTab({
           label="Do Not Disturb is on"
           value={settings.pause_during_dnd}
           onChange={(v) => update("pause_during_dnd", v)}
-          tip="Reads your OS-level DnD / Focus state (macOS, Windows, and GNOME/KDE on Linux). When on, scheduled breaks are suppressed until DnD turns off."
+          tip={
+            caps.supportsDndRead
+              ? "Reads your OS-level DnD / Focus state (macOS, Windows, and GNOME/KDE on Linux). When on, scheduled breaks are suppressed until DnD turns off."
+              : "Reads your OS-level DnD / Focus state where available. When on, scheduled breaks are suppressed until DnD turns off."
+          }
         />
         <CheckboxRow
           label="Camera is in use"
@@ -64,7 +69,11 @@ export function QuietTab({
           label="Pause media while a break is showing"
           value={settings.pause_media_during_breaks}
           onChange={(v) => update("pause_media_during_breaks", v)}
-          tip="When a break starts, pauses whatever is playing (video or audio) and resumes it when the break ends. On Linux this targets your media players precisely; on macOS and Windows it sends a play/pause media key as a best-effort, so it works for most players but can't guarantee the exact app."
+          tip={
+            caps.mediaPauseGranular
+              ? "When a break starts, pauses whatever is playing (video or audio) and resumes it when the break ends. This targets your media players precisely."
+              : "When a break starts, pauses whatever is playing (video or audio) and resumes it when the break ends. This sends a play/pause media key as a best-effort, so it works for most players but can't guarantee the exact app."
+          }
         />
       </section>
 


### PR DESCRIPTION
## Summary

Replaces per-component `platform === "…"` UI branching with capability flags surfaced from the backend, mirroring the existing `get_platform` command + `usePlatform()` cache pattern. A platform gaining/losing a capability is now one backend change instead of an audit of every consumer.

- **`src-tauri/src/platform.rs`** — adds a `#[derive(Serialize)] PlatformCapabilities` struct (`supports_dnd_read`, `media_pause_granular`, `installer_unsigned_warning`) and a `get_platform_capabilities` command. The cfg/OS logic lives in a pure, `os`-parameterised `capabilities_for(os)` so every branch is unit-testable on a single host; only the `std::env::consts::OS` read is the uncovered OS shim. Registered in the Tauri builder in `lib.rs`.
- **`src/lib/platform.ts`** — adds a `usePlatformCapabilities()` hook with the same single-flight cache + UA-derived fallback shape as `usePlatform()`, plus a `PlatformCapabilities` interface mirroring the Rust struct.
- **`about-tab` / `quiet-tab`** — the Windows SmartScreen notice, the DnD-read support copy, and the media-pause granularity copy now gate on capability flags instead of the platform string / inline platform prose. User-facing copy stays in the components; only the gating moved. (`quiet-tab` still uses `usePlatform()` for the per-platform suggestion-chip token lookup, which is a string lookup rather than a boolean gate.)

## Capability mapping

| flag | macOS | Windows | Linux | other |
|---|---|---|---|---|
| `supports_dnd_read` | ✓ | ✓ | ✓ | — |
| `media_pause_granular` | — | — | ✓ | — |
| `installer_unsigned_warning` | — | ✓ | — | — |

## Test Plan

- `cargo test` — 706 passed (incl. 5 new platform-capability cases: macOS / Windows / Linux / unknown-platform / host-matches-command)
- `cargo clippy --all-targets -- -D warnings` — clean
- `npm test` — 535 passed (incl. 4 new `usePlatformCapabilities` cases with mocked `invoke`: sync-fallback-then-upgrade, invoke-failure fallback, single-flight, cached re-render; `about-tab` SmartScreen tests rewired to drive the capability flag)
- `npm run typecheck` — clean
- `npm run lint` — clean (one pre-existing warning in unrelated `use-local-draft.ts`)

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Coverage exception (admin bypass requested)

`codecov/patch` reports one uncovered line: `platform::get_platform_capabilities,` in the `tauri::generate_handler!` registration inside `run()` (`src-tauri/src/lib.rs:113`). This is a Wry-runtime-bound line — `run()` only executes when the real app launches, so no unit test can reach it, and a Tauri command cannot be registered without it. It sits directly beside the pre-existing, equally-uncovered `platform::get_platform` registration. The testable core (`capabilities_for`) and the command function are unit-tested across all OS targets. Requesting an **admin `codecov/patch` bypass** per the repo coverage policy (non-reachable line only).