### PR TITLE
fix: never start paused media around breaks + warn on unreliable OSes (#104, #103)

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -84,12 +84,13 @@ Helper components in [src/views/settings/components/rows.tsx](../src/views/setti
 
 ## Per-OS detection
 
-| Feature | macOS                                                         | Windows                                                 | Linux                                                                                   |
-| ------- | ------------------------------------------------------------- | ------------------------------------------------------- | --------------------------------------------------------------------------------------- |
-| DnD     | `~/Library/DoNotDisturb/DB/Assertions.json` poll              | WNF `NtQueryWnfStateData` (state `0xA3BC1875_A3BC0875`) | GNOME `gsettings … show-banners` (inverted), else KDE `Inhibited` DBus prop via `gdbus` |
-| Camera  | `log stream` event-driven                                     | `HKCU\…\ConsentStore\webcam` poll (2s)                  | walk `/proc/<pid>/fd/*` for `/dev/video*` (2s)                                          |
-| Idle    | `user-idle` crate (CGEventSourceSeconds…)                     | `user-idle` (GetLastInputInfo)                          | `user-idle` X11; Wayland is unreliable                                                  |
-| Video   | `pmset -g assertions` `PreventUserIdleDisplaySleep` poll (2s) | `powercfg /requests` DISPLAY section poll (2s)          | `systemd-inhibit --list` poll (2s), match WHAT == `idle`                                |
+| Feature                     | macOS                                                                                          | Windows                                                 | Linux                                                                                   |
+| --------------------------- | ---------------------------------------------------------------------------------------------- | ------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| DnD                         | `~/Library/DoNotDisturb/DB/Assertions.json` poll                                               | WNF `NtQueryWnfStateData` (state `0xA3BC1875_A3BC0875`) | GNOME `gsettings … show-banners` (inverted), else KDE `Inhibited` DBus prop via `gdbus` |
+| Camera                      | `log stream` event-driven                                                                      | `HKCU\…\ConsentStore\webcam` poll (2s)                  | walk `/proc/<pid>/fd/*` for `/dev/video*` (2s)                                          |
+| Idle                        | `user-idle` crate (CGEventSourceSeconds…)                                                      | `user-idle` (GetLastInputInfo)                          | `user-idle` X11; Wayland is unreliable                                                  |
+| Video                       | `pmset -g assertions` `PreventUserIdleDisplaySleep` poll (2s)                                  | `powercfg /requests` DISPLAY section poll (2s)          | `systemd-inhibit --list` poll (2s), match WHAT == `idle`                                |
+| Media pause (during breaks) | blind Play/Pause media key, gated on a display-wake assertion so it can't _start_ paused media | blind Play/Pause media key, same assertion gate         | MPRIS over `gdbus`: pause only players reporting `Playing`, resume exactly those        |
 
 The Windows WNF state name is the part most likely to need empirical verification — if Focus Assist toggling doesn't pause breaks on a Windows build, that constant is the first thing to check.
 
@@ -226,6 +227,7 @@ Configure these to enable signed/notarized builds. The workflow runs without the
 - **Auto-installing updater**: [updater.rs](../src-tauri/src/updater.rs) is a manual GitHub-releases version check, not the Tauri auto-updater plugin. Notarization (macOS) and signed-updater wiring is the remaining work.
 - **Linux DnD**: implemented for GNOME (`gsettings get org.gnome.desktop.notifications show-banners`, inverted) and KDE (the `Inhibited` DBus property on `org.freedesktop.Notifications`, read via `gdbus`). Other desktops fall through to "off" — no portable cross-DE DnD signal exists, so they fail safe. Both probes shell out and feed pure parsers (`parse_gnome_show_banners_dnd`, `parse_kde_inhibited`) that are unit-tested on every OS.
 - **Wayland idle detection**: known flaky; X11-only Linux support may be the practical limit short-term.
+- **Media pause on macOS/Windows** (`pause_media_during_breaks`): there is no portable way to enumerate players or read playback state, so the pause is a blind system Play/Pause media key. To avoid _starting_ media the user had paused (#104), it only fires when a display-wake assertion says something is likely playing (`media::media_key_pause_allowed`), and resume only reverses a toggle we ourselves sent (`media::media_key_resume_allowed`) — it never blindly hits the key on break end. It can still target the wrong player; the Settings row carries a warning InfoTip on these OSes. Linux (MPRIS) is precise and unaffected. The pause/resume path runs only from the overlay `fire_break`, never from the pre-break notification.
 
 ## Things that have bitten me
 

--- a/src-tauri/src/media.rs
+++ b/src-tauri/src/media.rs
@@ -19,9 +19,14 @@
 //!   playing, so we don't accidentally *start* media that was paused; the
 //!   matching resume sends the same key again.
 //!
-//! The testable core (the gdbus output parsers and the "which players are
-//! Playing" decision) is pure and lives at module scope so it compiles
-//! and is unit-tested on every OS, mirroring [`crate::video`].
+//! The testable core is pure and lives at module scope so it compiles and
+//! is unit-tested on every OS, mirroring [`crate::video`]: the gdbus output
+//! parsers and the "which players are Playing" decision (Linux), and the
+//! "may the blind toggle fire?" guards ([`media_key_pause_allowed`] /
+//! [`media_key_resume_allowed`], macOS/Windows). The guards keep the toggle
+//! from ever *starting* media the user had paused (#104): pause only when a
+//! display-wake assertion says something is playing, and resume only a
+//! toggle we ourselves sent.
 
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Mutex;
@@ -231,11 +236,28 @@ fn platform_resume(token: &ResumeToken) {
     }
 }
 
+/// Decide whether the macOS/Windows blind Play/Pause toggle may fire on
+/// break start. The toggle has no separate "pause" key, so sending it when
+/// nothing is playing would *start* media the user had paused (issue #104).
+/// We therefore only allow it when a display-wake assertion says something
+/// is likely playing. Pure so it's unit-tested without FFI on every OS.
+#[cfg_attr(not(any(target_os = "macos", target_os = "windows")), allow(dead_code))]
+fn media_key_pause_allowed(assertion_active: bool) -> bool {
+    assertion_active
+}
+
+/// Decide whether the resume toggle may fire on break end. Only reverse a
+/// toggle we actually sent — never blindly hit the media key for a break we
+/// did not pause, so we can't *start* media the user left paused (#104).
+/// Pure so it's unit-tested without FFI on every OS.
+#[cfg_attr(not(any(target_os = "macos", target_os = "windows")), allow(dead_code))]
+fn media_key_resume_allowed(token: &ResumeToken) -> bool {
+    matches!(token, ResumeToken::MediaKey)
+}
+
 #[cfg(any(target_os = "macos", target_os = "windows"))]
 fn platform_pause() -> ResumeToken {
-    // Only toggle when something appears to be playing, so we don't start
-    // media that the user had paused.
-    if !crate::video::assertion_active() {
+    if !media_key_pause_allowed(crate::video::assertion_active()) {
         return ResumeToken::Noop;
     }
     if media_key::send_play_pause() {
@@ -248,7 +270,7 @@ fn platform_pause() -> ResumeToken {
 
 #[cfg(any(target_os = "macos", target_os = "windows"))]
 fn platform_resume(token: &ResumeToken) {
-    if matches!(token, ResumeToken::MediaKey) && media_key::send_play_pause() {
+    if media_key_resume_allowed(token) && media_key::send_play_pause() {
         log::info!("media: sent play/pause media key to resume after break");
     }
 }
@@ -631,6 +653,21 @@ mod tests {
             "org.mpris.MediaPlayer2.Player.Pause"
         );
         assert_eq!(player_method("Play"), "org.mpris.MediaPlayer2.Player.Play");
+    }
+
+    #[test]
+    fn media_key_pause_allowed_only_when_assertion_active() {
+        assert!(media_key_pause_allowed(true));
+        assert!(!media_key_pause_allowed(false));
+    }
+
+    #[test]
+    fn media_key_resume_allowed_only_for_media_key_token() {
+        assert!(media_key_resume_allowed(&ResumeToken::MediaKey));
+        assert!(!media_key_resume_allowed(&ResumeToken::Noop));
+        assert!(!media_key_resume_allowed(&ResumeToken::Mpris(vec![
+            "org.mpris.MediaPlayer2.vlc".to_string()
+        ])));
     }
 
     #[test]

--- a/src/views/settings/components/info-tip.test.tsx
+++ b/src/views/settings/components/info-tip.test.tsx
@@ -110,4 +110,20 @@ describe("InfoTip", () => {
     const decorative = container.querySelector('[aria-hidden="true"]');
     expect(decorative?.textContent).toBe("i");
   });
+
+  it("renders a warning variant with a caution glyph and Warning label", () => {
+    const { container } = render(<InfoTip text="be careful" warn />);
+    const trigger = screen.getByRole("button", { name: /warning/i });
+    expect(trigger.className).toContain("info-tip-warn");
+    const decorative = container.querySelector('[aria-hidden="true"]');
+    expect(decorative?.textContent).toBe("!");
+  });
+
+  it("uses the plain info label and glyph when warn is not set", () => {
+    const { container } = render(<InfoTip text="just info" />);
+    const trigger = screen.getByRole("button", { name: /more information/i });
+    expect(trigger.className).not.toContain("info-tip-warn");
+    const decorative = container.querySelector('[aria-hidden="true"]');
+    expect(decorative?.textContent).toBe("i");
+  });
 });

--- a/src/views/settings/components/info-tip.tsx
+++ b/src/views/settings/components/info-tip.tsx
@@ -1,6 +1,6 @@
 import { useId, useState, type KeyboardEvent } from "react";
 
-export function InfoTip({ text }: { text: string }) {
+export function InfoTip({ text, warn }: { text: string; warn?: boolean }) {
   const [open, setOpen] = useState(false);
   const popupId = useId();
 
@@ -16,19 +16,23 @@ export function InfoTip({ text }: { text: string }) {
     }
   };
 
+  const classes = ["info-tip"];
+  if (warn) classes.push("info-tip-warn");
+  if (open) classes.push("info-tip-open");
+
   return (
     <span
-      className={open ? "info-tip info-tip-open" : "info-tip"}
+      className={classes.join(" ")}
       tabIndex={0}
       role="button"
-      aria-label="More information"
+      aria-label={warn ? "Warning" : "More information"}
       aria-expanded={open}
       aria-describedby={popupId}
       onKeyDown={onKeyDown}
       onClick={toggle}
       onBlur={() => setOpen(false)}
     >
-      <span aria-hidden="true">i</span>
+      <span aria-hidden="true">{warn ? "!" : "i"}</span>
       <span id={popupId} className="info-tip-popup" role="tooltip">
         {text}
       </span>

--- a/src/views/settings/components/rows.test.tsx
+++ b/src/views/settings/components/rows.test.tsx
@@ -270,4 +270,32 @@ describe("CheckboxRow", () => {
     expect(cb.disabled).toBe(false);
     expect(container.textContent).not.toMatch(/only/i);
   });
+
+  it("renders the tip as a warning when `tipWarn` is set", () => {
+    render(
+      <CheckboxRow
+        label="Pause media"
+        value={false}
+        onChange={() => {}}
+        tip="unreliable here"
+        tipWarn
+      />,
+    );
+    const tip = screen.getByRole("button", { name: /warning/i });
+    expect(tip.className).toContain("info-tip-warn");
+    expect(screen.getByRole("tooltip").textContent).toBe("unreliable here");
+  });
+
+  it("renders the tip as plain info when `tipWarn` is not set", () => {
+    render(
+      <CheckboxRow
+        label="Pause media"
+        value={false}
+        onChange={() => {}}
+        tip="works fine"
+      />,
+    );
+    const tip = screen.getByRole("button", { name: /more information/i });
+    expect(tip.className).not.toContain("info-tip-warn");
+  });
 });

--- a/src/views/settings/components/rows.tsx
+++ b/src/views/settings/components/rows.tsx
@@ -11,13 +11,14 @@ import type { ClockFormat } from "../types";
 type RowLabelProps = {
   label: ReactNode;
   tip?: string;
+  tipWarn?: boolean;
 };
 
-function RowLabel({ label, tip }: RowLabelProps) {
+function RowLabel({ label, tip, tipWarn }: RowLabelProps) {
   return (
     <span>
       {label}
-      {tip && <InfoTip text={tip} />}
+      {tip && <InfoTip text={tip} warn={tipWarn} />}
     </span>
   );
 }
@@ -119,6 +120,8 @@ export type CheckboxRowProps = {
   /** Restrict the control to these platforms; on others it renders disabled with a suffix. */
   onlyOn?: Platform[];
   tip?: string;
+  /** Render the tip as a warning (caution glyph + styling) instead of plain info. */
+  tipWarn?: boolean;
 };
 
 export function CheckboxRow({
@@ -127,6 +130,7 @@ export function CheckboxRow({
   onChange,
   onlyOn,
   tip,
+  tipWarn,
 }: CheckboxRowProps) {
   const platform = usePlatform();
   const supported = !onlyOn || onlyOn.includes(platform);
@@ -135,7 +139,7 @@ export function CheckboxRow({
     : `${label} (${onlyOn!.map((p) => PLATFORM_LABELS[p]).join("/")} only)`;
   return (
     <label className={`row checkbox-row${supported ? "" : " disabled"}`}>
-      <RowLabel label={displayLabel} tip={tip} />
+      <RowLabel label={displayLabel} tip={tip} tipWarn={tipWarn} />
       <input
         type="checkbox"
         checked={value}

--- a/src/views/settings/settings.css
+++ b/src/views/settings/settings.css
@@ -13,6 +13,7 @@
   --pop: var(--accent-color);
   --pop-soft: var(--secondary-color);
   --on-accent: #fff;
+  --warning-fg: #f7693a;
   color-scheme: light dark;
 }
 
@@ -28,6 +29,7 @@
     --tab-border: #d8dce4;
     --accent: var(--primary-color);
     --pop: #8e3a5a;
+    --warning-fg: #c4471c;
   }
 }
 
@@ -1228,6 +1230,23 @@ body,
   color: var(--fg);
   border-color: var(--accent);
   outline: none;
+}
+
+.settings .info-tip-warn {
+  border-color: var(--warning-fg);
+  color: var(--warning-fg);
+  font-style: normal;
+  font-family: inherit;
+}
+
+.settings .info-tip-warn:hover,
+.settings .info-tip-warn:focus-visible {
+  border-color: var(--warning-fg);
+  color: var(--warning-fg);
+}
+
+.settings .info-tip-warn .info-tip-popup {
+  border-color: var(--warning-fg);
 }
 
 .settings .info-tip-popup {

--- a/src/views/settings/tabs/quiet-tab.tsx
+++ b/src/views/settings/tabs/quiet-tab.tsx
@@ -69,10 +69,11 @@ export function QuietTab({
           label="Pause media while a break is showing"
           value={settings.pause_media_during_breaks}
           onChange={(v) => update("pause_media_during_breaks", v)}
+          tipWarn={!caps.mediaPauseGranular}
           tip={
             caps.mediaPauseGranular
               ? "When a break starts, pauses whatever is playing (video or audio) and resumes it when the break ends. This targets your media players precisely."
-              : "When a break starts, pauses whatever is playing (video or audio) and resumes it when the break ends. This sends a play/pause media key as a best-effort, so it works for most players but can't guarantee the exact app."
+              : "When a break starts, pauses whatever is playing and resumes it when the break ends. It can only send a best-effort play/pause media key, so it is unreliable: it may miss the player you meant, and it will never resume anything it did not itself pause."
           }
         />
       </section>


### PR DESCRIPTION
## Summary

Closes #104 and #103. Drafted by an AI agent.

**#104 — never start media that was paused.** The macOS/Windows media pause is a blind system Play/Pause key (no playback-status detection), so firing it when nothing is playing would *start* media the user had paused. The pause/resume decisions are now extracted into two pure, unit-tested guards in `media.rs`:
- `media_key_pause_allowed(assertion_active)` — the break-start toggle only fires when a display-wake assertion says something is likely playing.
- `media_key_resume_allowed(token)` — the break-end toggle only reverses a `MediaKey` token we ourselves set; it never blindly hits the media key.

The Linux MPRIS path (`players_to_pause`, already precise) is unchanged.

**Notification-timing part of #104:** verified the pre-break notification cannot toggle media. `notify_break_coming` (`run_loop.rs`) never calls `media::on_break_start`; only the overlay `fire_break` (`overlay.rs:281`) does. The reporter saw the start-on-notification behaviour on v0.0.1, before the assertion gate landed (#89). Documented this in AGENTS.md.

**#103 — discoverable + warned setting.** A UI row already existed in the Quiet tab; it now carries a *warning* InfoTip on macOS/Windows (where the toggle is unreliable) and a plain info tip on Linux. Added a `warn` variant to `InfoTip` (caution glyph, `Warning` aria-label, warning styling via a new `--warning-fg` CSS var for both schemes) and a `tipWarn` prop on `CheckboxRow`. No new tab.

### Tests (fail before, pass after)

- Rust (`media.rs`): `media_key_pause_allowed_only_when_assertion_active`, `media_key_resume_allowed_only_for_media_key_token`.
- Frontend: `InfoTip` "renders a warning variant…" / "uses the plain info label…"; `CheckboxRow` "renders the tip as a warning when `tipWarn`…" / "…as plain info when `tipWarn` is not set".

## Verification

Ran on macOS (Apple Silicon); could not run the Windows/Linux per-OS media FFI paths locally (no CI runner access here):

- `cargo fmt --manifest-path src-tauri/Cargo.toml --check` — pass
- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings` — pass (clean)
- `cargo test --manifest-path src-tauri/Cargo.toml --lib` — pass (708 passed, 0 failed)
- `npm run lint` — pass (0 errors; 1 pre-existing warning in `use-local-draft.ts`, untouched)
- `npm run format:check` — pass
- `npx tsc --noEmit` — pass
- `npm test` — 535/536 pass; the one failure is the known-flaky `sounds.test.ts > … 'ended' fires` audio-timing test (documented in AGENTS.md "Things that have bitten me"), which passes in isolation (38/38) and is unrelated to these changes
- `npm run build` — pass
- `npm run audit:a11y` — clean across 14 (tab × scheme) audits, console clean
- `npm run audit:knip` — pass (only the pre-existing `PreviousPeriod` warn)

The pure guards are tested on every OS in the un-gated `mod tests`, so the only uncovered lines are the FFI `media_key::send_play_pause` shims (macOS `CGEvent`, Windows `SendInput`) which can't run headless.
