### PR TITLE
fix(camera): detect camera use on macOS 26 via Control Center aggregate (#113)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Versions on the `0.0.X` line are public beta releases; `0.1.X` and onwards will 
 
 ## [Unreleased]
 
+### Fixed
+
+- **Camera-in-use detection works again on macOS 26 (Apple Silicon).** macOS 26 stopped posting the `kCameraStream` log events Entracte watched, so breaks were no longer paused while the camera was live. Detection now also reads Control Center's aggregate "cameras changed to […]" signal — an empty list means every camera was released — which is both version-resilient and reflects all in-use cameras at once. ([#113](https://github.com/drmowinckels/entracte/issues/113))
+
 ## [0.0.4] — 2026-06-01
 
 Follow-up Linux/Wayland beta from Steffi's dual-4K @ 200% testing (#67): the break overlay now sizes and places itself correctly on scaled Wayland displays, breaks fire on time when idle detection isn't available, and choosing a sound plays it straight away.

--- a/src-tauri/src/camera.rs
+++ b/src-tauri/src/camera.rs
@@ -18,15 +18,39 @@ pub fn spawn_monitor(active: Arc<AtomicBool>) {
 /// markers, matching the original `if/else if` ordering. Kept un-gated so
 /// the start/stop contract is unit-tested on every OS — only the macOS
 /// log-stream reader calls it in non-test builds.
+///
+/// Two signals are recognised:
+///   * Legacy (pre-macOS 26) `AppleCameraAssistant` posts
+///     `kCameraStreamStart`/`kCameraStreamStop` events.
+///   * macOS 26+ stopped posting those on Apple Silicon (#113). Control
+///     Center instead publishes the *full set* of in-use cameras as
+///     `Frame publisher cameras changed to [...]` — an empty `[]` means
+///     every camera was released, a non-empty list means at least one is
+///     live. This aggregate is more robust than the old per-stream events.
 #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 pub(crate) fn classify_camera_line(line: &str) -> Option<bool> {
     if line.contains("kCameraStreamStart") {
-        Some(true)
-    } else if line.contains("kCameraStreamStop") {
-        Some(false)
-    } else {
-        None
+        return Some(true);
     }
+    if line.contains("kCameraStreamStop") {
+        return Some(false);
+    }
+    if let Some((_, rest)) = line.split_once("cameras changed to ") {
+        return classify_camera_set(rest);
+    }
+    None
+}
+
+/// Decide whether Control Center's published camera set is empty. `rest`
+/// is everything after `"cameras changed to "`. `Some(false)` for an empty
+/// list (`[]`), `Some(true)` for a non-empty one. Returns `None` when the
+/// payload is redacted (`<private>`) or otherwise has no bracketed list —
+/// we can't tell the state, so we leave it unchanged rather than guess.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+fn classify_camera_set(rest: &str) -> Option<bool> {
+    let open = rest.find('[')?;
+    let inner = rest[open + 1..].trim_start();
+    Some(!inner.starts_with(']'))
 }
 
 /// The Windows webcam-in-use rule: an app's `LastUsedTimeStop` of `0`
@@ -60,7 +84,8 @@ mod macos {
                     "--style",
                     "compact",
                     "--predicate",
-                    "eventMessage contains \"Post event kCameraStream\"",
+                    "eventMessage contains \"Post event kCameraStream\" \
+                     or eventMessage contains \"Frame publisher cameras changed to\"",
                     "--info",
                 ])
                 .stdout(Stdio::piped())
@@ -222,6 +247,34 @@ mod tests {
     fn classify_prefers_start_when_both_markers_present() {
         let line = "kCameraStreamStart ... kCameraStreamStop";
         assert_eq!(classify_camera_line(line), Some(true));
+    }
+
+    #[test]
+    fn classify_control_center_non_empty_set_is_on() {
+        let line = "2026-06-03 ControlCenter[1169:2621] \
+            [com.apple.controlcenter:captureFrameReceiver] Frame publisher \
+            cameras changed to [us.zoom.xos: [\"0x1000002e1a4c01\"]]";
+        assert_eq!(classify_camera_line(line), Some(true));
+    }
+
+    #[test]
+    fn classify_control_center_empty_set_is_off() {
+        let line = "2026-06-03 ControlCenter[1169:2621] \
+            [com.apple.controlcenter:captureFrameReceiver] Frame publisher \
+            cameras changed to []";
+        assert_eq!(classify_camera_line(line), Some(false));
+    }
+
+    #[test]
+    fn classify_control_center_empty_set_tolerates_inner_space() {
+        let line = "Frame publisher cameras changed to [ ]";
+        assert_eq!(classify_camera_line(line), Some(false));
+    }
+
+    #[test]
+    fn classify_control_center_redacted_set_is_unknown() {
+        let line = "Frame publisher cameras changed to <private>";
+        assert_eq!(classify_camera_line(line), None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #113. On macOS 26 (Apple Silicon), camera-in-use detection stopped pausing breaks: macOS no longer posts the `kCameraStream` log events the monitor watched, so the `camera_active` atomic never flipped.

The detector now **also** reads Control Center's aggregate event, `Frame publisher cameras changed to [...]`, which publishes the full set of in-use cameras:

- empty list `[]` → every camera released (off)
- non-empty list → at least one camera live (on)
- redacted `<private>` payload → `None` (state left unchanged, never guessed)

This aggregate is version-resilient and reflects *all* in-use cameras at once, which is strictly better than the old per-stream start/stop markers. Legacy `kCameraStream` handling is retained for older macOS, so the change is additive.

Both signals are captured by broadening the existing `log stream --predicate` with an `or` clause; classification is a pure function (`classify_camera_line` / `classify_camera_set`) unit-tested on every OS.

## Test plan

- `cargo test --lib camera` — 13 pass, including 4 new cases:
  - Control Center non-empty set → on
  - Control Center empty set → off
  - empty set with inner whitespace (`[ ]`) → off
  - redacted `<private>` payload → `None`
- `cargo fmt` clean, `cargo clippy --all-targets` 0 warnings.
- Manual verification on a macOS 26 device still needed (reporter has one); the new predicate matches the verbatim Control Center line from the issue's debug capture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)