### PR TITLE
fix(tray): make icon template mode macOS-only so it stays visible on Linux

### DIFF
--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -190,7 +190,7 @@ pub fn setup(app: &AppHandle) -> tauri::Result<()> {
 
     let tray = TrayIconBuilder::with_id("main")
         .icon(tray_icon)
-        .icon_as_template(true)
+        .icon_as_template(icon_is_template(std::env::consts::OS))
         .menu(&menu)
         .tooltip(tooltip_for(&initial_active))
         .show_menu_on_left_click(true)
@@ -386,6 +386,17 @@ fn tray_title_for(snapshot: &TrayCountdownSnapshot, text_enabled: bool) -> Optio
     Some(format!(" {body}"))
 }
 
+/// Whether the tray icon should be registered as a template image.
+///
+/// Template mode is a macOS-only concept: AppKit recolours a monochrome
+/// template glyph to suit the light/dark menu bar. On Linux
+/// (StatusNotifierItem / AppIndicator) and Windows there is no template
+/// recolouring, so a dark monochrome glyph stays dark and vanishes against
+/// a dark panel (#86). Only macOS gets template mode.
+fn icon_is_template(os: &str) -> bool {
+    os == "macos"
+}
+
 #[cfg_attr(target_os = "windows", allow(dead_code))]
 fn tray_icon_kind_for(snapshot: &TrayCountdownSnapshot) -> TrayIconKind {
     match snapshot {
@@ -410,7 +421,7 @@ fn spawn_countdown_ticker(app: AppHandle, tray: Arc<TrayIcon<tauri::Wry>>) {
             if Some(icon_kind) != last_icon {
                 if let Ok(icon) = Image::from_bytes(icon_kind.bytes()) {
                     let _ = tray.set_icon(Some(icon));
-                    let _ = tray.set_icon_as_template(true);
+                    let _ = tray.set_icon_as_template(icon_is_template(std::env::consts::OS));
                 }
                 last_icon = Some(icon_kind);
             }
@@ -552,6 +563,13 @@ mod tests {
         let secs = seconds_until_tomorrow_morning();
         assert!(secs >= 60);
         assert!(secs <= 36 * 60 * 60);
+    }
+
+    #[test]
+    fn icon_is_template_only_on_macos() {
+        assert!(icon_is_template("macos"));
+        assert!(!icon_is_template("linux"));
+        assert!(!icon_is_template("windows"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The tray icon was registered with `icon_as_template(true)` unconditionally (`src-tauri/src/tray.rs`, initial build at ~L193 and on every icon swap in the countdown ticker at ~L411-413). Template mode is a **macOS-only** concept: AppKit recolours a monochrome template glyph to match the light/dark menu bar. On Linux (StatusNotifierItem / AppIndicator) and Windows there is no template recolouring, so the dark monochrome stage-arch glyph stayed dark and vanished against a dark panel — exactly the report in #86 (Ubuntu 24.04, X11, dark panel).

- Extracted the decision into a pure `icon_is_template(os: &str) -> bool` helper (macOS → true, everything else → false), mirroring the `platform.rs` / `std::env::consts::OS` style, so every branch is unit-testable on a single host and only the OS read itself is uncovered.
- Wired the helper into **both** call sites: the initial `TrayIconBuilder` and the per-swap `set_icon_as_template` in the countdown ticker.
- macOS and Windows behaviour is unchanged (macOS still gets template tinting; Windows already ignored the flag).

## Asset follow-up (recommended, not in this PR)

The code fix turns template mode **off** on Linux so the OS no longer expects to recolour the glyph. However, the current `src-tauri/icons/trayIconTemplate.png` is a **solid black** stage-arch glyph on transparent background with no outline. With template off, a dark panel will still render it as dark-on-dark with low contrast. A proper fix for full Linux contrast needs a Linux-readable asset — a glyph with a light outline or a theme-appropriate fill — so it reads on both light and dark panels.

I did not produce that binary PNG here: generating a good outlined raster from `docs/img/logo.svg` isn't feasible to do well without image tooling in this environment, and AGENTS.md explicitly forbids replacing the macOS `trayIconTemplate.png` with a colored icon. The right shape is a separate Linux variant (e.g. `trayIcon.png` with an outline) selected on Linux, left as a follow-up. This PR ships the code-correctness half (template mode is no longer applied where it's meaningless/harmful), which removes the actively-wrong behaviour.

## Verification

Run on macOS (Apple Silicon):

- `cargo fmt --manifest-path src-tauri/Cargo.toml --check` — pass
- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings` — pass
- `cargo test --manifest-path src-tauri/Cargo.toml --lib` — pass (707 tests). New test `tray::tests::icon_is_template_only_on_macos` asserts macOS→true, Linux→false, Windows→false.

Could not verify on hardware: **Linux** (visual confirmation that the glyph now reads on a dark panel — see asset follow-up above; the template-mode-off change is the prerequisite) and **Windows** (no behaviour change expected). Please confirm tray visibility on a dark Linux panel.

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Opus 4.8, AI agent authored)