### PR TITLE
feat: explain missing Skip on enforceable long breaks

### DIFF
--- a/docs/developer/architecture-internals.md
+++ b/docs/developer/architecture-internals.md
@@ -233,6 +233,8 @@ Focus styling lives in [`src/views/settings/settings.css`](https://github.com/dr
 
 Strict mode swaps the dialog for an `aria-live="assertive"` `role="alert"` region instead — the user has opted into being interrupted.
 
+When a long break is enforceable it intentionally renders no Skip control. In that case (and only that case — not micro/sleep breaks, not when Skip or Postpone are available) the overlay surfaces a static `role="note"` line explaining why and where to change it. The decision is the pure [`shouldShowEnforceableHint`](https://github.com/drmowinckels/entracte/blob/main/src/views/break-overlay/skip-hint.ts) helper; the hint is informational, not interactive, and is part of the dialog's described content rather than a live region.
+
 ### Audit infrastructure
 
 `npm run audit:a11y` boots a Vite preview, drives Chromium with puppeteer, and runs axe-core against every tab × light/dark scheme. The same script also fails on any unexpected `console.error` in the renderer. Add new violations to the explicit allowlist only when you've ruled out a real bug — the default is to fix.

--- a/src/views/break-overlay.css
+++ b/src/views/break-overlay.css
@@ -178,6 +178,14 @@
   letter-spacing: 0.03em;
 }
 
+.overlay-enforceable-hint {
+  font-size: calc(0.85rem * var(--entracte-overlay-font-scale, 1));
+  opacity: 0.55;
+  margin: 0.25rem 0 0;
+  max-width: 30ch;
+  letter-spacing: 0.02em;
+}
+
 .overlay-credit {
   position: absolute;
   bottom: 1.25rem;
@@ -226,6 +234,7 @@
 .overlay-root.high-contrast .overlay-clock,
 .overlay-root.high-contrast .overlay-hint,
 .overlay-root.high-contrast .overlay-dismiss,
+.overlay-root.high-contrast .overlay-enforceable-hint,
 .overlay-root.high-contrast .overlay-paused {
   opacity: 1;
   color: #fff;

--- a/src/views/break-overlay.test.tsx
+++ b/src/views/break-overlay.test.tsx
@@ -345,6 +345,52 @@ describe("BreakOverlay ARIA contract", () => {
     expect(note.textContent).toBe("Look 20 feet away.");
   });
 
+  it("explains the missing Skip on an enforceable long break", async () => {
+    const { getByTestId } = await startBreak(false, {
+      kind: "long",
+      duration_secs: 300,
+      enforceable: true,
+      postpone_available: false,
+    });
+    const hint = getByTestId("overlay-enforceable-hint");
+    expect(hint.getAttribute("role")).toBe("note");
+    expect(hint.tagName).toBe("P");
+    expect(hint.textContent).toMatch(/enforceable/i);
+    expect(hint.textContent).toMatch(/settings/i);
+  });
+
+  it("omits the enforceable hint when Skip is available", async () => {
+    const { queryByTestId, getByRole } = await startBreak(false, {
+      kind: "long",
+      duration_secs: 300,
+      enforceable: false,
+      postpone_available: false,
+    });
+    getByRole("button", { name: "Skip break" });
+    expect(queryByTestId("overlay-enforceable-hint")).toBeNull();
+  });
+
+  it("omits the enforceable hint when Postpone is available", async () => {
+    const { queryByTestId, getByRole } = await startBreak(false, {
+      kind: "long",
+      duration_secs: 300,
+      enforceable: true,
+      postpone_available: true,
+    });
+    getByRole("button", { name: "Postpone break" });
+    expect(queryByTestId("overlay-enforceable-hint")).toBeNull();
+  });
+
+  it("omits the enforceable hint for an enforceable micro break", async () => {
+    const { queryByTestId } = await startBreak(false, {
+      kind: "micro",
+      duration_secs: 20,
+      enforceable: true,
+      postpone_available: false,
+    });
+    expect(queryByTestId("overlay-enforceable-hint")).toBeNull();
+  });
+
   it("fires the start milestone immediately on a short break", async () => {
     // 20-second micro break: at remaining=20 we're already ≤ the
     // ten-second window once the countdown ticks one cycle. Drive

--- a/src/views/break-overlay.tsx
+++ b/src/views/break-overlay.tsx
@@ -20,6 +20,10 @@ import { useFocusTrap } from "./break-overlay/hooks/use-focus-trap";
 import { useMilestoneAnnouncer } from "./break-overlay/hooks/use-milestone-announcer";
 import { useMountFocus } from "./break-overlay/hooks/use-mount-focus";
 import { derivePostpone } from "./break-overlay/postpone";
+import {
+  ENFORCEABLE_LONG_BREAK_HINT,
+  shouldShowEnforceableHint,
+} from "./break-overlay/skip-hint";
 import { breakSoundFor, labelFor } from "./break-overlay/types";
 import {
   RING_RADIUS,
@@ -109,6 +113,12 @@ export default function BreakOverlay() {
   const dismissable = !active.enforceable;
   const showPostpone = active.postpone_available && !finished;
   const showSkip = dismissable && !finished;
+  const showEnforceableHint = shouldShowEnforceableHint({
+    kind: active.kind,
+    enforceable: active.enforceable,
+    postpone_available: active.postpone_available,
+    finished,
+  });
   const showFinishButton = finished && active.manual_finish;
   const activeSoundCfg = breakSoundFor(active.kind, appearance);
   const creditSound =
@@ -263,6 +273,15 @@ export default function BreakOverlay() {
         {showPostpone && postpone.exhausted && (
           <p className="overlay-dismiss">
             Postpone exhausted — take this break
+          </p>
+        )}
+        {showEnforceableHint && (
+          <p
+            className="overlay-enforceable-hint"
+            role="note"
+            data-testid="overlay-enforceable-hint"
+          >
+            {ENFORCEABLE_LONG_BREAK_HINT}
           </p>
         )}
       </div>

--- a/src/views/break-overlay/skip-hint.test.ts
+++ b/src/views/break-overlay/skip-hint.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { shouldShowEnforceableHint } from "./skip-hint";
+
+const base = {
+  kind: "long" as const,
+  enforceable: true,
+  postpone_available: false,
+  finished: false,
+};
+
+describe("shouldShowEnforceableHint", () => {
+  it("shows for an enforceable long break with no postpone", () => {
+    expect(shouldShowEnforceableHint(base)).toBe(true);
+  });
+
+  it("hides when the long break is dismissable (Skip available)", () => {
+    expect(shouldShowEnforceableHint({ ...base, enforceable: false })).toBe(
+      false,
+    );
+  });
+
+  it("hides when postpone is available", () => {
+    expect(
+      shouldShowEnforceableHint({ ...base, postpone_available: true }),
+    ).toBe(false);
+  });
+
+  it("hides once the break is finished", () => {
+    expect(shouldShowEnforceableHint({ ...base, finished: true })).toBe(false);
+  });
+
+  it("hides for micro breaks", () => {
+    expect(shouldShowEnforceableHint({ ...base, kind: "micro" })).toBe(false);
+  });
+
+  it("hides for sleep breaks", () => {
+    expect(shouldShowEnforceableHint({ ...base, kind: "sleep" })).toBe(false);
+  });
+});

--- a/src/views/break-overlay/skip-hint.ts
+++ b/src/views/break-overlay/skip-hint.ts
@@ -1,0 +1,24 @@
+import type { BreakEvent } from "./types";
+
+export const ENFORCEABLE_LONG_BREAK_HINT =
+  "Long breaks are set to enforceable — change in Settings → Schedule.";
+
+type SkipHintInput = Pick<
+  BreakEvent,
+  "kind" | "enforceable" | "postpone_available"
+> & { finished: boolean };
+
+/** Whether to surface the "why is there no Skip?" hint. Only the
+ * enforceable long-break case qualifies: a long break that can't be
+ * dismissed and offers no postpone leaves the user with no visible
+ * control and no explanation. Micro/sleep breaks, finished breaks, and
+ * any break that still offers Skip or Postpone are excluded — they
+ * either have a control or aren't the long-break-by-default surprise. */
+export function shouldShowEnforceableHint(input: SkipHintInput): boolean {
+  return (
+    input.kind === "long" &&
+    input.enforceable &&
+    !input.postpone_available &&
+    !input.finished
+  );
+}


### PR DESCRIPTION
## Summary

Long breaks ship **enforceable by default** (`long_enforceable: true`), which intentionally renders **no Skip control** on the overlay — that's the point of an undismissable long break. But on the default config a user sees no Skip and no explanation, so it reads as broken (issue #87, surfaced by @paocorrales on #67). This is a discoverability gap, not a logic bug.

This adds a brief, accessible, non-interactive note to the overlay — **only** in the enforceable long-break case where controls are suppressed:

> Long breaks are set to enforceable — change in Settings → Schedule.

- The decision is extracted into a pure `shouldShowEnforceableHint` helper (`src/views/break-overlay/skip-hint.ts`) so the branch is unit-testable without rendering.
- The hint shows **only** when `kind === "long"`, `enforceable`, no postpone available, and not finished. It is **absent** for micro/sleep breaks, finished breaks, and any break still offering Skip or Postpone (those already have a visible control).
- Rendered as `role="note"` informational text (not a live region, not interactive), styled to match `.overlay-dismiss` and the overlay's always-dark theme, including the high-contrast override.
- Renderer AT contract updated in `docs/developer/architecture-internals.md` → "Accessibility contract" in the same change.

## Verification

All gates run locally and passing:

- `npm run lint` — pass (only a pre-existing warning in `use-local-draft.ts`, untouched here)
- `npm run format:check` — pass
- `npm run lint:css` — pass
- `npx tsc --noEmit` — pass
- `npm test` — pass (542 tests / 52 files; ran with `--no-file-parallelism` to work around a local forks-worker resource limit)
- `npm run build` — pass
- `npm run audit:a11y` — pass (axe + console-error clean across 14 tab × scheme audits)
- `npm run audit:knip` — pass (only the pre-existing `PreviousPeriod` warn-level unused type)
- `npm run audit:spell` — no novel unknown words introduced (note: the local `audit:spell` script reports 0 files because this worktree lives under `.claude/`, which is in cspell's `ignorePaths`; on CI it runs against the normal checkout)

### Tests added (fail before, pass after)

- `skip-hint.test.ts` — `shouldShowEnforceableHint` truth table: shows for enforceable long break; hides when dismissable / postpone available / finished / micro / sleep.
- `break-overlay.test.tsx`:
  - "explains the missing Skip on an enforceable long break" — asserts a `role="note"` (non-button) hint mentioning *enforceable* and *settings*.
  - "omits the enforceable hint when Skip is available"
  - "omits the enforceable hint when Postpone is available"
  - "omits the enforceable hint for an enforceable micro break"

Tests assert the contract (hint present/absent, role, not interactive), not exact copy.

> Note: authored by an AI agent (Claude Opus 4.8).

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)