### PR TITLE
chore(deny): ignore RUSTSEC-2024-0429 (unpatched glib via Tauri GTK3)

### DIFF
--- a/src-tauri/deny.toml
+++ b/src-tauri/deny.toml
@@ -11,7 +11,16 @@ all-features = false
 version = 2
 yanked = "deny"
 unmaintained = "workspace"
-ignore = []
+ignore = [
+  # RUSTSEC-2024-0429: glib's VariantStrIter has unsound Iterator /
+  # DoubleEndedIterator impls. No patched glib version exists yet; it is a
+  # transitive dependency via Tauri's Linux GTK3 backend and cannot be
+  # upgraded independently of Tauri. Remove this ignore once a patched glib
+  # is published and pulled into a Tauri release.
+  # https://rustsec.org/advisories/RUSTSEC-2024-0429
+  # Tracking: https://github.com/drmowinckels/entracte/issues/84
+  "RUSTSEC-2024-0429",
+]
 
 [licenses]
 version = 2


### PR DESCRIPTION
## Summary

RUSTSEC-2024-0429 flags `glib@0.18.5`'s unsound `VariantStrIter` `Iterator`/`DoubleEndedIterator` impls. There is **no patched version** available — `glib` is a transitive dependency via Tauri's Linux GTK3 backend and cannot be upgraded independently of Tauri.

Per the sanctioned action in #84, this adds an explicit `RUSTSEC-2024-0429` entry to the `[advisories] ignore` list in `src-tauri/deny.toml` with an inline tracking comment (advisory URL, transitive-via-Tauri rationale, link to #84, and a note to remove the ignore once a patched glib lands in a Tauri release).

Pure config/chore change — no code added (exempt from the test requirement per AGENTS.md).

## Verification

Ran locally on macOS (cargo-deny 0.19.6):

- `cargo deny check advisories` → `advisories ok`
- `cargo deny check` → `advisories ok, bans ok, licenses ok, sources ok` (exit 0)

cargo-deny emits a benign `advisory-not-detected` warning because the glib/GTK3 Linux dependency isn't present in the macOS dependency graph; the ignore entry is parsed correctly and the check passes. On the Linux CI target the advisory will be matched and suppressed.

Authored by an AI agent (Claude Opus 4.8).

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)