### PR TITLE
refactor: small overlay/stats cleanups (clamp01, shared KIND_ORDER, dead ref)

### DIFF
--- a/src/lib/stats-format.ts
+++ b/src/lib/stats-format.ts
@@ -35,6 +35,10 @@ export type SuppressionRowInput = {
   count: number;
 };
 
+/** Canonical break-kind ordering for stable colour/segment layout
+ * across the Insights views. */
+export const KIND_ORDER = ["micro", "long", "sleep"];
+
 export type SuppressionByReason = {
   reason: string;
   label: string;
@@ -62,7 +66,6 @@ export function groupSuppressionsByReason(
     }
     bucket.segments.set(r.kind, (bucket.segments.get(r.kind) ?? 0) + r.count);
   }
-  const KIND_ORDER = ["micro", "long", "sleep"];
   return [...byReason.values()]
     .map((b) => {
       const segments = [...b.segments.entries()]

--- a/src/views/break-overlay.tsx
+++ b/src/views/break-overlay.tsx
@@ -23,6 +23,7 @@ import { derivePostpone } from "./break-overlay/postpone";
 import { breakSoundFor, labelFor } from "./break-overlay/types";
 import {
   RING_RADIUS,
+  clamp01,
   systemPrefersContrast,
   systemPrefersReducedTransparency,
 } from "./break-overlay/visual";
@@ -105,7 +106,7 @@ export default function BreakOverlay() {
   const seconds = remaining % 60;
   const label = labelFor(active.kind);
   const hintText = active.hints[hintIndex] ?? "";
-  const intensity = Math.max(0, Math.min(1, active.health_intensity));
+  const intensity = clamp01(active.health_intensity);
   const dismissable = !active.enforceable;
   const showPostpone = active.postpone_available && !finished;
   const showSkip = dismissable && !finished;

--- a/src/views/break-overlay/hooks/use-break-state.ts
+++ b/src/views/break-overlay/hooks/use-break-state.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { pickRotationTheme } from "../../../lib/color";
@@ -51,7 +51,6 @@ export function useBreakState(deps: BreakStateDeps = {}): BreakStateApi {
     DEFAULT_OVERLAY_SETTINGS,
   );
   const [resolvedTheme, setResolvedTheme] = useState<string>("dark");
-  const startedAtRef = useRef<number>(0);
 
   const clearBreak = useCallback(() => {
     setActive(null);
@@ -96,7 +95,6 @@ export function useBreakState(deps: BreakStateDeps = {}): BreakStateApi {
         hints.length > 0 ? Math.floor(Math.random() * hints.length) : 0;
       setHintIndex(initialIndex);
       setFinished(false);
-      startedAtRef.current = Date.now();
       setActive({ ...payload, hints });
       setRemaining(payload.duration_secs);
       try {

--- a/src/views/break-overlay/hooks/use-overlay-css-vars.ts
+++ b/src/views/break-overlay/hooks/use-overlay-css-vars.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from "react";
 import type { RefObject } from "react";
-import { RING_CIRCUMFERENCE, progressColor, rgbFor } from "../visual";
+import { RING_CIRCUMFERENCE, clamp01, progressColor, rgbFor } from "../visual";
 import type { BreakEvent, OverlaySettings } from "../types";
 
 export type OverlayCssVarsRefs = {
@@ -27,7 +27,7 @@ export function useOverlayCssVars(
   useEffect(() => {
     const el = rootRef.current;
     if (!el || !active) return;
-    const intensity = Math.max(0, Math.min(1, active.health_intensity));
+    const intensity = clamp01(active.health_intensity);
     const bg = highContrast
       ? "#000000"
       : `rgba(${rgbFor(resolvedTheme, appearance.overlay_custom_rgb)}, ${(opaque ? 1 : appearance.overlay_opacity).toFixed(3)})`;

--- a/src/views/break-overlay/visual.test.ts
+++ b/src/views/break-overlay/visual.test.ts
@@ -2,11 +2,25 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   RING_CIRCUMFERENCE,
   RING_RADIUS,
+  clamp01,
   progressColor,
   rgbFor,
   systemPrefersContrast,
   systemPrefersReducedTransparency,
 } from "./visual";
+
+describe("clamp01", () => {
+  it("passes through values already inside [0, 1]", () => {
+    expect(clamp01(0)).toBe(0);
+    expect(clamp01(0.42)).toBe(0.42);
+    expect(clamp01(1)).toBe(1);
+  });
+
+  it("clamps out-of-range values to the nearest bound", () => {
+    expect(clamp01(-0.5)).toBe(0);
+    expect(clamp01(1.7)).toBe(1);
+  });
+});
 
 describe("rgbFor", () => {
   it("returns the custom RGB string verbatim when theme is 'custom'", () => {

--- a/src/views/break-overlay/visual.ts
+++ b/src/views/break-overlay/visual.ts
@@ -49,3 +49,10 @@ export function progressColor(remainingFraction: number): string {
   const b = Math.round(RING_START[2] * t + RING_END[2] * (1 - t));
   return `rgb(${r}, ${g}, ${b})`;
 }
+
+/** Clamp a value into the `[0, 1]` range. Used for the overlay's
+ * health-intensity fraction, which a stale or out-of-range break event
+ * could otherwise push past the bounds the vignette CSS expects. */
+export function clamp01(value: number): number {
+  return Math.max(0, Math.min(1, value));
+}

--- a/src/views/settings/components/suppression-bars.tsx
+++ b/src/views/settings/components/suppression-bars.tsx
@@ -1,4 +1,7 @@
-import { groupSuppressionsByReason } from "../../../lib/stats-format";
+import {
+  KIND_ORDER,
+  groupSuppressionsByReason,
+} from "../../../lib/stats-format";
 import type { SuppressionByKind } from "../types";
 
 const KIND_LABEL: Record<string, string> = {
@@ -13,11 +16,7 @@ export function SuppressionBars({ rows }: { rows: SuppressionByKind[] }) {
   const max = Math.max(1, ...grouped.map((g) => g.total));
   const kindsPresent = Array.from(
     new Set(grouped.flatMap((g) => g.segments.map((s) => s.kind))),
-  ).sort(
-    (a, b) =>
-      ["micro", "long", "sleep"].indexOf(a) -
-      ["micro", "long", "sleep"].indexOf(b),
-  );
+  ).sort((a, b) => KIND_ORDER.indexOf(a) - KIND_ORDER.indexOf(b));
   return (
     <div
       className="suppression-bars"


### PR DESCRIPTION
## Summary

Three contained, behaviour-preserving quality cleanups surfaced by a `/simplify` review:

- **`clamp01` helper** — extract the `[0,1]` health-intensity clamp into `break-overlay/visual.ts` and call it from `break-overlay.tsx` and `use-overlay-css-vars.ts`, replacing two copies of `Math.max(0, Math.min(1, …))`.
- **Shared `KIND_ORDER`** — hoist/export the micro/long/sleep ordering from `stats-format.ts` (it was a local const there *and* inlined twice in one sort expression in `suppression-bars.tsx`); both now reference one source.
- **Drop dead `startedAtRef`** in `use-break-state.ts` — written on every break start but never read; the now-unused `useRef` import goes with it.

No behaviour change; pure dedup/dead-code removal.

## Test Plan

- `tsc --noEmit` — clean
- `prettier --check` on all changed files — clean
- `vitest` — 80 affected tests pass (visual, suppression-bars, use-break-state, break-overlay, stats-format), incl. a new `clamp01` test covering in-range pass-through and out-of-range clamping

🤖 Generated with [Claude Code](https://claude.com/claude-code)