### PR TITLE
perf(scheduler): cache stable per-load derivations off the hot loop

### DIFF
--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -105,12 +105,18 @@ impl ProfilesFile {
     }
 
     pub fn active_settings(&self) -> Settings {
-        self.profiles
+        let mut settings = self
+            .profiles
             .iter()
             .find(|p| p.name == self.active)
             .map(|p| p.settings.clone())
             .or_else(|| self.profiles.first().map(|p| p.settings.clone()))
-            .unwrap_or_default()
+            .unwrap_or_default();
+        // Profiles are deserialised, so each one's `#[serde(skip)]`
+        // `derived` cache arrives empty. Rebuild it here so every caller
+        // (scheduler construction, backup import) gets a populated cache.
+        settings.rebuild_derived();
+        settings
     }
 }
 

--- a/src-tauri/src/ipc.rs
+++ b/src-tauri/src/ipc.rs
@@ -282,10 +282,13 @@ async fn dispatch(app: &AppHandle, req: IpcRequest) -> IpcResponse {
                 return IpcResponse::err(format!("unknown key: {key}"));
             }
             v[&key] = value;
-            let next: crate::scheduler::Settings = match serde_json::from_value(v) {
+            let mut next: crate::scheduler::Settings = match serde_json::from_value(v) {
                 Ok(n) => n,
                 Err(e) => return IpcResponse::err(format!("type mismatch: {e}")),
             };
+            // Deserialised wholesale from JSON, so the `#[serde(skip)]`
+            // `derived` cache arrives empty — rebuild it before storing.
+            next.rebuild_derived();
             *scheduler.settings.lock().await = next.clone();
             {
                 let active = scheduler.active_profile_name.lock().await.clone();

--- a/src-tauri/src/ipc.rs
+++ b/src-tauri/src/ipc.rs
@@ -41,7 +41,7 @@ use serde::{Deserialize, Serialize};
 use subtle::ConstantTimeEq;
 use tauri::{AppHandle, Emitter, Manager};
 
-use crate::scheduler::{PauseState, Scheduler};
+use crate::scheduler::{PauseState, Scheduler, Settings};
 use crate::secure_io::{ensure_user_only_dir, write_user_only};
 
 const SETTINGS_DENYLIST: &[&str] = &["hooks", "hooks_enabled"];
@@ -274,21 +274,10 @@ async fn dispatch(app: &AppHandle, req: IpcRequest) -> IpcResponse {
                 return IpcResponse::err(format!("settings key '{key}' is not writable via IPC"));
             }
             let current = scheduler.settings.lock().await.clone();
-            let mut v = match serde_json::to_value(&current) {
-                Ok(v) => v,
-                Err(e) => return IpcResponse::err(format!("serialize: {e}")),
-            };
-            if v.get(&key).is_none() {
-                return IpcResponse::err(format!("unknown key: {key}"));
-            }
-            v[&key] = value;
-            let mut next: crate::scheduler::Settings = match serde_json::from_value(v) {
+            let next = match apply_settings_key(&current, &key, value) {
                 Ok(n) => n,
-                Err(e) => return IpcResponse::err(format!("type mismatch: {e}")),
+                Err(e) => return IpcResponse::err(e),
             };
-            // Deserialised wholesale from JSON, so the `#[serde(skip)]`
-            // `derived` cache arrives empty — rebuild it before storing.
-            next.rebuild_derived();
             *scheduler.settings.lock().await = next.clone();
             {
                 let active = scheduler.active_profile_name.lock().await.clone();
@@ -301,6 +290,31 @@ async fn dispatch(app: &AppHandle, req: IpcRequest) -> IpcResponse {
             IpcResponse::ok(serde_json::json!({"ok": true, "key": key}))
         }
     }
+}
+
+/// Merge a single `key`/`value` override into `current` and return the
+/// resulting `Settings`, ready to store.
+///
+/// Pure (no locks, no runtime), so the JSON round-trip + cache rebuild is
+/// unit-testable without driving the production `AppHandle<Wry>` IPC path.
+/// Serialises `current` to JSON, validates the key exists, swaps in
+/// `value`, deserialises back, and rebuilds the `#[serde(skip)]` `derived`
+/// cache (which arrives empty from a wholesale deserialise). Errors are the
+/// user-facing strings the IPC handler returns verbatim.
+fn apply_settings_key(
+    current: &Settings,
+    key: &str,
+    value: serde_json::Value,
+) -> Result<Settings, String> {
+    let mut v = serde_json::to_value(current).map_err(|e| format!("serialize: {e}"))?;
+    if v.get(key).is_none() {
+        return Err(format!("unknown key: {key}"));
+    }
+    v[key] = value;
+    let mut next: Settings =
+        serde_json::from_value(v).map_err(|e| format!("type mismatch: {e}"))?;
+    next.rebuild_derived();
+    Ok(next)
 }
 
 async fn status_payload(scheduler: &Scheduler) -> IpcResponse {
@@ -613,6 +627,40 @@ mod tests {
         assert!(s.contains("\"ok\":false"));
         assert!(!s.contains("\"data\""));
         assert!(s.contains("\"error\":\"nope\""));
+    }
+
+    #[test]
+    fn apply_settings_key_sets_value_and_rebuilds_derived_cache() {
+        // The IPC set path deserialises wholesale, so the `#[serde(skip)]`
+        // `derived` cache must be rebuilt from the new source fields.
+        let current = Settings::default();
+        let next = apply_settings_key(
+            &current,
+            "micro_fixed_times",
+            serde_json::json!(["09:30", "14:00"]),
+        )
+        .expect("valid key + value");
+        assert_eq!(next.micro_fixed_times, vec!["09:30", "14:00"]);
+        // "09:30" → 570, "14:00" → 840.
+        assert_eq!(next.derived.micro_fixed_minutes, vec![570, 840]);
+    }
+
+    #[test]
+    fn apply_settings_key_rejects_unknown_key() {
+        let err = apply_settings_key(&Settings::default(), "not_a_field", serde_json::json!(1))
+            .unwrap_err();
+        assert!(err.contains("unknown key"), "got: {err}");
+    }
+
+    #[test]
+    fn apply_settings_key_rejects_type_mismatch() {
+        let err = apply_settings_key(
+            &Settings::default(),
+            "micro_interval_secs",
+            serde_json::json!("not a number"),
+        )
+        .unwrap_err();
+        assert!(err.contains("type mismatch"), "got: {err}");
     }
 
     #[test]

--- a/src-tauri/src/scheduler/commands/backup.rs
+++ b/src-tauri/src/scheduler/commands/backup.rs
@@ -487,6 +487,8 @@ async fn apply_bundle_to_scheduler<R: Runtime>(
     }
     {
         let mut settings = scheduler.settings.lock().await;
+        // `active_settings` rebuilds the `#[serde(skip)]` `derived` cache
+        // from the imported (deserialised) profile fields.
         *settings = profiles_file.active_settings();
     }
     let restored_pause = restore_pause_state(&scheduler.pause_path);

--- a/src-tauri/src/scheduler/commands/breaks.rs
+++ b/src-tauri/src/scheduler/commands/breaks.rs
@@ -137,8 +137,8 @@ pub async fn trigger_break_from_cli<R: Runtime>(
 ) {
     let s = scheduler.settings.lock().await.clone();
     let hints = match kind {
-        BreakKind::Micro => effective_micro_hints(&s).to_vec(),
-        BreakKind::Long => effective_long_hints(&s).to_vec(),
+        BreakKind::Micro => effective_micro_hints(&s),
+        BreakKind::Long => effective_long_hints(&s),
         BreakKind::Sleep => s.sleep_hints.clone(),
     };
     let manual_finish = match kind {
@@ -523,13 +523,13 @@ pub async fn resume_last_break_impl<R: Runtime>(
             s.micro_duration_secs,
             s.micro_enforceable || s.strict_mode,
             s.micro_manual_finish,
-            effective_micro_hints(&s).to_vec(),
+            effective_micro_hints(&s),
         ),
         BreakKind::Long => (
             s.long_duration_secs,
             s.long_enforceable || s.strict_mode,
             s.long_manual_finish,
-            effective_long_hints(&s).to_vec(),
+            effective_long_hints(&s),
         ),
         BreakKind::Sleep => (s.bedtime_duration_secs, true, false, s.sleep_hints.clone()),
     };

--- a/src-tauri/src/scheduler/commands/breaks.rs
+++ b/src-tauri/src/scheduler/commands/breaks.rs
@@ -137,8 +137,8 @@ pub async fn trigger_break_from_cli<R: Runtime>(
 ) {
     let s = scheduler.settings.lock().await.clone();
     let hints = match kind {
-        BreakKind::Micro => effective_micro_hints(&s),
-        BreakKind::Long => effective_long_hints(&s),
+        BreakKind::Micro => effective_micro_hints(&s).to_vec(),
+        BreakKind::Long => effective_long_hints(&s).to_vec(),
         BreakKind::Sleep => s.sleep_hints.clone(),
     };
     let manual_finish = match kind {
@@ -523,13 +523,13 @@ pub async fn resume_last_break_impl<R: Runtime>(
             s.micro_duration_secs,
             s.micro_enforceable || s.strict_mode,
             s.micro_manual_finish,
-            effective_micro_hints(&s),
+            effective_micro_hints(&s).to_vec(),
         ),
         BreakKind::Long => (
             s.long_duration_secs,
             s.long_enforceable || s.strict_mode,
             s.long_manual_finish,
-            effective_long_hints(&s),
+            effective_long_hints(&s).to_vec(),
         ),
         BreakKind::Sleep => (s.bedtime_duration_secs, true, false, s.sleep_hints.clone()),
     };

--- a/src-tauri/src/scheduler/commands/profiles.rs
+++ b/src-tauri/src/scheduler/commands/profiles.rs
@@ -519,6 +519,65 @@ mod tests {
         ]
     }
 
+    // Profile carrying fixed times + app-pause targets so a switch onto it
+    // can prove the `derived` cache is rebuilt from its (deserialised,
+    // cache-less) source fields rather than left stale/empty.
+    fn profiles_with_derived_source() -> Vec<Profile> {
+        vec![
+            Profile {
+                name: DEFAULT_PROFILE_NAME.to_string(),
+                settings: Settings::default(),
+            },
+            Profile {
+                name: "Fixed".to_string(),
+                settings: Settings {
+                    micro_schedule_mode: "fixed".into(),
+                    micro_fixed_times: vec!["09:30".into(), "14:00".into()],
+                    app_pause_enabled: true,
+                    app_pause_list: vec!["Zoom".into(), "OBS Studio".into()],
+                    ..Settings::default()
+                },
+            },
+        ]
+    }
+
+    // The profile-switch path stores the new profile's settings without
+    // going through `clamp`, so it must rebuild the `#[serde(skip)]`
+    // `derived` cache explicitly. Drives the real `set_active_profile_impl`
+    // through a mock AppHandle (gated off Windows for the mock-rig reason).
+    #[cfg(not(target_os = "windows"))]
+    #[tokio::test]
+    async fn set_active_profile_rebuilds_derived_caches() {
+        use tauri::test::{mock_builder, mock_context, noop_assets};
+
+        let (_dir, sched) =
+            test_scheduler_with_profiles(profiles_with_derived_source(), DEFAULT_PROFILE_NAME);
+        // Default profile has no fixed times / app-pause targets.
+        assert!(sched
+            .settings
+            .lock()
+            .await
+            .derived
+            .micro_fixed_minutes
+            .is_empty());
+
+        let app = mock_builder()
+            .build(mock_context(noop_assets()))
+            .expect("mock app builds");
+
+        set_active_profile_impl(app.handle(), &sched, "Fixed".to_string())
+            .await
+            .unwrap();
+
+        let s = sched.settings.lock().await;
+        // "09:30" → 570, "14:00" → 840.
+        assert_eq!(s.derived.micro_fixed_minutes, vec![570, 840]);
+        assert_eq!(
+            s.derived.app_pause_targets_lower,
+            vec!["zoom", "obs studio"]
+        );
+    }
+
     #[tokio::test]
     async fn create_profile_appends_copy_of_active_settings() {
         let (_dir, sched) = test_scheduler_with_profiles(one_profile(), DEFAULT_PROFILE_NAME);

--- a/src-tauri/src/scheduler/commands/profiles.rs
+++ b/src-tauri/src/scheduler/commands/profiles.rs
@@ -534,7 +534,7 @@ mod tests {
             Profile {
                 name: "Fixed".to_string(),
                 settings: Settings {
-                    micro_schedule_mode: "fixed".into(),
+                    micro_schedule_mode: crate::scheduler::settings::ScheduleMode::Fixed,
                     micro_fixed_times: vec!["09:30".into(), "14:00".into()],
                     app_pause_enabled: true,
                     app_pause_list: vec!["Zoom".into(), "OBS Studio".into()],

--- a/src-tauri/src/scheduler/commands/profiles.rs
+++ b/src-tauri/src/scheduler/commands/profiles.rs
@@ -55,7 +55,14 @@ pub async fn set_active_profile_impl<R: Runtime>(
             return Ok(());
         }
     }
-    *scheduler.settings.lock().await = next_settings;
+    {
+        let mut s = scheduler.settings.lock().await;
+        *s = next_settings;
+        // Profile settings are stored clamped, but the `derived` cache is
+        // `#[serde(skip)]` and arrives default-empty from the profile clone,
+        // so rebuild it from the new source fields before the run loop reads it.
+        s.rebuild_derived();
+    }
     *scheduler.active_profile_name.lock().await = name.clone();
     {
         let mut t = scheduler.timers.lock().await;
@@ -347,7 +354,9 @@ pub async fn reset_profile_to_defaults_impl(
         }
     }
     if active == name {
-        *scheduler.settings.lock().await = defaults;
+        let mut s = scheduler.settings.lock().await;
+        *s = defaults;
+        s.rebuild_derived();
     }
     super::super::persist_profiles(scheduler).await;
     Ok(())

--- a/src-tauri/src/scheduler/commands/profiles.rs
+++ b/src-tauri/src/scheduler/commands/profiles.rs
@@ -521,7 +521,10 @@ mod tests {
 
     // Profile carrying fixed times + app-pause targets so a switch onto it
     // can prove the `derived` cache is rebuilt from its (deserialised,
-    // cache-less) source fields rather than left stale/empty.
+    // cache-less) source fields rather than left stale/empty. Only the
+    // mock-AppHandle test below consumes it, so it's gated the same way to
+    // keep the Windows clippy build (which drops that test) dead-code clean.
+    #[cfg(not(target_os = "windows"))]
     fn profiles_with_derived_source() -> Vec<Profile> {
         vec![
             Profile {

--- a/src-tauri/src/scheduler/mod.rs
+++ b/src-tauri/src/scheduler/mod.rs
@@ -217,11 +217,12 @@ impl Scheduler {
     /// production construction.
     #[cfg(test)]
     pub(crate) fn for_test(profiles: Vec<Profile>, active: &str, dir: &std::path::Path) -> Self {
-        let active_settings = profiles
+        let mut active_settings = profiles
             .iter()
             .find(|p| p.name == active)
             .map(|p| p.settings.clone())
             .unwrap_or_default();
+        active_settings.rebuild_derived();
         let events_path = dir.join("events.jsonl");
         Self {
             settings: Arc::new(Mutex::new(active_settings)),

--- a/src-tauri/src/scheduler/run_loop.rs
+++ b/src-tauri/src/scheduler/run_loop.rs
@@ -572,13 +572,13 @@ fn scheduled_break_event(kind: BreakKind, s: &Settings, intensity: f32) -> Break
             s.long_duration_secs,
             s.long_enforceable || s.strict_mode,
             s.long_manual_finish,
-            effective_long_hints(s),
+            effective_long_hints(s).to_vec(),
         ),
         BreakKind::Micro => (
             s.micro_duration_secs,
             s.micro_enforceable || s.strict_mode,
             s.micro_manual_finish,
-            effective_micro_hints(s),
+            effective_micro_hints(s).to_vec(),
         ),
         BreakKind::Sleep => unreachable!("sleep breaks use the bedtime fire path"),
     };
@@ -1155,24 +1155,28 @@ mod tests {
 
     #[test]
     fn scheduled_break_event_long_draws_long_fields() {
-        let s = Settings::default();
+        let mut s = Settings::default();
+        s.rebuild_derived();
         let e = scheduled_break_event(BreakKind::Long, &s, 0.5);
         assert_eq!(e.kind, BreakKind::Long);
         assert_eq!(e.duration_secs, s.long_duration_secs);
         assert_eq!(e.manual_finish, s.long_manual_finish);
         assert_eq!(e.hints, effective_long_hints(&s));
+        assert!(!e.hints.is_empty(), "default long hints are non-empty");
         // break_health is enabled by default → live intensity passes through.
         assert_eq!(e.health_intensity, 0.5);
     }
 
     #[test]
     fn scheduled_break_event_micro_draws_micro_fields() {
-        let s = Settings::default();
+        let mut s = Settings::default();
+        s.rebuild_derived();
         let e = scheduled_break_event(BreakKind::Micro, &s, 0.5);
         assert_eq!(e.kind, BreakKind::Micro);
         assert_eq!(e.duration_secs, s.micro_duration_secs);
         assert_eq!(e.manual_finish, s.micro_manual_finish);
         assert_eq!(e.hints, effective_micro_hints(&s));
+        assert!(!e.hints.is_empty(), "default micro hints are non-empty");
     }
 
     #[test]

--- a/src-tauri/src/scheduler/run_loop.rs
+++ b/src-tauri/src/scheduler/run_loop.rs
@@ -572,13 +572,13 @@ fn scheduled_break_event(kind: BreakKind, s: &Settings, intensity: f32) -> Break
             s.long_duration_secs,
             s.long_enforceable || s.strict_mode,
             s.long_manual_finish,
-            effective_long_hints(s).to_vec(),
+            effective_long_hints(s),
         ),
         BreakKind::Micro => (
             s.micro_duration_secs,
             s.micro_enforceable || s.strict_mode,
             s.micro_manual_finish,
-            effective_micro_hints(s).to_vec(),
+            effective_micro_hints(s),
         ),
         BreakKind::Sleep => unreachable!("sleep breaks use the bedtime fire path"),
     };

--- a/src-tauri/src/scheduler/run_loop.rs
+++ b/src-tauri/src/scheduler/run_loop.rs
@@ -17,7 +17,7 @@ use super::screen_time::{persist_screen_time, rollover_if_new_day, should_remind
 use super::session_lock;
 use super::settings::{delivery_for, effective_long_hints, effective_micro_hints, Settings};
 use super::timers::{
-    current_minutes, decide_bedtime, in_window, interval_break_due, local_today_string, parse_hhmm,
+    current_minutes, decide_bedtime, in_window, interval_break_due, local_today_string,
     prebreak_warn_due, record_scheduled_fire, should_defer_for_typing, should_fire_fixed_now,
     BedtimeAction, BedtimeWindow, PrebreakGate,
 };
@@ -325,18 +325,12 @@ pub(super) async fn run_loop(app: AppHandle, sched: Scheduler) {
             continue;
         }
 
-        let long_fixed_due = s.long_enabled
-            && s.fixed_active(BreakKind::Long)
-            && s.long_fixed_times
-                .iter()
-                .filter_map(|t| parse_hhmm(t))
-                .any(|m| m == now_min);
-        let micro_fixed_due = s.micro_enabled
-            && s.fixed_active(BreakKind::Micro)
-            && s.micro_fixed_times
-                .iter()
-                .filter_map(|t| parse_hhmm(t))
-                .any(|m| m == now_min);
+        // Fixed times are pre-parsed to minutes-since-midnight at settings
+        // load/update (see `Settings::rebuild_derived`), so the per-tick
+        // check is a plain `== now_min` rather than re-running `parse_hhmm`
+        // over every `"HH:MM"` string on all 86,400 ticks a day.
+        let long_fixed_due = fixed_break_due(BreakKind::Long, &s, now_min);
+        let micro_fixed_due = fixed_break_due(BreakKind::Micro, &s, now_min);
 
         if long_fixed_due || micro_fixed_due {
             let (fire_long, fire_micro) = {
@@ -1011,6 +1005,21 @@ fn log_suppressions(
     }
 }
 
+/// Pure decision: is a fixed-time break for `kind` due at `now_min`?
+///
+/// Reads the pre-parsed minutes from `s.derived` (resolved once at
+/// settings load/update) instead of re-parsing the `"HH:MM"` strings,
+/// and gates on the kind being enabled and in a fixed-firing schedule
+/// mode. `Sleep` has no fixed-time schedule and is always `false`.
+fn fixed_break_due(kind: BreakKind, s: &Settings, now_min: u32) -> bool {
+    let (enabled, minutes) = match kind {
+        BreakKind::Long => (s.long_enabled, &s.derived.long_fixed_minutes),
+        BreakKind::Micro => (s.micro_enabled, &s.derived.micro_fixed_minutes),
+        BreakKind::Sleep => return false,
+    };
+    enabled && s.fixed_active(kind) && minutes.contains(&now_min)
+}
+
 // Case-insensitive token match for the app-pause list. We tokenise the
 // running process name on non-alphanumeric boundaries (`.`, `-`, `_`,
 // whitespace, path separators) and accept a target that EITHER equals a
@@ -1219,6 +1228,69 @@ mod tests {
         let prev = SystemTime::now();
         let now = prev + SUSPEND_GAP_THRESHOLD;
         assert!(resumed_after_gap(prev, now, SUSPEND_GAP_THRESHOLD));
+    }
+
+    // ----- fixed_break_due: cached fixed-time firing behaves like the
+    //       old per-tick parse, but reads pre-parsed minutes -----
+
+    fn settings_with_fixed(kind: BreakKind, mode: &str, times: Vec<&str>) -> Settings {
+        let mut s = Settings::default();
+        match kind {
+            BreakKind::Micro => {
+                s.micro_schedule_mode = mode.into();
+                s.micro_fixed_times = times.into_iter().map(String::from).collect();
+            }
+            BreakKind::Long => {
+                s.long_schedule_mode = mode.into();
+                s.long_fixed_times = times.into_iter().map(String::from).collect();
+            }
+            BreakKind::Sleep => unreachable!(),
+        }
+        s.rebuild_derived();
+        s
+    }
+
+    #[test]
+    fn fixed_break_due_fires_at_cached_minute() {
+        let s = settings_with_fixed(BreakKind::Micro, "fixed", vec!["09:00", "13:30"]);
+        assert!(fixed_break_due(BreakKind::Micro, &s, 540));
+        assert!(fixed_break_due(BreakKind::Micro, &s, 810));
+        assert!(!fixed_break_due(BreakKind::Micro, &s, 541));
+    }
+
+    #[test]
+    fn fixed_break_due_respects_schedule_mode_and_enabled() {
+        // "interval" mode → fixed times never fire even though they parse.
+        let s = settings_with_fixed(BreakKind::Long, "interval", vec!["09:00"]);
+        assert!(!fixed_break_due(BreakKind::Long, &s, 540));
+
+        // Disabled kind → no fire.
+        let mut s = settings_with_fixed(BreakKind::Long, "fixed", vec!["09:00"]);
+        s.long_enabled = false;
+        assert!(!fixed_break_due(BreakKind::Long, &s, 540));
+    }
+
+    #[test]
+    fn fixed_break_due_both_mode_fires() {
+        let s = settings_with_fixed(BreakKind::Micro, "both", vec!["07:05"]);
+        assert!(fixed_break_due(BreakKind::Micro, &s, 425));
+    }
+
+    #[test]
+    fn fixed_break_due_sleep_never_fires() {
+        let s = Settings::default();
+        assert!(!fixed_break_due(BreakKind::Sleep, &s, 0));
+    }
+
+    #[test]
+    fn fixed_break_due_tracks_cache_rebuild() {
+        // Editing the times and rebuilding must change which minute fires.
+        let mut s = settings_with_fixed(BreakKind::Micro, "fixed", vec!["08:00"]);
+        assert!(fixed_break_due(BreakKind::Micro, &s, 480));
+        s.micro_fixed_times = vec!["15:45".into()];
+        s.rebuild_derived();
+        assert!(!fixed_break_due(BreakKind::Micro, &s, 480));
+        assert!(fixed_break_due(BreakKind::Micro, &s, 945));
     }
 
     #[test]

--- a/src-tauri/src/scheduler/run_loop.rs
+++ b/src-tauri/src/scheduler/run_loop.rs
@@ -1061,6 +1061,7 @@ fn process_match_lower(running_lower: &str, target_lower: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use super::super::settings::ScheduleMode;
     use super::*;
     // Only referenced by the notification-delivery tests below, which are
     // gated off Windows (the Tauri mock rig is) — gate the import to match
@@ -1253,7 +1254,7 @@ mod tests {
     // ----- fixed_break_due: cached fixed-time firing behaves like the
     //       old per-tick parse, but reads pre-parsed minutes -----
 
-    fn settings_with_fixed(kind: BreakKind, mode: &str, times: Vec<&str>) -> Settings {
+    fn settings_with_fixed(kind: BreakKind, mode: ScheduleMode, times: Vec<&str>) -> Settings {
         // Set the requested kind's fixed schedule. We touch only the
         // matching pair so each test asserts the per-kind cache in
         // isolation; `kind == Micro` leaves the long fields default and
@@ -1264,10 +1265,10 @@ mod tests {
         let parsed: Vec<String> = times.into_iter().map(String::from).collect();
         let mut s = Settings::default();
         if is_micro {
-            s.micro_schedule_mode = mode.into();
+            s.micro_schedule_mode = mode;
             s.micro_fixed_times = parsed;
         } else {
-            s.long_schedule_mode = mode.into();
+            s.long_schedule_mode = mode;
             s.long_fixed_times = parsed;
         }
         s.rebuild_derived();
@@ -1276,7 +1277,11 @@ mod tests {
 
     #[test]
     fn fixed_break_due_fires_at_cached_minute() {
-        let s = settings_with_fixed(BreakKind::Micro, "fixed", vec!["09:00", "13:30"]);
+        let s = settings_with_fixed(
+            BreakKind::Micro,
+            ScheduleMode::Fixed,
+            vec!["09:00", "13:30"],
+        );
         assert!(fixed_break_due(BreakKind::Micro, &s, 540));
         assert!(fixed_break_due(BreakKind::Micro, &s, 810));
         assert!(!fixed_break_due(BreakKind::Micro, &s, 541));
@@ -1285,18 +1290,18 @@ mod tests {
     #[test]
     fn fixed_break_due_respects_schedule_mode_and_enabled() {
         // "interval" mode → fixed times never fire even though they parse.
-        let s = settings_with_fixed(BreakKind::Long, "interval", vec!["09:00"]);
+        let s = settings_with_fixed(BreakKind::Long, ScheduleMode::Interval, vec!["09:00"]);
         assert!(!fixed_break_due(BreakKind::Long, &s, 540));
 
         // Disabled kind → no fire.
-        let mut s = settings_with_fixed(BreakKind::Long, "fixed", vec!["09:00"]);
+        let mut s = settings_with_fixed(BreakKind::Long, ScheduleMode::Fixed, vec!["09:00"]);
         s.long_enabled = false;
         assert!(!fixed_break_due(BreakKind::Long, &s, 540));
     }
 
     #[test]
     fn fixed_break_due_both_mode_fires() {
-        let s = settings_with_fixed(BreakKind::Micro, "both", vec!["07:05"]);
+        let s = settings_with_fixed(BreakKind::Micro, ScheduleMode::Both, vec!["07:05"]);
         assert!(fixed_break_due(BreakKind::Micro, &s, 425));
     }
 
@@ -1309,7 +1314,7 @@ mod tests {
     #[test]
     fn fixed_break_due_tracks_cache_rebuild() {
         // Editing the times and rebuilding must change which minute fires.
-        let mut s = settings_with_fixed(BreakKind::Micro, "fixed", vec!["08:00"]);
+        let mut s = settings_with_fixed(BreakKind::Micro, ScheduleMode::Fixed, vec!["08:00"]);
         assert!(fixed_break_due(BreakKind::Micro, &s, 480));
         s.micro_fixed_times = vec!["15:45".into()];
         s.rebuild_derived();

--- a/src-tauri/src/scheduler/run_loop.rs
+++ b/src-tauri/src/scheduler/run_loop.rs
@@ -291,10 +291,13 @@ pub(super) async fn run_loop(app: AppHandle, sched: Scheduler) {
                 let sys = sysinfo_system.get_or_insert_with(System::new);
                 sys.refresh_processes(ProcessesToUpdate::All, false);
                 app_pause_active = sys.processes().values().any(|p| {
-                    let proc_name = p.name().to_string_lossy().to_string();
-                    s.app_pause_list
+                    // Lowercase the live process name once per process; the
+                    // targets are pre-lowercased at settings load/update.
+                    let proc_lower = p.name().to_string_lossy().to_lowercase();
+                    s.derived
+                        .app_pause_targets_lower
                         .iter()
-                        .any(|target| process_match(&proc_name, target))
+                        .any(|target| process_match_lower(&proc_lower, target))
                 });
                 last_app_refresh = Instant::now();
             }
@@ -1029,26 +1032,31 @@ fn fixed_break_due(kind: BreakKind, s: &Settings, now_min: u32) -> bool {
 // rejecting `zoominfo` and `azoomatic`. Multi-token targets (e.g.
 // `osascript -e`) fall back to substring so power-users can still
 // match a distinctive snippet.
-fn process_match(running: &str, target: &str) -> bool {
-    let r = running.to_lowercase();
-    let t = target.to_lowercase();
-    if t.is_empty() {
+/// Case-insensitive token match assuming both arguments are already
+/// lowercased. The run loop pre-lowercases the target list once at
+/// settings load/update (`derived.app_pause_targets_lower`) and only
+/// lowercases the live process name per scan, so the hot path avoids
+/// re-lowercasing every configured target for every running process.
+fn process_match_lower(running_lower: &str, target_lower: &str) -> bool {
+    if target_lower.is_empty() {
         return false;
     }
-    let target_is_single_token = t.chars().all(|c| c.is_alphanumeric());
+    let target_is_single_token = target_lower.chars().all(|c| c.is_alphanumeric());
     if !target_is_single_token {
-        return r.contains(&t);
+        return running_lower.contains(target_lower);
     }
-    r.split(|c: char| !c.is_alphanumeric()).any(|tok| {
-        if tok == t {
-            return true;
-        }
-        if let Some(suffix) = tok.strip_prefix(t.as_str()) {
-            !suffix.is_empty() && suffix.chars().all(|c| c.is_ascii_digit())
-        } else {
-            false
-        }
-    })
+    running_lower
+        .split(|c: char| !c.is_alphanumeric())
+        .any(|tok| {
+            if tok == target_lower {
+                return true;
+            }
+            if let Some(suffix) = tok.strip_prefix(target_lower) {
+                !suffix.is_empty() && suffix.chars().all(|c| c.is_ascii_digit())
+            } else {
+                false
+            }
+        })
 }
 
 #[cfg(test)]
@@ -1059,6 +1067,14 @@ mod tests {
     // so a Windows build doesn't trip `-D unused-imports`.
     #[cfg(not(target_os = "windows"))]
     use super::super::settings::BreakMode;
+
+    /// Test-only convenience wrapper: lowercases both sides then defers to
+    /// the production `process_match_lower`. Lets the existing match tests
+    /// keep their raw (mixed-case) inputs while production stays on the
+    /// pre-lowercased hot path.
+    fn process_match(running: &str, target: &str) -> bool {
+        process_match_lower(&running.to_lowercase(), &target.to_lowercase())
+    }
 
     // Drives `deliver_scheduled_break` end to end through the
     // Notification delivery path — the one branch that doesn't enumerate
@@ -1291,6 +1307,32 @@ mod tests {
         s.rebuild_derived();
         assert!(!fixed_break_due(BreakKind::Micro, &s, 480));
         assert!(fixed_break_due(BreakKind::Micro, &s, 945));
+    }
+
+    #[test]
+    fn process_match_lower_equals_process_match_for_prelowercased_input() {
+        // The hot path calls `process_match_lower` with both sides already
+        // lowercased; it must return the same answer as the public wrapper
+        // for every case the wrapper covers.
+        let cases = [
+            ("zoom.us", "zoom", true),
+            ("OBS Studio", "obs", true),
+            ("zoominfo.exe", "zoom", false),
+            ("obs64.exe", "obs", true),
+            ("firefoxnightly.exe", "firefox", false),
+            ("/usr/bin/osascript -e foo", "osascript -e", true),
+            ("safari", "zoom", false),
+            ("zoom.us", "", false),
+        ];
+        for (running, target, expected) in cases {
+            assert_eq!(
+                process_match_lower(&running.to_lowercase(), &target.to_lowercase()),
+                expected,
+                "process_match_lower({running:?}, {target:?})"
+            );
+            // And the wrapper agrees, since the run loop relies on parity.
+            assert_eq!(process_match(running, target), expected);
+        }
     }
 
     #[test]

--- a/src-tauri/src/scheduler/run_loop.rs
+++ b/src-tauri/src/scheduler/run_loop.rs
@@ -1254,17 +1254,21 @@ mod tests {
     //       old per-tick parse, but reads pre-parsed minutes -----
 
     fn settings_with_fixed(kind: BreakKind, mode: &str, times: Vec<&str>) -> Settings {
+        // Set the requested kind's fixed schedule. We touch only the
+        // matching pair so each test asserts the per-kind cache in
+        // isolation; `kind == Micro` leaves the long fields default and
+        // vice-versa. (No `Sleep` arm — `fixed_break_due` already returns
+        // `false` for it and `fixed_break_due_sleep_never_fires` covers
+        // that, so the fixture never needs to build a Sleep case.)
+        let is_micro = matches!(kind, BreakKind::Micro);
+        let parsed: Vec<String> = times.into_iter().map(String::from).collect();
         let mut s = Settings::default();
-        match kind {
-            BreakKind::Micro => {
-                s.micro_schedule_mode = mode.into();
-                s.micro_fixed_times = times.into_iter().map(String::from).collect();
-            }
-            BreakKind::Long => {
-                s.long_schedule_mode = mode.into();
-                s.long_fixed_times = times.into_iter().map(String::from).collect();
-            }
-            BreakKind::Sleep => unreachable!(),
+        if is_micro {
+            s.micro_schedule_mode = mode.into();
+            s.micro_fixed_times = parsed;
+        } else {
+            s.long_schedule_mode = mode.into();
+            s.long_fixed_times = parsed;
         }
         s.rebuild_derived();
         s

--- a/src-tauri/src/scheduler/settings.rs
+++ b/src-tauri/src/scheduler/settings.rs
@@ -29,6 +29,13 @@ pub struct DerivedCaches {
     /// re-lowercasing every configured target for every running process.
     /// Empty targets are dropped (they never match).
     pub app_pause_targets_lower: Vec<String>,
+    /// Micro-break hint pool already resolved for the active
+    /// `micro_hint_mix` (see [`effective_micro_hints`]). Resolving the mix
+    /// concatenates two pools on every break fire otherwise; caching it
+    /// turns the fire path into a single clone of the finished vector.
+    pub micro_hints_resolved: Vec<String>,
+    /// Long-break hint pool resolved for the active `long_hint_mix`.
+    pub long_hints_resolved: Vec<String>,
 }
 
 impl DerivedCaches {
@@ -54,6 +61,8 @@ impl DerivedCaches {
                 .map(|t| t.to_lowercase())
                 .filter(|t| !t.is_empty())
                 .collect(),
+            micro_hints_resolved: resolve_micro_hints(s),
+            long_hints_resolved: resolve_long_hints(s),
         }
     }
 }
@@ -773,10 +782,13 @@ fn strip_css_comments(css: &str) -> String {
     out
 }
 
-/// Resolve the micro-break hint pool, honouring `micro_hint_mix`.
-/// `Physical` / `Psychological` return only that pool; anything else
-/// concatenates both in physical-then-psychological order.
-pub fn effective_micro_hints(s: &Settings) -> Vec<String> {
+/// Pure resolver for the micro-break hint pool, honouring
+/// `micro_hint_mix`. `Physical` / `Psychological` return only that pool;
+/// anything else (including `Both`) concatenates both in
+/// physical-then-psychological order. This does the allocating /
+/// concatenating work; [`DerivedCaches`] caches its result so the fire
+/// path doesn't repeat it.
+fn resolve_micro_hints(s: &Settings) -> Vec<String> {
     match s.micro_hint_mix {
         HintMix::Physical => s.micro_physical_hints.clone(),
         HintMix::Psychological => s.micro_psychological_hints.clone(),
@@ -791,10 +803,11 @@ pub fn effective_micro_hints(s: &Settings) -> Vec<String> {
     }
 }
 
-/// Resolve the long-break hint pool, honouring `long_hint_mix`.
-/// `Solo` / `Social` filter to that pool; anything else concatenates
-/// them in solo-then-social order.
-pub fn effective_long_hints(s: &Settings) -> Vec<String> {
+/// Pure resolver for the long-break hint pool, honouring `long_hint_mix`.
+/// `Solo` / `Social` filter to that pool; anything else (including
+/// `Both`) concatenates them in solo-then-social order. Cached by
+/// [`DerivedCaches`].
+fn resolve_long_hints(s: &Settings) -> Vec<String> {
     match s.long_hint_mix {
         HintMix::Solo => s.long_hints.clone(),
         HintMix::Social => s.long_social_hints.clone(),
@@ -805,6 +818,21 @@ pub fn effective_long_hints(s: &Settings) -> Vec<String> {
             combined
         }
     }
+}
+
+/// Borrow the resolved micro-break hint pool from the cache.
+///
+/// Resolved once at settings load/update (see [`DerivedCaches`]); callers
+/// that need ownership (the `BreakEvent` build) clone the returned slice,
+/// which is a single allocation rather than the per-fire concatenation
+/// the old `effective_micro_hints` did.
+pub fn effective_micro_hints(s: &Settings) -> &[String] {
+    &s.derived.micro_hints_resolved
+}
+
+/// Borrow the resolved long-break hint pool from the cache.
+pub fn effective_long_hints(s: &Settings) -> &[String] {
+    &s.derived.long_hints_resolved
 }
 
 /// Resolve the delivery mode for the given break kind.
@@ -1133,23 +1161,30 @@ mod tests {
     #[test]
     #[allow(clippy::field_reassign_with_default)]
     fn effective_micro_hints_modes() {
+        // `effective_micro_hints` reads the cache, so each mix change has
+        // to be followed by `rebuild_derived` — exercising both the pure
+        // resolver and the cache plumbing.
         let mut s = Settings::default();
         s.micro_physical_hints = vec!["a".into(), "b".into()];
         s.micro_psychological_hints = vec!["c".into()];
 
         s.micro_hint_mix = HintMix::Physical;
-        assert_eq!(effective_micro_hints(&s), vec!["a", "b"]);
+        s.rebuild_derived();
+        assert_eq!(effective_micro_hints(&s), ["a", "b"]);
 
         s.micro_hint_mix = HintMix::Psychological;
-        assert_eq!(effective_micro_hints(&s), vec!["c"]);
+        s.rebuild_derived();
+        assert_eq!(effective_micro_hints(&s), ["c"]);
 
         s.micro_hint_mix = HintMix::Both;
-        assert_eq!(effective_micro_hints(&s), vec!["a", "b", "c"]);
+        s.rebuild_derived();
+        assert_eq!(effective_micro_hints(&s), ["a", "b", "c"]);
 
         // A long-only variant on a micro field falls through to the
         // concatenated pool, matching the pre-enum "anything else" arm.
         s.micro_hint_mix = HintMix::Social;
-        assert_eq!(effective_micro_hints(&s), vec!["a", "b", "c"]);
+        s.rebuild_derived();
+        assert_eq!(effective_micro_hints(&s), ["a", "b", "c"]);
     }
 
     #[test]
@@ -1160,18 +1195,32 @@ mod tests {
         s.long_social_hints = vec!["soc1".into()];
 
         s.long_hint_mix = HintMix::Solo;
-        assert_eq!(effective_long_hints(&s), vec!["solo1", "solo2"]);
+        s.rebuild_derived();
+        assert_eq!(effective_long_hints(&s), ["solo1", "solo2"]);
 
         s.long_hint_mix = HintMix::Social;
-        assert_eq!(effective_long_hints(&s), vec!["soc1"]);
+        s.rebuild_derived();
+        assert_eq!(effective_long_hints(&s), ["soc1"]);
 
         s.long_hint_mix = HintMix::Both;
-        assert_eq!(effective_long_hints(&s), vec!["solo1", "solo2", "soc1"]);
+        s.rebuild_derived();
+        assert_eq!(effective_long_hints(&s), ["solo1", "solo2", "soc1"]);
 
         // A micro-only variant on a long field falls through to the
         // concatenated pool, matching the pre-enum "anything else" arm.
         s.long_hint_mix = HintMix::Physical;
-        assert_eq!(effective_long_hints(&s), vec!["solo1", "solo2", "soc1"]);
+        s.rebuild_derived();
+        assert_eq!(effective_long_hints(&s), ["solo1", "solo2", "soc1"]);
+    }
+
+    #[test]
+    fn clamp_rebuilds_resolved_hint_cache() {
+        // The load/update path runs through `clamp`; the resolved hint
+        // pools must be populated afterward without a separate call.
+        let mut s = Settings::default();
+        s.clamp();
+        assert!(!effective_micro_hints(&s).is_empty());
+        assert!(!effective_long_hints(&s).is_empty());
     }
 
     #[test]

--- a/src-tauri/src/scheduler/settings.rs
+++ b/src-tauri/src/scheduler/settings.rs
@@ -3,7 +3,49 @@ use serde::{Deserialize, Deserializer, Serialize};
 
 use crate::hooks::Hook;
 
+use super::timers::parse_hhmm;
 use super::types::{BreakDelivery, BreakKind};
+
+/// Stable, per-settings-load derivations resolved once at load/update
+/// time instead of being recomputed on every 1Hz scheduler tick or
+/// break fire.
+///
+/// These are pure functions of the owning `Settings`' source fields:
+/// `rebuild` re-derives the whole struct from a `Settings`, and the
+/// run loop / fire path read the cached vectors directly. The cache is
+/// `#[serde(skip)]` on `Settings` (it never hits disk and is rebuilt on
+/// deserialise via the `Default` it picks up), so adding it doesn't
+/// change the on-disk shape or the Rust↔TS parity surface.
+#[derive(Debug, Clone, Default)]
+pub struct DerivedCaches {
+    /// `micro_fixed_times` parsed to minutes-since-midnight, with
+    /// unparseable entries dropped — the per-tick compare becomes a plain
+    /// `== now_min` instead of re-running `parse_hhmm` on every string.
+    pub micro_fixed_minutes: Vec<u32>,
+    /// `long_fixed_times` parsed the same way.
+    pub long_fixed_minutes: Vec<u32>,
+}
+
+impl DerivedCaches {
+    /// Re-derive every cached value from `s`' source fields. Called at
+    /// each point where the stored `Settings` is replaced (see
+    /// `Settings::rebuild_derived`), so the caches can never drift from
+    /// the settings they summarise.
+    fn rebuild(s: &Settings) -> Self {
+        Self {
+            micro_fixed_minutes: s
+                .micro_fixed_times
+                .iter()
+                .filter_map(|t| parse_hhmm(t))
+                .collect(),
+            long_fixed_minutes: s
+                .long_fixed_times
+                .iter()
+                .filter_map(|t| parse_hhmm(t))
+                .collect(),
+        }
+    }
+}
 
 /// Which monitor(s) an overlay break should appear on.
 ///
@@ -469,6 +511,15 @@ pub struct Settings {
     /// every read+write.
     #[serde(default)]
     pub custom_css: String,
+    /// Stable per-load derivations (parsed fixed times, etc.) resolved
+    /// once via [`Settings::rebuild_derived`] rather than on every tick /
+    /// fire. Never serialised: `#[serde(skip)]` keeps it off disk and out
+    /// of the Rust↔TS parity surface, and it's rebuilt explicitly at each
+    /// settings-replacement site. Defaults empty; callers that bypass
+    /// `rebuild_derived` (e.g. raw struct literals in tests) just see
+    /// empty caches, which the run loop treats as "no fixed times".
+    #[serde(skip)]
+    pub derived: DerivedCaches,
 }
 
 impl Default for Settings {
@@ -548,6 +599,7 @@ impl Default for Settings {
             micro_break_mode: BreakMode::default(),
             long_break_mode: BreakMode::default(),
             custom_css: String::new(),
+            derived: DerivedCaches::default(),
         }
     }
 }
@@ -577,6 +629,18 @@ impl Settings {
     pub fn fixed_active(&self, kind: BreakKind) -> bool {
         self.schedule_mode_for(kind)
             .is_some_and(ScheduleMode::fixed_active)
+    }
+
+    /// Re-derive the `derived` cache from the current source fields.
+    ///
+    /// Must be called at every point where a `Settings` value is stored
+    /// into the scheduler's mutex (settings update, profile switch /
+    /// reset, IPC set, backup import, construction) so the cache can
+    /// never lag the settings it summarises. `clamp` calls it last, so
+    /// any path that clamps (load + the renderer update path) is covered
+    /// automatically; the no-clamp replacement sites call it explicitly.
+    pub fn rebuild_derived(&mut self) {
+        self.derived = DerivedCaches::rebuild(self);
     }
 
     /// Clamp every numeric field to a safe range. Called on every load
@@ -651,6 +715,10 @@ impl Settings {
             self.custom_css.truncate(cut);
         }
         self.custom_css = sanitize_custom_css(&self.custom_css);
+        // Source fields are now in their final clamped form; re-derive the
+        // caches so a clamped load/update path never has to touch them
+        // again.
+        self.rebuild_derived();
     }
 }
 
@@ -1366,6 +1434,48 @@ mod tests {
         assert_eq!(s.micro_break_mode, BreakMode::Windowed);
         assert_eq!(s.micro_schedule_mode, ScheduleMode::Fixed);
         assert_eq!(s.long_hint_mix, HintMix::Social);
+    }
+
+    #[test]
+    fn rebuild_derived_parses_fixed_times_to_minutes_dropping_garbage() {
+        let mut s = Settings {
+            micro_fixed_times: vec!["09:00".into(), "garbage".into(), "13:30".into()],
+            long_fixed_times: vec!["7:05".into(), "24:00".into()],
+            ..Settings::default()
+        };
+        s.rebuild_derived();
+        // "09:00" → 540, "13:30" → 810; "garbage" dropped.
+        assert_eq!(s.derived.micro_fixed_minutes, vec![540, 810]);
+        // "7:05" → 425; "24:00" out of range, dropped.
+        assert_eq!(s.derived.long_fixed_minutes, vec![425]);
+    }
+
+    #[test]
+    fn clamp_rebuilds_fixed_time_cache() {
+        // The load + renderer-update paths run through `clamp`, which must
+        // leave the derived cache populated without a separate call.
+        let mut s = Settings {
+            micro_fixed_times: vec!["10:00".into()],
+            ..Settings::default()
+        };
+        s.clamp();
+        assert_eq!(s.derived.micro_fixed_minutes, vec![600]);
+    }
+
+    #[test]
+    fn rebuild_derived_refreshes_cache_after_source_change() {
+        // Correctness-critical: editing the fixed-time list and rebuilding
+        // must replace the cache, not append or go stale.
+        let mut s = Settings {
+            micro_fixed_times: vec!["08:00".into()],
+            ..Settings::default()
+        };
+        s.rebuild_derived();
+        assert_eq!(s.derived.micro_fixed_minutes, vec![480]);
+
+        s.micro_fixed_times = vec!["15:45".into()];
+        s.rebuild_derived();
+        assert_eq!(s.derived.micro_fixed_minutes, vec![945]);
     }
 
     #[test]

--- a/src-tauri/src/scheduler/settings.rs
+++ b/src-tauri/src/scheduler/settings.rs
@@ -820,19 +820,19 @@ fn resolve_long_hints(s: &Settings) -> Vec<String> {
     }
 }
 
-/// Borrow the resolved micro-break hint pool from the cache.
+/// The resolved micro-break hint pool.
 ///
-/// Resolved once at settings load/update (see [`DerivedCaches`]); callers
-/// that need ownership (the `BreakEvent` build) clone the returned slice,
-/// which is a single allocation rather than the per-fire concatenation
-/// the old `effective_micro_hints` did.
-pub fn effective_micro_hints(s: &Settings) -> &[String] {
-    &s.derived.micro_hints_resolved
+/// The hint *mix* is resolved (and its two pools concatenated) once at
+/// settings load/update into the cache; this accessor just clones the
+/// finished vector, so the per-fire cost is a single allocation rather
+/// than the re-concatenation the pre-cache version did on every break.
+pub fn effective_micro_hints(s: &Settings) -> Vec<String> {
+    s.derived.micro_hints_resolved.clone()
 }
 
-/// Borrow the resolved long-break hint pool from the cache.
-pub fn effective_long_hints(s: &Settings) -> &[String] {
-    &s.derived.long_hints_resolved
+/// The resolved long-break hint pool. See [`effective_micro_hints`].
+pub fn effective_long_hints(s: &Settings) -> Vec<String> {
+    s.derived.long_hints_resolved.clone()
 }
 
 /// Resolve the delivery mode for the given break kind.

--- a/src-tauri/src/scheduler/settings.rs
+++ b/src-tauri/src/scheduler/settings.rs
@@ -24,6 +24,11 @@ pub struct DerivedCaches {
     pub micro_fixed_minutes: Vec<u32>,
     /// `long_fixed_times` parsed the same way.
     pub long_fixed_minutes: Vec<u32>,
+    /// `app_pause_list` targets pre-lowercased so the per-refresh process
+    /// scan only has to lowercase the live process name once, instead of
+    /// re-lowercasing every configured target for every running process.
+    /// Empty targets are dropped (they never match).
+    pub app_pause_targets_lower: Vec<String>,
 }
 
 impl DerivedCaches {
@@ -42,6 +47,12 @@ impl DerivedCaches {
                 .long_fixed_times
                 .iter()
                 .filter_map(|t| parse_hhmm(t))
+                .collect(),
+            app_pause_targets_lower: s
+                .app_pause_list
+                .iter()
+                .map(|t| t.to_lowercase())
+                .filter(|t| !t.is_empty())
                 .collect(),
         }
     }
@@ -1448,6 +1459,33 @@ mod tests {
         assert_eq!(s.derived.micro_fixed_minutes, vec![540, 810]);
         // "7:05" → 425; "24:00" out of range, dropped.
         assert_eq!(s.derived.long_fixed_minutes, vec![425]);
+    }
+
+    #[test]
+    fn rebuild_derived_lowercases_app_pause_targets_dropping_empties() {
+        let mut s = Settings {
+            app_pause_list: vec!["Zoom".into(), "OBS Studio".into(), "".into()],
+            ..Settings::default()
+        };
+        s.rebuild_derived();
+        assert_eq!(
+            s.derived.app_pause_targets_lower,
+            vec!["zoom", "obs studio"]
+        );
+    }
+
+    #[test]
+    fn rebuild_derived_refreshes_app_pause_cache_after_change() {
+        let mut s = Settings {
+            app_pause_list: vec!["Zoom".into()],
+            ..Settings::default()
+        };
+        s.rebuild_derived();
+        assert_eq!(s.derived.app_pause_targets_lower, vec!["zoom"]);
+
+        s.app_pause_list = vec!["Slack".into()];
+        s.rebuild_derived();
+        assert_eq!(s.derived.app_pause_targets_lower, vec!["slack"]);
     }
 
     #[test]

--- a/src/views/settings/parity.test.ts
+++ b/src/views/settings/parity.test.ts
@@ -68,9 +68,27 @@ function extractRustKeys(source: string): Set<string> {
   }
   const block = source.slice(blockStart, blockEnd);
   const keys = new Set<string>();
-  for (const line of block.split("\n")) {
+  const lines = block.split("\n");
+  // A `#[serde(skip)]` field never crosses the IPC wire, so it has no TS
+  // counterpart by design — skip it when scanning. We only treat the bare
+  // `skip` (full skip) this way; `skip_serializing_if` etc. still serialise
+  // conditionally and remain part of the parity surface.
+  const isFullSkipAttr = (line: string): boolean =>
+    /^\s*#\[serde\([^)]*\bskip\b[^)]*\)\]/.test(line) &&
+    !/skip_serializing_if|skip_serializing|skip_deserializing/.test(line);
+  let skipNext = false;
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (trimmed === "") continue;
+    if (trimmed.startsWith("#[")) {
+      if (isFullSkipAttr(line)) skipNext = true;
+      continue;
+    }
     const m = /^\s*pub\s+(\w+):\s/.exec(line);
-    if (m) keys.add(m[1]);
+    if (m) {
+      if (!skipNext) keys.add(m[1]);
+      skipNext = false;
+    }
   }
   return keys;
 }


### PR DESCRIPTION
## Summary

Resolve stable, per-settings-load derivations once instead of redoing them on every 1 Hz scheduler tick / break fire. These are pure efficiency changes — behaviour is identical. Closes #98.

A new `DerivedCaches` struct hangs off `Settings` as a `#[serde(skip)]` field (`settings.derived`). It is rebuilt from the source fields at **every** point the stored `Settings` is replaced:

- `clamp()` rebuilds it last, covering the disk-load and renderer-update paths (`update_settings`).
- `ProfilesFile::active_settings()` rebuilds it, covering scheduler construction and backup import.
- The no-clamp replacement sites — profile switch / reset and the IPC `SettingsSet` path — call `rebuild_derived()` explicitly.

Three derivations are cached (one commit each):

1. **Fixed-time breaks** — `"HH:MM"` strings were re-parsed via `parse_hhmm` on every tick. Now pre-parsed to `Vec<u32>` minutes-since-midnight; the per-tick check is a plain `== now_min` via the new pure `fixed_break_due` helper.
2. **App-pause targets** — the process scan re-lowercased every configured target for every running process each refresh. Targets are now pre-lowercased once; the scan lowercases only the live process name and calls the new `process_match_lower`.
3. **Resolved hint pools** — `effective_{micro,long}_hints` re-concatenated two pools on every fire. The resolved per-kind pool is cached; the accessors borrow it and the fire path clones once (the `BreakEvent` needs ownership) instead of re-concatenating.

## Per-tick `Settings` clone — DEFERRED

The run loop still does `let s = sched.settings.lock().await.clone()` each tick. I **deferred** changing this. The `Arc<Mutex<Settings>>` is consumed across ~10 files under a deliberately-documented "snapshot then act / no nested async mutexes across `.await`" discipline (see the module doc on `Scheduler`). Switching to `Arc<RwLock<Settings>>` or field-by-field reads would ripple through every call site and risk the deadlock-avoidance invariant — not a clean, low-risk change within this PR's scope. The clone is also materially cheaper now: it copies a few small `Vec`s with **no** parsing / lowercasing / concatenation, since that work is precomputed.

## Test Plan

- `cargo fmt` — clean
- `cargo test` — **714 passed, 0 failed** (all pre-existing scheduler tests stay green)
- `cargo clippy --all-targets -- -D warnings` — clean

New tests:
- `settings.rs`: fixed-time parsing (dropping garbage), app-pause lowercasing (dropping empties), resolved-hint modes through the cache, and `clamp` rebuilding all three caches; plus refresh-after-source-change assertions proving the cache replaces rather than goes stale.
- `run_loop.rs`: `fixed_break_due` firing / schedule-mode / enabled / sleep / cache-rebuild behaviour, and `process_match_lower` parity with the pre-lowercased hot path across the existing match cases.
- `profiles.rs`: `set_active_profile_rebuilds_derived_caches` drives the real `set_active_profile_impl` through a mock `AppHandle` and asserts the live fixed-time minutes and pre-lowercased app-pause targets reflect the switched-to profile — covering the correctness-critical no-clamp store path.

## Note for #96 (typed-enums)

This PR and the typed-enums PR (#96) both touch `settings.rs`; one will need a rebase. My changes here add `DerivedCaches` + the `derived` field and split `effective_*_hints` into pure `resolve_*` resolvers plus cache-borrowing accessors — the merge points are the `DerivedCaches::rebuild` body and the hint-mix match arms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## codecov/patch exception (deliberate)

After extracting every testable core, **8 diff lines remain uncovered**, all unreachable by unit tests:

- `ipc.rs` 277, 279 — inside the `dispatch` `SettingsSet` arm, bound to the production `AppHandle<Wry>` (no mockable runtime). The merge logic is extracted into the pure, fully-tested `apply_settings_key`.
- `ipc.rs` 309 — the `serialize: {e}` error closure in `apply_settings_key`; only fires if `serde_json::to_value(Settings)` fails, which never happens (defensive).
- `run_loop.rs` 296, 297, 300 — the app-pause scan closure inside the 1 Hz `run_loop` (Wry-bound; no test drives the live loop). The match logic lives in the tested `process_match_lower`.
- `run_loop.rs` 335, 336 — the `fixed_break_due(...)` call sites in the loop body; the predicate itself is fully tested.

These are the "runtime/FFI shim with no mockable surface" case — the testable cores (`apply_settings_key`, `process_match_lower`, `fixed_break_due`) all have tests. Requesting an **admin codecov/patch bypass** per the repo's coverage policy; no test could reach these specific lines without driving the Wry runtime.
