### PR TITLE
feat(settings): make break-idea Mix selectors free, gate only editing (#118)

### DIFF
--- a/.github/audit/cspell/project-words.txt
+++ b/.github/audit/cspell/project-words.txt
@@ -173,3 +173,4 @@ describedby
 MPRIS
 noninteractive
 autofocus
+textareas

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Versions on the `0.0.X` line are public beta releases; `0.1.X` and onwards will 
 
 ## [Unreleased]
 
+### Changed
+
+- **Choosing which break ideas appear is now free.** The Micro (Physical / Psychological / Both) and Long (Solo / Social / Both) **Mix** selectors moved out from behind the Supporter pack, so anyone can drop the "social" prompts (e.g. "walk over to a coworker's desk for a chat") by picking **Solo only** — handy when you work alone. Editing the hint pool text remains a Supporter pack feature. ([#118](https://github.com/drmowinckels/entracte/issues/118))
+
 ## [0.0.4] — 2026-06-01
 
 Follow-up Linux/Wayland beta from Steffi's dual-4K @ 200% testing (#67): the break overlay now sizes and places itself correctly on scaled Wayland displays, breaks fire on time when idle detection isn't available, and choosing a sound plays it straight away.

--- a/src/views/settings/tabs/breaks-tab.test.tsx
+++ b/src/views/settings/tabs/breaks-tab.test.tsx
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn().mockResolvedValue(undefined),
+}));
+
+const { BreaksTab } = await import("./breaks-tab");
+import type { SchedulerSettings, SupporterStatus } from "../types";
+
+const baseSettings = {
+  overlay_opacity: 0.92,
+  overlay_font_scale: 1,
+  overlay_color: "dark",
+  overlay_custom_rgb: "20, 24, 32",
+  overlay_high_contrast: false,
+  break_health_enabled: false,
+  show_hint: true,
+  hint_rotate_seconds: 0,
+  show_current_time: true,
+  monitor_placement: "primary",
+  sound_volume: 0.5,
+  strict_mode: false,
+  postpone_enabled: true,
+  postpone_escalation_enabled: false,
+  postpone_escalation_step_secs: 120,
+  postpone_max_count: 3,
+  postpone_minutes: 5,
+  micro_hint_mix: "both",
+  long_hint_mix: "both",
+  micro_physical_hints: ["Look away"],
+  micro_psychological_hints: ["Breathe"],
+  long_hints: ["Take a walk"],
+  long_social_hints: ["Call a friend"],
+  sleep_hints: ["Wind down"],
+  custom_css: "",
+} as unknown as SchedulerSettings;
+
+function renderTab(isSupporter: boolean) {
+  const supporter: SupporterStatus = {
+    is_supporter: isSupporter,
+    masked_key: null,
+    last_validated_at: null,
+  };
+  return render(
+    <BreaksTab
+      settings={baseSettings}
+      update={() => {}}
+      supporter={supporter}
+    />,
+  );
+}
+
+describe("BreaksTab break ideas", () => {
+  it("shows the micro and long mix selectors to free users", () => {
+    renderTab(false);
+    expect(
+      screen.getByRole("heading", { name: "Break ideas" }),
+    ).toBeTruthy();
+    // Options unique to each mix selector prove both render for free users:
+    // "Physical only" (micro) and "Social only" (long).
+    expect(
+      screen.getByRole("option", { name: "Physical only" }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("option", { name: "Social only" }),
+    ).toBeTruthy();
+  });
+
+  it("hides the editable hint textareas from free users", () => {
+    renderTab(false);
+    expect(
+      screen.queryByText("Solo (stretch, fresh air, snack, tidy)"),
+    ).toBeNull();
+    expect(
+      screen.queryByText("Social (call, walk together, share a coffee)"),
+    ).toBeNull();
+    expect(screen.queryByRole("heading", { name: "Bedtime" })).toBeNull();
+    expect(screen.queryByRole("heading", { name: "Custom CSS" })).toBeNull();
+  });
+
+  it("shows the editable hint textareas and Custom CSS to supporters", () => {
+    renderTab(true);
+    expect(
+      screen.getByText("Solo (stretch, fresh air, snack, tidy)"),
+    ).toBeTruthy();
+    expect(
+      screen.getByText("Social (call, walk together, share a coffee)"),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("heading", { name: "Bedtime" }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("heading", { name: "Custom CSS" }),
+    ).toBeTruthy();
+  });
+});

--- a/src/views/settings/tabs/breaks-tab.test.tsx
+++ b/src/views/settings/tabs/breaks-tab.test.tsx
@@ -54,17 +54,11 @@ function renderTab(isSupporter: boolean) {
 describe("BreaksTab break ideas", () => {
   it("shows the micro and long mix selectors to free users", () => {
     renderTab(false);
-    expect(
-      screen.getByRole("heading", { name: "Break ideas" }),
-    ).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Break ideas" })).toBeTruthy();
     // Options unique to each mix selector prove both render for free users:
     // "Physical only" (micro) and "Social only" (long).
-    expect(
-      screen.getByRole("option", { name: "Physical only" }),
-    ).toBeTruthy();
-    expect(
-      screen.getByRole("option", { name: "Social only" }),
-    ).toBeTruthy();
+    expect(screen.getByRole("option", { name: "Physical only" })).toBeTruthy();
+    expect(screen.getByRole("option", { name: "Social only" })).toBeTruthy();
   });
 
   it("hides the editable hint textareas from free users", () => {
@@ -87,11 +81,7 @@ describe("BreaksTab break ideas", () => {
     expect(
       screen.getByText("Social (call, walk together, share a coffee)"),
     ).toBeTruthy();
-    expect(
-      screen.getByRole("heading", { name: "Bedtime" }),
-    ).toBeTruthy();
-    expect(
-      screen.getByRole("heading", { name: "Custom CSS" }),
-    ).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Bedtime" })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Custom CSS" })).toBeTruthy();
   });
 });

--- a/src/views/settings/tabs/breaks-tab.test.tsx
+++ b/src/views/settings/tabs/breaks-tab.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 
 vi.mock("@tauri-apps/api/core", () => ({
   invoke: vi.fn().mockResolvedValue(undefined),
@@ -36,7 +36,10 @@ const baseSettings = {
   custom_css: "",
 } as unknown as SchedulerSettings;
 
-function renderTab(isSupporter: boolean) {
+function renderTab(
+  isSupporter: boolean,
+  update: (key: string, value: unknown) => void = () => {},
+) {
   const supporter: SupporterStatus = {
     is_supporter: isSupporter,
     masked_key: null,
@@ -45,10 +48,20 @@ function renderTab(isSupporter: boolean) {
   return render(
     <BreaksTab
       settings={baseSettings}
-      update={() => {}}
+      update={update as never}
       supporter={supporter}
     />,
   );
+}
+
+/** The <select> owning an option with the given label. */
+function selectWithOption(optionName: string): HTMLSelectElement {
+  const option = screen.getByRole("option", {
+    name: optionName,
+  }) as HTMLOptionElement;
+  const select = option.closest("select");
+  if (!select) throw new Error(`no <select> owns option "${optionName}"`);
+  return select;
 }
 
 describe("BreaksTab break ideas", () => {
@@ -59,6 +72,24 @@ describe("BreaksTab break ideas", () => {
     // "Physical only" (micro) and "Social only" (long).
     expect(screen.getByRole("option", { name: "Physical only" })).toBeTruthy();
     expect(screen.getByRole("option", { name: "Social only" })).toBeTruthy();
+  });
+
+  it("free users can switch the long mix to drop social hints", () => {
+    const update = vi.fn();
+    renderTab(false, update);
+    fireEvent.change(selectWithOption("Social only"), {
+      target: { value: "solo" },
+    });
+    expect(update).toHaveBeenCalledWith("long_hint_mix", "solo");
+  });
+
+  it("free users can switch the micro mix", () => {
+    const update = vi.fn();
+    renderTab(false, update);
+    fireEvent.change(selectWithOption("Physical only"), {
+      target: { value: "physical" },
+    });
+    expect(update).toHaveBeenCalledWith("micro_hint_mix", "physical");
   });
 
   it("hides the editable hint textareas from free users", () => {

--- a/src/views/settings/tabs/breaks-tab.tsx
+++ b/src/views/settings/tabs/breaks-tab.tsx
@@ -344,31 +344,36 @@ export function BreaksTab({
         </div>
       </section>
 
-      {isSupporter && (
-        <>
-          <h2>Break ideas</h2>
-          <section>
-            <p className="placeholder">
-              One idea per line. Each break picks a random starting idea from
-              the pool.
-            </p>
-            <h3>Micro breaks</h3>
-            <label className="row">
-              <span>Mix</span>
-              <select
-                value={settings.micro_hint_mix}
-                onChange={(e) =>
-                  update(
-                    "micro_hint_mix",
-                    e.target.value as typeof settings.micro_hint_mix,
-                  )
-                }
-              >
-                <option value="both">Both</option>
-                <option value="physical">Physical only</option>
-                <option value="psychological">Psychological only</option>
-              </select>
-            </label>
+      <h2>Break ideas</h2>
+      <section>
+        <p className="placeholder">
+          Choose which kinds of prompt appear during each break.
+          {isSupporter
+            ? " Edit the pools below — one idea per line; each break picks a random starting idea."
+            : ""}
+        </p>
+        <h3>Micro breaks</h3>
+        <label className="row">
+          <span>
+            Mix
+            <InfoTip text="Physical: stretches, eye rest, movement. Psychological: breathing, awareness, tension release." />
+          </span>
+          <select
+            value={settings.micro_hint_mix}
+            onChange={(e) =>
+              update(
+                "micro_hint_mix",
+                e.target.value as typeof settings.micro_hint_mix,
+              )
+            }
+          >
+            <option value="both">Both</option>
+            <option value="physical">Physical only</option>
+            <option value="psychological">Psychological only</option>
+          </select>
+        </label>
+        {isSupporter && (
+          <>
             <label className="row stacked">
               <span>Physical (stretches, eye rest, movement)</span>
               <textarea
@@ -396,26 +401,30 @@ export function BreaksTab({
                 }
               />
             </label>
-            <h3>Long breaks</h3>
-            <label className="row">
-              <span>
-                Mix
-                <InfoTip text="Solo: things to do on your own (stretch, fresh air, snack). Social: things to do with someone (call, walk together, sit outside)." />
-              </span>
-              <select
-                value={settings.long_hint_mix}
-                onChange={(e) =>
-                  update(
-                    "long_hint_mix",
-                    e.target.value as typeof settings.long_hint_mix,
-                  )
-                }
-              >
-                <option value="both">Both</option>
-                <option value="solo">Solo only</option>
-                <option value="social">Social only</option>
-              </select>
-            </label>
+          </>
+        )}
+        <h3>Long breaks</h3>
+        <label className="row">
+          <span>
+            Mix
+            <InfoTip text="Solo: things to do on your own (stretch, fresh air, snack). Social: things to do with someone (call, walk together, sit outside). Working alone? Pick Solo only to drop the social prompts." />
+          </span>
+          <select
+            value={settings.long_hint_mix}
+            onChange={(e) =>
+              update(
+                "long_hint_mix",
+                e.target.value as typeof settings.long_hint_mix,
+              )
+            }
+          >
+            <option value="both">Both</option>
+            <option value="solo">Solo only</option>
+            <option value="social">Social only</option>
+          </select>
+        </label>
+        {isSupporter && (
+          <>
             <label className="row stacked">
               <span>Solo (stretch, fresh air, snack, tidy)</span>
               <textarea
@@ -449,8 +458,12 @@ export function BreaksTab({
                 onBlur={() => update("sleep_hints", linesToList(sleep))}
               />
             </label>
-          </section>
+          </>
+        )}
+      </section>
 
+      {isSupporter && (
+        <>
           <h2>Custom CSS</h2>
           <section>
             <p className="placeholder">


### PR DESCRIPTION
## Summary

Fixes #118. Solo workers asked to turn off the "social" long-break prompts (e.g. *"walk over to a coworker's desk for a chat"*) while keeping the rest.

The Solo / Social / Both (and micro Physical / Psychological / Both) **Mix** selectors already existed, but were gated behind the Supporter pack — even though the docs already described them as free (`docs/guide/supporter.md`: *"Mix selectors and rotation cadence remain free"*; `docs/guide/settings.md`: *"editing the pool text is a Supporter pack feature"*). The code had simply drifted from the documented design.

This aligns the code to the docs:

- The **Break ideas** section and both Mix selectors now render for **everyone**.
- The editable hint-pool textareas, the Bedtime pool, and the Custom CSS section stay **Supporter-only**.
- Picking **Solo only** drops the social prompts for free users — the exact ask in the issue.

No new tabs; everything stays within the existing Breaks tab, and supporter-only UI is hidden (not stubbed) for free users.

## Test plan

- New `src/views/settings/tabs/breaks-tab.test.tsx`:
  - free users see the Micro + Long mix selectors (unique options `Physical only` / `Social only`)
  - free users do **not** see the editable textareas, Bedtime, or Custom CSS
  - supporters see the textareas, Bedtime, and Custom CSS
- `npm run typecheck` clean, `eslint` clean on changed files.
- Full suite: **555 passed**.
- Docs already match; no doc change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)