### PR TITLE
fix(ipc): open Windows CLI pipe inside a Tokio runtime + add CLI↔app IPC smoke test

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,141 @@
+name: E2E smoke (CLI ↔ app IPC)
+
+# Black-box runtime smoke test on Windows and Linux. Development happens on
+# macOS, so this is the only automated check that the app actually *boots*
+# on the other OSes and that the CLI can talk to it over the per-OS IPC
+# transport (Unix domain socket vs Windows named pipe) — the surface most
+# likely to break per-platform and invisible to `cargo test`.
+#
+# It builds the real binary, launches it as the background tray app, then
+# drives it through the public CLI: wait for `status` to answer (proves the
+# IPC server came up), exercise pause/resume and a break trigger, and shut
+# it down. macOS is intentionally excluded: GUI/menu-bar apps don't get a
+# reliable WindowServer session on the hosted macOS runners, and macOS is
+# the platform we already test by hand.
+#
+# Note: headless GUI launch is inherently runner-sensitive (xvfb + webkit2gtk
+# on Linux). Keep this workflow OFF branch-protection's required list until a
+# few green runs prove it's stable; treat early red runs as harness tuning,
+# not product bugs.
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [ubuntu-22.04, windows-latest]
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Linux deps
+        if: matrix.platform == 'ubuntu-22.04'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libxss-dev xvfb
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: lts/*
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      - run: npm ci
+
+      # `--no-bundle` compiles the binary + frontend without packaging
+      # installers (faster, and skips updater signing entirely). The same
+      # binary is both the tray app and the CLI client.
+      - name: Build app binary
+        shell: bash
+        run: npm run tauri build -- --debug --no-bundle
+
+      - name: Smoke test CLI ↔ app IPC
+        shell: bash
+        env:
+          # webkit2gtk under xvfb needs compositing disabled or it can hang
+          # bringing up the (hidden) main window, which would stop the IPC
+          # server from ever starting.
+          WEBKIT_DISABLE_COMPOSITING_MODE: "1"
+          WEBKIT_DISABLE_DMABUF_RENDERER: "1"
+        run: |
+          set -uo pipefail
+
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            BIN="src-tauri/target/debug/entracte.exe"
+            "$BIN" > app.out 2>&1 &
+            APP_PID=$!
+          else
+            BIN="src-tauri/target/debug/entracte"
+            xvfb-run -a "$BIN" > app.out 2>&1 &
+            APP_PID=$!
+          fi
+          echo "launched app (pid $APP_PID)"
+
+          # Tail the app's own captured output (NOT `entracte log`, which
+          # follows the file forever and would hang the job).
+          cleanup() {
+            echo "::group::app output tail"
+            tail -n 80 app.out 2>/dev/null || true
+            echo "::endgroup::"
+            if [ "$RUNNER_OS" = "Windows" ]; then
+              taskkill //F //IM entracte.exe >/dev/null 2>&1 || true
+            else
+              kill "$APP_PID" >/dev/null 2>&1 || true
+            fi
+          }
+          trap cleanup EXIT
+
+          # The CLI commands are `runs_locally` and exit before any window is
+          # created, so they need no display — they just hit the IPC socket.
+          echo "waiting for IPC server..."
+          up=0
+          for _ in $(seq 1 45); do
+            if "$BIN" status > status.json 2>status.err; then up=1; break; fi
+            sleep 2
+          done
+          if [ "$up" != "1" ]; then
+            echo "::error::app IPC never came up within ~90s"
+            cat status.err || true
+            exit 1
+          fi
+          echo "IPC up. status:"; cat status.json
+
+          echo "--- pause 30m ---"
+          "$BIN" pause 30m
+          "$BIN" status > paused.json
+          cat paused.json
+          grep -q '"paused": true' paused.json || {
+            echo "::error::status did not reflect the pause"; exit 1; }
+
+          echo "--- resume ---"
+          "$BIN" resume
+          "$BIN" status > resumed.json
+          cat resumed.json
+          grep -q '"paused": false' resumed.json || {
+            echo "::error::status did not reflect the resume"; exit 1; }
+
+          # Fire a break: the CLI call only sends the IPC request and returns;
+          # the overlay is built in the app process and may not render under
+          # xvfb, so we assert the request is accepted, not that it's visible.
+          echo "--- trigger micro ---"
+          "$BIN" trigger micro
+
+          echo "smoke test passed on $RUNNER_OS"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -75,9 +75,6 @@ jobs:
           # server from ever starting.
           WEBKIT_DISABLE_COMPOSITING_MODE: "1"
           WEBKIT_DISABLE_DMABUF_RENDERER: "1"
-          # Temporary: capture a full backtrace for the Windows IPC startup
-          # panic under investigation (#119).
-          RUST_BACKTRACE: "full"
         run: |
           set -uo pipefail
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -75,6 +75,9 @@ jobs:
           # server from ever starting.
           WEBKIT_DISABLE_COMPOSITING_MODE: "1"
           WEBKIT_DISABLE_DMABUF_RENDERER: "1"
+          # Temporary: capture a full backtrace for the Windows IPC startup
+          # panic under investigation (#119).
+          RUST_BACKTRACE: "full"
         run: |
           set -uo pipefail
 

--- a/src-tauri/src/ipc.rs
+++ b/src-tauri/src/ipc.rs
@@ -516,7 +516,7 @@ mod windows_pipe {
                     }
                 };
                 rt.block_on(async move {
-                    log::info!("ipc: listening on {name}");
+                    log::info!("ipc: listening on {name} [dedicated-rt]");
                     // First instance uses `create` so the default DACL (current
                     // user only) is applied; subsequent instances reuse the same
                     // name to accept additional clients.

--- a/src-tauri/src/ipc.rs
+++ b/src-tauri/src/ipc.rs
@@ -494,62 +494,37 @@ mod windows_pipe {
 
     pub fn spawn_server(app: AppHandle, token: String) {
         let name = pipe_name();
-        // The pipe server must be created and driven inside a Tokio runtime
-        // with the IO reactor enabled, and every async op on a given pipe must
-        // run on the runtime that created it. `tauri::async_runtime::spawn`
-        // doesn't satisfy this on Windows — `ServerOptions::create` panics with
-        // "there is no reactor running" — so own a dedicated thread + runtime
-        // here. (The Unix path avoids the issue by using a blocking std
-        // listener and only offloading per-client work.)
-        let spawned = std::thread::Builder::new()
-            .name("ipc-pipe".into())
-            .spawn(move || {
-                let rt = match tokio::runtime::Builder::new_multi_thread()
-                    .worker_threads(1)
-                    .enable_all()
-                    .build()
-                {
-                    Ok(rt) => rt,
+        tauri::async_runtime::spawn(async move {
+            log::info!("ipc: listening on {name}");
+            // First instance uses `create` so the default DACL (current
+            // user only) is applied; subsequent instances reuse the same
+            // name to accept additional clients.
+            let mut first = true;
+            loop {
+                let server_res = if first {
+                    ServerOptions::new().first_pipe_instance(true).create(&name)
+                } else {
+                    ServerOptions::new().create(&name)
+                };
+                let server = match server_res {
+                    Ok(s) => s,
                     Err(e) => {
-                        log::warn!("ipc: failed to build pipe runtime: {e}");
+                        log::warn!("ipc: pipe create failed: {e}");
                         return;
                     }
                 };
-                rt.block_on(async move {
-                    log::info!("ipc: listening on {name}");
-                    // First instance uses `create` so the default DACL (current
-                    // user only) is applied; subsequent instances reuse the same
-                    // name to accept additional clients.
-                    let mut first = true;
-                    loop {
-                        let server_res = if first {
-                            ServerOptions::new().first_pipe_instance(true).create(&name)
-                        } else {
-                            ServerOptions::new().create(&name)
-                        };
-                        let server = match server_res {
-                            Ok(s) => s,
-                            Err(e) => {
-                                log::warn!("ipc: pipe create failed: {e}");
-                                return;
-                            }
-                        };
-                        first = false;
-                        if let Err(e) = server.connect().await {
-                            log::warn!("ipc: pipe connect failed: {e}");
-                            continue;
-                        }
-                        let app = app.clone();
-                        let token = token.clone();
-                        tokio::task::spawn(async move {
-                            handle_client(server, app, token).await;
-                        });
-                    }
+                first = false;
+                if let Err(e) = server.connect().await {
+                    log::warn!("ipc: pipe connect failed: {e}");
+                    continue;
+                }
+                let app = app.clone();
+                let token = token.clone();
+                tauri::async_runtime::spawn(async move {
+                    handle_client(server, app, token).await;
                 });
-            });
-        if let Err(e) = spawned {
-            log::warn!("ipc: failed to spawn pipe thread: {e}");
-        }
+            }
+        });
     }
 
     async fn handle_client(server: NamedPipeServer, app: AppHandle, expected_token: String) {

--- a/src-tauri/src/ipc.rs
+++ b/src-tauri/src/ipc.rs
@@ -516,7 +516,7 @@ mod windows_pipe {
                     }
                 };
                 rt.block_on(async move {
-                    log::info!("ipc: listening on {name} [dedicated-rt]");
+                    log::info!("ipc: listening on {name}");
                     // First instance uses `create` so the default DACL (current
                     // user only) is applied; subsequent instances reuse the same
                     // name to accept additional clients.
@@ -584,51 +584,52 @@ mod windows_pipe {
 
     pub fn call(body: &str) -> Result<IpcResponse, String> {
         let name = pipe_name();
-        let mut last_err: Option<String> = None;
-        // Connecting can race with the server momentarily having no
-        // available instance — retry a few times.
-        for _ in 0..5 {
-            match ClientOptions::new().open(&name) {
-                Ok(stream) => {
-                    return blocking_round_trip(stream, body);
-                }
-                Err(e) => {
-                    last_err = Some(format!("connect {name}: {e}. Is Entracte running?"));
-                    std::thread::sleep(Duration::from_millis(50));
-                }
-            }
-        }
-        Err(last_err.unwrap_or_else(|| "named pipe connect failed".to_string()))
-    }
-
-    fn blocking_round_trip(
-        stream: tokio::net::windows::named_pipe::NamedPipeClient,
-        body: &str,
-    ) -> Result<IpcResponse, String> {
-        // The CLI process is sync — drive the async round-trip on a
-        // private runtime instead of dragging tokio through the caller.
+        // `ClientOptions::open` registers the pipe with the Tokio reactor, so
+        // it must run inside a runtime — and the round-trip that follows must
+        // run on the *same* runtime the client was created on. The CLI process
+        // is sync, so own a private current-thread runtime for the whole
+        // exchange rather than dragging tokio through the caller.
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
             .map_err(|e| e.to_string())?;
         rt.block_on(async move {
-            let (read_half, mut write_half) = tokio::io::split(stream);
-            write_half
-                .write_all(body.as_bytes())
-                .await
-                .map_err(|e| e.to_string())?;
-            write_half
-                .write_all(b"\n")
-                .await
-                .map_err(|e| e.to_string())?;
-            write_half.shutdown().await.map_err(|e| e.to_string())?;
-            let mut reader = TokioBufReader::new(read_half.take(MAX_REQUEST_BYTES));
-            let mut buf = String::new();
-            tokio::io::AsyncBufReadExt::read_line(&mut reader, &mut buf)
-                .await
-                .map_err(|e| e.to_string())?;
-            serde_json::from_str(buf.trim()).map_err(|e| format!("parse response: {e}: {buf}"))
+            let mut last_err: Option<String> = None;
+            // Connecting can race with the server momentarily having no
+            // available instance — retry a few times.
+            for _ in 0..5 {
+                match ClientOptions::new().open(&name) {
+                    Ok(stream) => return round_trip(stream, body).await,
+                    Err(e) => {
+                        last_err = Some(format!("connect {name}: {e}. Is Entracte running?"));
+                        tokio::time::sleep(Duration::from_millis(50)).await;
+                    }
+                }
+            }
+            Err(last_err.unwrap_or_else(|| "named pipe connect failed".to_string()))
         })
+    }
+
+    async fn round_trip(
+        stream: tokio::net::windows::named_pipe::NamedPipeClient,
+        body: &str,
+    ) -> Result<IpcResponse, String> {
+        let (read_half, mut write_half) = tokio::io::split(stream);
+        write_half
+            .write_all(body.as_bytes())
+            .await
+            .map_err(|e| e.to_string())?;
+        write_half
+            .write_all(b"\n")
+            .await
+            .map_err(|e| e.to_string())?;
+        write_half.shutdown().await.map_err(|e| e.to_string())?;
+        let mut reader = TokioBufReader::new(read_half.take(MAX_REQUEST_BYTES));
+        let mut buf = String::new();
+        tokio::io::AsyncBufReadExt::read_line(&mut reader, &mut buf)
+            .await
+            .map_err(|e| e.to_string())?;
+        serde_json::from_str(buf.trim()).map_err(|e| format!("parse response: {e}: {buf}"))
     }
 }
 

--- a/src-tauri/src/ipc.rs
+++ b/src-tauri/src/ipc.rs
@@ -494,37 +494,62 @@ mod windows_pipe {
 
     pub fn spawn_server(app: AppHandle, token: String) {
         let name = pipe_name();
-        tauri::async_runtime::spawn(async move {
-            log::info!("ipc: listening on {name}");
-            // First instance uses `create` so the default DACL (current
-            // user only) is applied; subsequent instances reuse the same
-            // name to accept additional clients.
-            let mut first = true;
-            loop {
-                let server_res = if first {
-                    ServerOptions::new().first_pipe_instance(true).create(&name)
-                } else {
-                    ServerOptions::new().create(&name)
-                };
-                let server = match server_res {
-                    Ok(s) => s,
+        // The pipe server must be created and driven inside a Tokio runtime
+        // with the IO reactor enabled, and every async op on a given pipe must
+        // run on the runtime that created it. `tauri::async_runtime::spawn`
+        // doesn't satisfy this on Windows — `ServerOptions::create` panics with
+        // "there is no reactor running" — so own a dedicated thread + runtime
+        // here. (The Unix path avoids the issue by using a blocking std
+        // listener and only offloading per-client work.)
+        let spawned = std::thread::Builder::new()
+            .name("ipc-pipe".into())
+            .spawn(move || {
+                let rt = match tokio::runtime::Builder::new_multi_thread()
+                    .worker_threads(1)
+                    .enable_all()
+                    .build()
+                {
+                    Ok(rt) => rt,
                     Err(e) => {
-                        log::warn!("ipc: pipe create failed: {e}");
+                        log::warn!("ipc: failed to build pipe runtime: {e}");
                         return;
                     }
                 };
-                first = false;
-                if let Err(e) = server.connect().await {
-                    log::warn!("ipc: pipe connect failed: {e}");
-                    continue;
-                }
-                let app = app.clone();
-                let token = token.clone();
-                tauri::async_runtime::spawn(async move {
-                    handle_client(server, app, token).await;
+                rt.block_on(async move {
+                    log::info!("ipc: listening on {name}");
+                    // First instance uses `create` so the default DACL (current
+                    // user only) is applied; subsequent instances reuse the same
+                    // name to accept additional clients.
+                    let mut first = true;
+                    loop {
+                        let server_res = if first {
+                            ServerOptions::new().first_pipe_instance(true).create(&name)
+                        } else {
+                            ServerOptions::new().create(&name)
+                        };
+                        let server = match server_res {
+                            Ok(s) => s,
+                            Err(e) => {
+                                log::warn!("ipc: pipe create failed: {e}");
+                                return;
+                            }
+                        };
+                        first = false;
+                        if let Err(e) = server.connect().await {
+                            log::warn!("ipc: pipe connect failed: {e}");
+                            continue;
+                        }
+                        let app = app.clone();
+                        let token = token.clone();
+                        tokio::task::spawn(async move {
+                            handle_client(server, app, token).await;
+                        });
+                    }
                 });
-            }
-        });
+            });
+        if let Err(e) = spawned {
+            log::warn!("ipc: failed to spawn pipe thread: {e}");
+        }
     }
 
     async fn handle_client(server: NamedPipeServer, app: AppHandle, expected_token: String) {


### PR DESCRIPTION
## Summary

Adds a black-box e2e smoke test that boots the real binary on Windows and Linux and drives it through the CLI over the per-OS IPC transport (Unix socket / Windows named pipe) — coverage `cargo test` can't give. The test immediately caught a real Windows defect, fixed here.

### The bug (Windows only)

`entracte status` (and other CLI commands) panicked at startup:

```
thread 'main' panicked at tokio .../named_pipe.rs:1005:
there is no reactor running, must be called from the context of a Tokio 1.x runtime
```

A full backtrace (captured via a temporary `RUST_BACKTRACE` in CI) pinned it to the **client**, not the server: `windows_pipe::call` called `ClientOptions::open()` *outside* any Tokio runtime, and `open()` registers the pipe handle with the reactor. The pre-existing `blocking_round_trip` built a runtime only *after* `open()` returned — too late — and on a *separate* runtime from the one the pipe would need.

### The fix

`call()` now builds one current-thread runtime and runs **both** `open()` and the round-trip inside it (`round_trip` is a plain async fn on that runtime). The server is unchanged.

## Test plan

- `smoke (windows-latest)` and `smoke (ubuntu-22.04)`: green (status/pause/resume/trigger round-trips succeed).
- Full `rust` matrix (macOS/ubuntu/windows), `frontend`, `codecov`, `advisory`: green.
- Diagnostic `RUST_BACKTRACE` env removed from the workflow before merge.

Closes #119.

🤖 Generated with [Claude Code](https://claude.com/claude-code)