### PR TITLE
fix(audio): play break sounds natively so Linux gets sound (#114)

### DIFF
--- a/.github/audit/cspell/project-words.txt
+++ b/.github/audit/cspell/project-words.txt
@@ -173,3 +173,8 @@ describedby
 MPRIS
 noninteractive
 autofocus
+rodio
+WASAPI
+ALSA
+GStreamer
+Symphonia

--- a/.github/workflows/build-preview.yml
+++ b/.github/workflows/build-preview.yml
@@ -55,7 +55,7 @@ jobs:
         if: matrix.platform == 'ubuntu-22.04'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libxss-dev rpm
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libxss-dev libasound2-dev rpm
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
         if: matrix.platform == 'ubuntu-22.04'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libxss-dev
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libxss-dev libasound2-dev
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy, rustfmt, llvm-tools-preview

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Install Linux deps (Tauri toolchain)
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libxss-dev
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libxss-dev libasound2-dev
       - uses: dtolnay/rust-toolchain@stable
       - uses: swatinem/rust-cache@v2
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install Linux deps (Tauri toolchain)
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libxss-dev
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libxss-dev libasound2-dev
       - uses: dtolnay/rust-toolchain@stable
       - uses: swatinem/rust-cache@v2
         with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -44,7 +44,7 @@ jobs:
         if: matrix.platform == 'ubuntu-22.04'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libxss-dev xvfb
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libxss-dev libasound2-dev xvfb
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
         if: matrix.platform == 'ubuntu-22.04'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libxss-dev rpm
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libxss-dev libasound2-dev rpm
 
       - uses: actions/setup-node@v6
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ Versions on the `0.0.X` line are public beta releases; `0.1.X` and onwards will 
 
 ## [Unreleased]
 
+### Fixed
+
+- **Break sounds now play on Linux.** Chimes and ambient tracks were silent on Linux (e.g. Ubuntu 24.04): playback went through the webview, and WebKitGTK can't decode the bundled MP3s without system GStreamer codecs that aren't installed by default. Playback now runs natively in-process, decoding the audio itself and playing through the OS audio stack (PipeWire/PulseAudio/ALSA on Linux, CoreAudio on macOS, WASAPI on Windows) — so it no longer depends on the webview or on installing extra codecs. ([#114](https://github.com/drmowinckels/entracte/issues/114))
+
+### Changed
+
+- Ambient sound auditions on the Settings page now stop with a hard cut after a few seconds instead of a brief fade-out.
+
 ## [0.0.4] — 2026-06-01
 
 Follow-up Linux/Wayland beta from Steffi's dual-4K @ 200% testing (#67): the break overlay now sizes and places itself correctly on scaled Wayland displays, breaks fire on time when idle detection isn't available, and choosing a sound plays it straight away.

--- a/docs/developer/architecture-internals.md
+++ b/docs/developer/architecture-internals.md
@@ -31,6 +31,8 @@ scheduler/              Break scheduling (the largest module)
 
 camera.rs / video.rs    Per-OS detection threads (macOS uses log stream / pmset,
                         Linux walks /proc, Windows reads the registry / WnfStateData)
+audio.rs                Native rodio playback thread + sound commands (decodes
+                        in-process, so it's webview/codec-independent)
 dnd.rs                  Do-Not-Disturb / Focus detection (macOS, Windows)
 hooks.rs                Shell-command execution model (off by default)
 platform.rs             get_platform Tauri command (renderer asks Rust what OS this is)
@@ -64,7 +66,8 @@ views/
     components/         InfoTip, Advanced, SoundControls, Rows, etc.
     tabs/               one component per tab (about/breaks/insights/profiles/quiet/schedule/system)
 
-lib/                    Pure utilities (color, time, sounds, platform, ...)
+lib/                    Utilities (color, time, platform, ...) + sounds.ts,
+                        thin wrappers over the native audio Tauri commands
 ```
 
 ## The 1Hz run loop

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -65,6 +65,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "alsa"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812947049edcd670a82cd5c73c3661d2e58468577ba8489de58e1a73c04cbd5d"
+dependencies = [
+ "alsa-sys",
+ "bitflags 2.11.1",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "alsa-sys"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad7569085a265dd3f607ebecce7458eaab2132a84393534c95b18dcbc3f31e04"
+dependencies = [
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "android_log-sys"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -723,6 +745,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "coreaudio-rs"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5d7dca3ebcf65a035582c9ad4385371a9d9ee6537474d2a278f4e1e475bb58"
+dependencies = [
+ "bitflags 2.11.1",
+ "libc",
+ "objc2-audio-toolbox",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "cpal"
+version = "0.17.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8942da362c0f0d895d7cac616263f2f9424edc5687364dfd1d25ef7eba506d7"
+dependencies = [
+ "alsa",
+ "coreaudio-rs",
+ "dasp_sample",
+ "jni 0.21.1",
+ "js-sys",
+ "libc",
+ "mach2",
+ "ndk",
+ "ndk-context",
+ "num-derive",
+ "num-traits",
+ "objc2",
+ "objc2-audio-toolbox",
+ "objc2-avf-audio",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows 0.61.3",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -874,6 +940,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "dasp_sample"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
 
 [[package]]
 name = "dbus"
@@ -1147,6 +1219,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "endi"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1172,6 +1253,7 @@ dependencies = [
  "objc2-core-graphics",
  "objc2-foundation",
  "reqwest 0.12.28",
+ "rodio",
  "serde",
  "serde_json",
  "sha2",
@@ -1273,6 +1355,12 @@ dependencies = [
  "event-listener",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "extended"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af9673d8203fcb076b19dfd17e38b3d4ae9f44959416ea532ce72415a6020365"
 
 [[package]]
 name = "fastrand"
@@ -2347,6 +2435,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2472,6 +2566,15 @@ name = "mach"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "mach2"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a1b95cd5421ec55b445b5ae102f5ea0e768de1f82bd3001e11f426c269c3aea"
 dependencies = [
  "libc",
 ]
@@ -2607,6 +2710,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
 name = "ndk-sys"
 version = "0.6.0+11769913"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2645,10 +2754,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -2722,6 +2872,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-audio-toolbox"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6948501a91121d6399b79abaa33a8aa4ea7857fe019f341b8c23ad6e81b79b08"
+dependencies = [
+ "bitflags 2.11.1",
+ "libc",
+ "objc2",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-avf-audio"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13a380031deed8e99db00065c45937da434ca987c034e13b87e4441f9e4090be"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-cloud-kit"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2730,6 +2905,29 @@ dependencies = [
  "bitflags 2.11.1",
  "objc2",
  "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-audio"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1eebcea8b0dbff5f7c8504f3107c68fc061a3eb44932051c8cf8a68d969c3b2"
+dependencies = [
+ "dispatch2",
+ "objc2",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-audio-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a89f2ec274a0cf4a32642b2991e8b351a404d290da87bb6a9a9d8632490bd1c"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
 ]
 
 [[package]]
@@ -2750,7 +2948,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.11.1",
+ "block2",
  "dispatch2",
+ "libc",
  "objc2",
 ]
 
@@ -3720,6 +3920,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rodio"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a536bb79db59098ef71a4dd4246c02eb87b316deceb1b68e0cde7167ec01eb"
+dependencies = [
+ "cpal",
+ "dasp_sample",
+ "num-rational",
+ "symphonia",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "rust_decimal"
 version = "1.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4360,6 +4573,153 @@ dependencies = [
  "base64 0.21.7",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "symphonia"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5773a4c030a19d9bfaa090f49746ff35c75dfddfa700df7a5939d5e076a57039"
+dependencies = [
+ "lazy_static",
+ "symphonia-bundle-flac",
+ "symphonia-bundle-mp3",
+ "symphonia-codec-aac",
+ "symphonia-codec-pcm",
+ "symphonia-codec-vorbis",
+ "symphonia-core",
+ "symphonia-format-isomp4",
+ "symphonia-format-ogg",
+ "symphonia-format-riff",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-bundle-flac"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c91565e180aea25d9b80a910c546802526ffd0072d0b8974e3ebe59b686c9976"
+dependencies = [
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+ "symphonia-utils-xiph",
+]
+
+[[package]]
+name = "symphonia-bundle-mp3"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4872dd6bb56bf5eac799e3e957aa1981086c3e613b27e0ac23b176054f7c57ed"
+dependencies = [
+ "lazy_static",
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-codec-aac"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c263845aa86881416849c1729a54c7f55164f8b96111dba59de46849e73a790"
+dependencies = [
+ "lazy_static",
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-codec-pcm"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e89d716c01541ad3ebe7c91ce4c8d38a7cf266a3f7b2f090b108fb0cb031d95"
+dependencies = [
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-codec-vorbis"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f025837c309cd69ffef572750b4a2257b59552c5399a5e49707cc5b1b85d1c73"
+dependencies = [
+ "log",
+ "symphonia-core",
+ "symphonia-utils-xiph",
+]
+
+[[package]]
+name = "symphonia-core"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea00cc4f79b7f6bb7ff87eddc065a1066f3a43fe1875979056672c9ef948c2af"
+dependencies = [
+ "arrayvec",
+ "bitflags 1.3.2",
+ "bytemuck",
+ "lazy_static",
+ "log",
+]
+
+[[package]]
+name = "symphonia-format-isomp4"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "243739585d11f81daf8dac8d9f3d18cc7898f6c09a259675fc364b382c30e0a5"
+dependencies = [
+ "encoding_rs",
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+ "symphonia-utils-xiph",
+]
+
+[[package]]
+name = "symphonia-format-ogg"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b4955c67c1ed3aa8ae8428d04ca8397fbef6a19b2b051e73b5da8b1435639cb"
+dependencies = [
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+ "symphonia-utils-xiph",
+]
+
+[[package]]
+name = "symphonia-format-riff"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2d7c3df0e7d94efb68401d81906eae73c02b40d5ec1a141962c592d0f11a96f"
+dependencies = [
+ "extended",
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-metadata"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36306ff42b9ffe6e5afc99d49e121e0bd62fe79b9db7b9681d48e29fa19e6b16"
+dependencies = [
+ "encoding_rs",
+ "lazy_static",
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-utils-xiph"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27c85ab799a338446b68eec77abf42e1a6f1bb490656e121c6e27bfbab9f16"
+dependencies = [
+ "symphonia-core",
+ "symphonia-metadata",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -34,6 +34,14 @@ tauri-plugin-single-instance = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-updater = "2"
 log = "0.4"
+rodio = { version = "0.22", default-features = false, features = [
+    "playback",
+    "mp3",
+    "wav",
+    "vorbis",
+    "flac",
+    "mp4",
+] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "sync", "net", "io-util"] }

--- a/src-tauri/src/audio.rs
+++ b/src-tauri/src/audio.rs
@@ -204,44 +204,59 @@ fn resource_sound_path(app: &AppHandle, sound_id: &str) -> Option<PathBuf> {
         .ok()
 }
 
-#[tauri::command]
-pub fn play_sound(app: AppHandle, audio: State<'_, AudioPlayer>, sound_id: String, volume: f32) {
+/// A user-supplied path, or `None` for empty input — keeps the empty-string
+/// short-circuit out of every custom-sound command.
+fn custom_path(path: String) -> Option<PathBuf> {
+    (!path.is_empty()).then(|| PathBuf::from(path))
+}
+
+/// Play a one-shot once `path` has been resolved (bundled id or custom file).
+/// `None` path or non-positive volume is a no-op. Shared by the bundled and
+/// custom command shims so the guard logic is tested once.
+fn dispatch_once(audio: &AudioPlayer, path: Option<PathBuf>, volume: f32) {
     if volume <= 0.0 {
         return;
     }
-    if let Some(path) = resource_sound_path(&app, &sound_id) {
+    if let Some(path) = path {
         audio.set_volume(volume);
         audio.play_once(path);
     }
 }
 
-#[tauri::command]
-pub fn play_custom_sound(audio: State<'_, AudioPlayer>, path: String, volume: f32) {
-    if volume <= 0.0 || path.is_empty() {
+/// Start (or preview) an ambient loop once `path` has been resolved. `None`
+/// path or non-positive volume is a no-op.
+fn dispatch_ambient(audio: &AudioPlayer, path: Option<PathBuf>, volume: f32, preview: bool) {
+    if volume <= 0.0 {
         return;
     }
-    audio.set_volume(volume);
-    audio.play_once(PathBuf::from(path));
+    if let Some(path) = path {
+        audio.set_volume(volume);
+        if preview {
+            audio.preview_ambient(path);
+        } else {
+            audio.start_ambient(path);
+        }
+    }
+}
+
+#[tauri::command]
+pub fn play_sound(app: AppHandle, audio: State<'_, AudioPlayer>, sound_id: String, volume: f32) {
+    dispatch_once(&audio, resource_sound_path(&app, &sound_id), volume);
+}
+
+#[tauri::command]
+pub fn play_custom_sound(audio: State<'_, AudioPlayer>, path: String, volume: f32) {
+    dispatch_once(&audio, custom_path(path), volume);
 }
 
 #[tauri::command]
 pub fn start_ambient(app: AppHandle, audio: State<'_, AudioPlayer>, sound_id: String, volume: f32) {
-    if volume <= 0.0 {
-        return;
-    }
-    if let Some(path) = resource_sound_path(&app, &sound_id) {
-        audio.set_volume(volume);
-        audio.start_ambient(path);
-    }
+    dispatch_ambient(&audio, resource_sound_path(&app, &sound_id), volume, false);
 }
 
 #[tauri::command]
 pub fn start_custom_ambient(audio: State<'_, AudioPlayer>, path: String, volume: f32) {
-    if volume <= 0.0 || path.is_empty() {
-        return;
-    }
-    audio.set_volume(volume);
-    audio.start_ambient(PathBuf::from(path));
+    dispatch_ambient(&audio, custom_path(path), volume, false);
 }
 
 #[tauri::command]
@@ -251,22 +266,12 @@ pub fn preview_ambient(
     sound_id: String,
     volume: f32,
 ) {
-    if volume <= 0.0 {
-        return;
-    }
-    if let Some(path) = resource_sound_path(&app, &sound_id) {
-        audio.set_volume(volume);
-        audio.preview_ambient(path);
-    }
+    dispatch_ambient(&audio, resource_sound_path(&app, &sound_id), volume, true);
 }
 
 #[tauri::command]
 pub fn preview_custom_ambient(audio: State<'_, AudioPlayer>, path: String, volume: f32) {
-    if volume <= 0.0 || path.is_empty() {
-        return;
-    }
-    audio.set_volume(volume);
-    audio.preview_ambient(PathBuf::from(path));
+    dispatch_ambient(&audio, custom_path(path), volume, true);
 }
 
 #[tauri::command]
@@ -325,5 +330,50 @@ mod tests {
             decode(Path::new(&path)).is_some(),
             "failed to decode bundled mp3 at {path}"
         );
+    }
+
+    #[test]
+    fn custom_path_empty_is_none_otherwise_some() {
+        assert_eq!(custom_path(String::new()), None);
+        assert_eq!(
+            custom_path("/tmp/a.wav".into()),
+            Some(PathBuf::from("/tmp/a.wav"))
+        );
+    }
+
+    // The command dispatch helpers and the `AudioPlayer` handle only enqueue
+    // commands; they never block on the audio device. In headless CI the
+    // device fails to open and the thread exits, so sends are dropped — but
+    // nothing panics, which is all these guard-coverage tests assert. A
+    // missing path keeps the player untouched.
+    const ABSENT: &str = "/no/such/audio/file.mp3";
+
+    #[test]
+    fn dispatch_once_covers_guard_and_action() {
+        let audio = AudioPlayer::spawn();
+        dispatch_once(&audio, Some(PathBuf::from(ABSENT)), 0.6);
+        dispatch_once(&audio, None, 0.6);
+        dispatch_once(&audio, Some(PathBuf::from(ABSENT)), 0.0);
+    }
+
+    #[test]
+    fn dispatch_ambient_covers_start_and_preview() {
+        let audio = AudioPlayer::spawn();
+        dispatch_ambient(&audio, Some(PathBuf::from(ABSENT)), 0.6, false);
+        dispatch_ambient(&audio, Some(PathBuf::from(ABSENT)), 0.6, true);
+        dispatch_ambient(&audio, None, 0.6, false);
+        dispatch_ambient(&audio, Some(PathBuf::from(ABSENT)), 0.0, true);
+    }
+
+    #[test]
+    fn audio_player_methods_do_not_panic() {
+        let audio = AudioPlayer::spawn();
+        audio.set_volume(0.5);
+        audio.set_volume(5.0);
+        audio.play_once(PathBuf::from(ABSENT));
+        audio.start_ambient(PathBuf::from(ABSENT));
+        audio.preview_ambient(PathBuf::from(ABSENT));
+        audio.stop_ambient();
+        audio.stop_all();
     }
 }

--- a/src-tauri/src/audio.rs
+++ b/src-tauri/src/audio.rs
@@ -1,0 +1,329 @@
+//! Native audio playback.
+//!
+//! Break sounds used to play through the webview's `HTMLAudioElement`. That
+//! works on macOS (WKWebView) and Windows (WebView2), which decode MP3
+//! natively, but not on Linux: WebKitGTK delegates media to GStreamer and
+//! cannot decode MP3 without system codecs that aren't installed by default,
+//! so every chime and ambient track fell silent (#114).
+//!
+//! Playback now runs in-process through `rodio`, which decodes with
+//! Symphonia regardless of the OS or webview, and plays via CoreAudio /
+//! WASAPI / ALSA. The frontend just tells us *what* to play and *when*.
+//!
+//! `rodio`'s device handle (`MixerDeviceSink`) and `Player`s are `!Send`, so
+//! they live on one dedicated thread fed by a command channel. Everything
+//! the unit tests can reach — the sound catalogue lookup and the volume
+//! clamp — is pulled out as plain functions; the thread that touches the
+//! audio device is the thin, untestable shim.
+
+use std::fs::File;
+use std::io::BufReader;
+use std::path::{Path, PathBuf};
+use std::sync::mpsc::{self, Receiver, Sender};
+use std::sync::{Mutex, OnceLock};
+use std::thread;
+use std::time::Duration;
+
+use rodio::Source;
+use serde::Deserialize;
+use tauri::path::BaseDirectory;
+use tauri::{AppHandle, Manager, State};
+
+/// How long an ambient preview plays before it is cut off. Auditions on the
+/// Settings page shouldn't loop forever.
+const PREVIEW_MAX: Duration = Duration::from_secs(6);
+
+/// The bundled sound catalogue, embedded at compile time. Only `id` and
+/// `file` matter here; the frontend owns the rest (titles, attribution).
+#[derive(Deserialize)]
+struct CatalogEntry {
+    id: String,
+    file: String,
+}
+
+const CATALOG_JSON: &str = include_str!("../../src/assets/sounds/credits.json");
+
+fn catalog() -> &'static [CatalogEntry] {
+    static CATALOG: OnceLock<Vec<CatalogEntry>> = OnceLock::new();
+    CATALOG.get_or_init(|| serde_json::from_str(CATALOG_JSON).unwrap_or_default())
+}
+
+/// Resolve a catalogue `sound_id` to its bundled file name, or `None` when
+/// the id isn't in the catalogue. The file name is then resolved against the
+/// app's resource directory by the Tauri command layer.
+pub fn file_for_id(id: &str) -> Option<&'static str> {
+    catalog()
+        .iter()
+        .find(|e| e.id == id)
+        .map(|e| e.file.as_str())
+}
+
+/// Clamp a volume to the playable `[0, 1]` range. Matches the frontend's
+/// old `clampVolume` so behaviour is identical across the IPC boundary.
+pub fn clamp_volume(volume: f32) -> f32 {
+    volume.clamp(0.0, 1.0)
+}
+
+enum AudioCmd {
+    SetVolume(f32),
+    PlayOnce(PathBuf),
+    StartAmbient(PathBuf),
+    PreviewAmbient(PathBuf),
+    StopAmbient,
+    StopAll,
+}
+
+/// Handle to the audio thread. Cloneable-by-reference through Tauri state;
+/// every method is fire-and-forget — a dropped thread (no output device)
+/// silently swallows commands rather than erroring up the call stack.
+pub struct AudioPlayer {
+    tx: Mutex<Sender<AudioCmd>>,
+}
+
+impl AudioPlayer {
+    /// Spawn the audio thread and return a handle to it.
+    pub fn spawn() -> Self {
+        let (tx, rx) = mpsc::channel();
+        let _ = thread::Builder::new()
+            .name("entracte-audio".into())
+            .spawn(move || run(rx));
+        Self { tx: Mutex::new(tx) }
+    }
+
+    fn send(&self, cmd: AudioCmd) {
+        if let Ok(tx) = self.tx.lock() {
+            let _ = tx.send(cmd);
+        }
+    }
+
+    pub fn set_volume(&self, volume: f32) {
+        self.send(AudioCmd::SetVolume(clamp_volume(volume)));
+    }
+
+    pub fn play_once(&self, path: PathBuf) {
+        self.send(AudioCmd::PlayOnce(path));
+    }
+
+    pub fn start_ambient(&self, path: PathBuf) {
+        self.send(AudioCmd::StartAmbient(path));
+    }
+
+    pub fn preview_ambient(&self, path: PathBuf) {
+        self.send(AudioCmd::PreviewAmbient(path));
+    }
+
+    pub fn stop_ambient(&self) {
+        self.send(AudioCmd::StopAmbient);
+    }
+
+    pub fn stop_all(&self) {
+        self.send(AudioCmd::StopAll);
+    }
+}
+
+/// Decode a sound file into a `rodio` source, logging (not panicking) on a
+/// missing file or an unsupported codec.
+fn decode(path: &Path) -> Option<rodio::Decoder<BufReader<File>>> {
+    let file = match File::open(path) {
+        Ok(f) => f,
+        Err(e) => {
+            log::warn!("audio: cannot open {}: {e}", path.display());
+            return None;
+        }
+    };
+    match rodio::Decoder::try_from(file) {
+        Ok(decoder) => Some(decoder),
+        Err(e) => {
+            log::warn!("audio: cannot decode {}: {e}", path.display());
+            None
+        }
+    }
+}
+
+fn run(rx: Receiver<AudioCmd>) {
+    let handle = match rodio::DeviceSinkBuilder::open_default_sink() {
+        Ok(handle) => handle,
+        Err(e) => {
+            log::warn!("audio: no output device, sounds disabled: {e}");
+            return;
+        }
+    };
+    let mixer = handle.mixer();
+    let mut volume: f32 = 1.0;
+    let mut ambient: Option<rodio::Player> = None;
+    let mut one_shots: Vec<rodio::Player> = Vec::new();
+
+    while let Ok(cmd) = rx.recv() {
+        // Drop finished one-shots so the vector can't grow without bound.
+        one_shots.retain(|p| !p.empty());
+        match cmd {
+            AudioCmd::SetVolume(v) => {
+                volume = v;
+                if let Some(p) = &ambient {
+                    p.set_volume(volume);
+                }
+            }
+            AudioCmd::PlayOnce(path) => {
+                if let Some(source) = decode(&path) {
+                    let player = rodio::Player::connect_new(mixer);
+                    player.set_volume(volume);
+                    player.append(source);
+                    one_shots.push(player);
+                }
+            }
+            AudioCmd::StartAmbient(path) => {
+                ambient = decode(&path).map(|source| {
+                    let player = rodio::Player::connect_new(mixer);
+                    player.set_volume(volume);
+                    player.append(source.repeat_infinite());
+                    player
+                });
+            }
+            AudioCmd::PreviewAmbient(path) => {
+                ambient = decode(&path).map(|source| {
+                    let player = rodio::Player::connect_new(mixer);
+                    player.set_volume(volume);
+                    player.append(source.repeat_infinite().take_duration(PREVIEW_MAX));
+                    player
+                });
+            }
+            AudioCmd::StopAmbient => ambient = None,
+            AudioCmd::StopAll => {
+                ambient = None;
+                one_shots.clear();
+            }
+        }
+    }
+}
+
+/// Resolve a bundled `sound_id` to its file inside the app's resource dir.
+fn resource_sound_path(app: &AppHandle, sound_id: &str) -> Option<PathBuf> {
+    let file = file_for_id(sound_id)?;
+    app.path()
+        .resolve(format!("sounds/{file}"), BaseDirectory::Resource)
+        .ok()
+}
+
+#[tauri::command]
+pub fn play_sound(app: AppHandle, audio: State<'_, AudioPlayer>, sound_id: String, volume: f32) {
+    if volume <= 0.0 {
+        return;
+    }
+    if let Some(path) = resource_sound_path(&app, &sound_id) {
+        audio.set_volume(volume);
+        audio.play_once(path);
+    }
+}
+
+#[tauri::command]
+pub fn play_custom_sound(audio: State<'_, AudioPlayer>, path: String, volume: f32) {
+    if volume <= 0.0 || path.is_empty() {
+        return;
+    }
+    audio.set_volume(volume);
+    audio.play_once(PathBuf::from(path));
+}
+
+#[tauri::command]
+pub fn start_ambient(app: AppHandle, audio: State<'_, AudioPlayer>, sound_id: String, volume: f32) {
+    if volume <= 0.0 {
+        return;
+    }
+    if let Some(path) = resource_sound_path(&app, &sound_id) {
+        audio.set_volume(volume);
+        audio.start_ambient(path);
+    }
+}
+
+#[tauri::command]
+pub fn start_custom_ambient(audio: State<'_, AudioPlayer>, path: String, volume: f32) {
+    if volume <= 0.0 || path.is_empty() {
+        return;
+    }
+    audio.set_volume(volume);
+    audio.start_ambient(PathBuf::from(path));
+}
+
+#[tauri::command]
+pub fn preview_ambient(
+    app: AppHandle,
+    audio: State<'_, AudioPlayer>,
+    sound_id: String,
+    volume: f32,
+) {
+    if volume <= 0.0 {
+        return;
+    }
+    if let Some(path) = resource_sound_path(&app, &sound_id) {
+        audio.set_volume(volume);
+        audio.preview_ambient(path);
+    }
+}
+
+#[tauri::command]
+pub fn preview_custom_ambient(audio: State<'_, AudioPlayer>, path: String, volume: f32) {
+    if volume <= 0.0 || path.is_empty() {
+        return;
+    }
+    audio.set_volume(volume);
+    audio.preview_ambient(PathBuf::from(path));
+}
+
+#[tauri::command]
+pub fn stop_ambient(audio: State<'_, AudioPlayer>) {
+    audio.stop_ambient();
+}
+
+#[tauri::command]
+pub fn stop_all_sounds(audio: State<'_, AudioPlayer>) {
+    audio.stop_all();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn catalog_parses_and_is_non_empty() {
+        assert!(!catalog().is_empty());
+    }
+
+    #[test]
+    fn file_for_known_id_resolves() {
+        // Temple bell — the default end chime.
+        let file = file_for_id("337048").expect("known id resolves");
+        assert!(file.ends_with(".mp3"), "got {file}");
+    }
+
+    #[test]
+    fn file_for_unknown_id_is_none() {
+        assert_eq!(file_for_id("not-a-real-id"), None);
+        assert_eq!(file_for_id(""), None);
+    }
+
+    #[test]
+    fn clamp_volume_bounds_to_unit_range() {
+        assert_eq!(clamp_volume(-0.5), 0.0);
+        assert_eq!(clamp_volume(0.0), 0.0);
+        assert_eq!(clamp_volume(0.5), 0.5);
+        assert_eq!(clamp_volume(1.0), 1.0);
+        assert_eq!(clamp_volume(2.0), 1.0);
+    }
+
+    #[test]
+    fn decode_missing_file_is_none() {
+        assert!(decode(Path::new("/no/such/sound.mp3")).is_none());
+    }
+
+    #[test]
+    fn decode_bundled_mp3_succeeds() {
+        // Proves the Symphonia MP3 decoder is wired up: decoding never
+        // touches an audio device, so this is safe in headless CI.
+        let file = file_for_id("337048").expect("known id");
+        let path = format!("{}/../src/assets/sounds/{file}", env!("CARGO_MANIFEST_DIR"));
+        assert!(
+            decode(Path::new(&path)).is_some(),
+            "failed to decode bundled mp3 at {path}"
+        );
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,3 +1,4 @@
+mod audio;
 mod camera;
 pub mod cli;
 mod config;
@@ -167,6 +168,14 @@ pub fn run() {
             platform::get_platform,
             platform::get_platform_capabilities,
             renderer_log::report_renderer_error,
+            audio::play_sound,
+            audio::play_custom_sound,
+            audio::start_ambient,
+            audio::start_custom_ambient,
+            audio::preview_ambient,
+            audio::preview_custom_ambient,
+            audio::stop_ambient,
+            audio::stop_all_sounds,
             get_supporter_status,
             verify_supporter_key,
             remove_supporter,
@@ -216,6 +225,8 @@ pub fn run() {
             let scheduler = Scheduler::new(config_path, pause_path, events_path, screen_time_path);
             scheduler.spawn(app.handle().clone());
             app.manage(scheduler);
+
+            app.manage(audio::AudioPlayer::spawn());
 
             let supporter_path = supporter::file_path(&data_dir);
             app.manage(SupporterAppState {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -46,6 +46,17 @@
       "icons/icon.icns",
       "icons/icon.ico"
     ],
+    "resources": {
+      "../src/assets/sounds/*.mp3": "sounds/"
+    },
+    "linux": {
+      "deb": {
+        "depends": ["libasound2"]
+      },
+      "rpm": {
+        "depends": ["alsa-lib"]
+      }
+    },
     "createUpdaterArtifacts": true
   },
   "plugins": {

--- a/src/lib/sounds.test.ts
+++ b/src/lib/sounds.test.ts
@@ -1,11 +1,12 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Sound } from "./sounds";
 
-// `convertFileSrc` is what bridges user-supplied filesystem paths into
-// the Tauri asset protocol. The lib uses it for the custom-sound
-// variants below — mocked here so tests don't need a Tauri runtime.
+// Playback runs natively in Rust via Tauri commands; the lib just forwards
+// to `invoke`. Mock it so tests assert which command fires with which args
+// without needing a Tauri runtime.
+const invoke = vi.fn().mockResolvedValue(undefined);
 vi.mock("@tauri-apps/api/core", () => ({
-  convertFileSrc: (p: string) => `mocked-asset://${p}`,
+  invoke: (...args: unknown[]) => invoke(...args),
 }));
 
 const {
@@ -78,407 +79,124 @@ describe("soundById", () => {
   });
 });
 
-// Audio playback covers the side-effecty paths. We stub the global
-// Audio constructor with a controllable fake so we can drive `ended` /
-// `error` events and assert volume / play / loop behavior.
+// Playback wrappers: assert the right Tauri command fires with the right
+// args, and that the cheap client-side short-circuits skip the IPC entirely.
 
-class FakeAudio {
-  src: string;
-  volume = 1;
-  loop = false;
-  currentTime = 0;
-  play: ReturnType<typeof vi.fn>;
-  pause = vi.fn();
-  private handlers = new Map<string, Set<() => void>>();
-
-  constructor(url: string) {
-    this.src = url;
-    this.play = vi.fn(FakeAudio.playBehavior);
-    createdAudios.push(this);
-    // Test fake tracks its own latest instance so assertions can reach it.
-    // eslint-disable-next-line @typescript-eslint/no-this-alias
-    lastAudio = this;
-  }
-
-  static playBehavior: () => Promise<void> = async () => undefined;
-
-  addEventListener(event: string, handler: () => void) {
-    if (!this.handlers.has(event)) this.handlers.set(event, new Set());
-    this.handlers.get(event)!.add(handler);
-  }
-
-  removeEventListener(event: string, handler: () => void) {
-    this.handlers.get(event)?.delete(handler);
-  }
-
-  fire(event: "ended" | "error") {
-    const set = this.handlers.get(event);
-    if (!set) return;
-    for (const h of [...set]) h();
-  }
-}
-
-let lastAudio: FakeAudio | null = null;
-const createdAudios: FakeAudio[] = [];
-
-function installFakeAudio(
-  playBehavior: () => Promise<void> = async () => undefined,
-) {
-  createdAudios.length = 0;
-  lastAudio = null;
-  FakeAudio.playBehavior = playBehavior;
-  vi.stubGlobal("Audio", FakeAudio);
-}
-
-function restoreAudio() {
-  vi.unstubAllGlobals();
-}
-
-// The Vite-lazy URL loader resolves over several event-loop turns
-// (not just microtasks); wait on macrotasks for the constructor to fire.
-async function waitForAudio(): Promise<FakeAudio> {
-  for (let i = 0; i < 50; i += 1) {
-    if (lastAudio) return lastAudio;
-    await new Promise((resolve) => setTimeout(resolve, 1));
-  }
-  throw new Error("Audio was never constructed");
-}
+beforeEach(() => {
+  invoke.mockClear();
+});
 
 describe("playSound", () => {
-  beforeEach(() => {
-    installFakeAudio();
-  });
-
-  afterEach(() => {
-    restoreAudio();
-  });
-
-  it("is a no-op when volume is zero (returns without constructing Audio)", async () => {
-    await playSound("398496", 0);
-    expect(createdAudios.length).toBe(0);
-  });
-
-  it("is a no-op when volume is negative", async () => {
-    await playSound("398496", -0.5);
-    expect(createdAudios.length).toBe(0);
-  });
-
-  it("is a no-op when the sound id is unknown (no Audio constructed)", async () => {
-    await playSound("not-a-real-id", 0.5);
-    expect(createdAudios.length).toBe(0);
-  });
-
-  it("constructs an Audio, sets volume, and resolves when 'ended' fires", async () => {
-    const promise = playSound("398496", 0.5);
-    const audio = await waitForAudio();
-    expect(audio.volume).toBe(0.5);
-    expect(audio.play).toHaveBeenCalledTimes(1);
-
-    audio.fire("ended");
-    await expect(promise).resolves.toBeUndefined();
-  });
-
-  it("clamps the volume to [0, 1]", async () => {
-    const promise = playSound("398496", 5);
-    const audio = await waitForAudio();
-    expect(audio.volume).toBe(1);
-    audio.fire("ended");
-    await promise;
-  });
-
-  it("resolves on 'error' as well as 'ended'", async () => {
-    const promise = playSound("398496", 0.5);
-    const audio = await waitForAudio();
-    audio.fire("error");
-    await expect(promise).resolves.toBeUndefined();
-  });
-
-  it("resolves when play() rejects (autoplay-blocked, missing codec, etc.)", async () => {
-    installFakeAudio(async () => {
-      throw new Error("autoplay blocked");
+  it("invokes play_sound with the id and volume", async () => {
+    await playSound("337048", 0.7);
+    expect(invoke).toHaveBeenCalledWith("play_sound", {
+      soundId: "337048",
+      volume: 0.7,
     });
-    const promise = playSound("398496", 0.5);
-    await expect(promise).resolves.toBeUndefined();
   });
 
-  it("tears down the element when play() rejects so a deferred play can't resume later", async () => {
-    installFakeAudio(async () => {
-      throw new Error("autoplay blocked");
+  it("is a no-op when volume is zero or negative", async () => {
+    await playSound("337048", 0);
+    await playSound("337048", -1);
+    expect(invoke).not.toHaveBeenCalled();
+  });
+});
+
+describe("playCustomSound", () => {
+  it("invokes play_custom_sound with the path and volume", async () => {
+    await playCustomSound("/tmp/chime.wav", 0.5);
+    expect(invoke).toHaveBeenCalledWith("play_custom_sound", {
+      path: "/tmp/chime.wav",
+      volume: 0.5,
     });
-    const promise = playSound("398496", 0.5);
-    const audio = await waitForAudio();
-    await promise;
-    expect(audio.pause).toHaveBeenCalled();
-    expect(audio.src).toBe("");
   });
 
-  it("resolves via the safety timeout even if neither 'ended' nor 'error' ever fires", async () => {
-    // Critical invariant: the breakSoundFor caller awaits playSound and
-    // must not hang forever if the Audio element gets wedged (e.g. a
-    // codec stalls). Documented timeout: 2.5s.
-    const promise = playSound("398496", 0.5);
-    const audio = await waitForAudio();
-    // Don't fire ended/error — let the safety timer carry it home.
-    await expect(
-      Promise.race([
-        promise,
-        new Promise((_, reject) =>
-          setTimeout(
-            () => reject(new Error("playSound hung past safety timeout")),
-            3500,
-          ),
-        ),
-      ]),
-    ).resolves.toBeUndefined();
-    // The safety timeout must also tear the element down — a chime that
-    // never started while the overlay was visible would otherwise resume
-    // and bleed into the start of the next break (issue #62).
-    expect(audio.pause).toHaveBeenCalled();
-    expect(audio.src).toBe("");
-  }, 5000);
+  it("is a no-op when volume is zero or the path is empty", async () => {
+    await playCustomSound("/tmp/chime.wav", 0);
+    await playCustomSound("", 0.5);
+    expect(invoke).not.toHaveBeenCalled();
+  });
 });
 
 describe("stopAllSounds", () => {
-  beforeEach(() => {
-    installFakeAudio();
-  });
-
-  afterEach(() => {
-    restoreAudio();
-  });
-
-  it("stops a one-shot playback still in flight and clears its src", async () => {
-    const promise = playSound("398496", 0.5);
-    const audio = await waitForAudio();
-    // Neither 'ended' nor 'error' has fired — the chime is still live.
+  it("invokes stop_all_sounds", () => {
     stopAllSounds();
-    expect(audio.pause).toHaveBeenCalled();
-    expect(audio.src).toBe("");
-    // Settle the still-pending promise so the test leaves nothing hanging.
-    audio.fire("ended");
-    await promise;
-  });
-
-  it("is a no-op when nothing is playing", () => {
-    expect(() => stopAllSounds()).not.toThrow();
-    expect(createdAudios.length).toBe(0);
+    expect(invoke).toHaveBeenCalledWith("stop_all_sounds");
   });
 });
 
 describe("startAmbient", () => {
-  beforeEach(() => {
-    installFakeAudio();
-  });
-
-  afterEach(() => {
-    restoreAudio();
-  });
-
-  it("returns null when volume is zero (no Audio constructed)", () => {
-    expect(startAmbient("398496", 0)).toBeNull();
-    expect(createdAudios.length).toBe(0);
-  });
-
-  it("returns a handle and loops the audio once the URL resolves", async () => {
-    const handle = startAmbient("398496", 0.4);
+  it("invokes start_ambient and returns a handle", () => {
+    const handle = startAmbient("180732", 0.4);
     expect(handle).not.toBeNull();
-    const audio = await waitForAudio();
-    expect(audio.loop).toBe(true);
-    expect(audio.volume).toBe(0.4);
+    expect(invoke).toHaveBeenCalledWith("start_ambient", {
+      soundId: "180732",
+      volume: 0.4,
+    });
   });
 
-  it("stop() pauses the audio and clears its src", async () => {
-    const handle = startAmbient("398496", 0.4);
-    const audio = await waitForAudio();
-    handle!.stop();
-    expect(audio.pause).toHaveBeenCalled();
-    expect(audio.src).toBe("");
+  it("returns null and skips IPC when volume is zero", () => {
+    expect(startAmbient("180732", 0)).toBeNull();
+    expect(invoke).not.toHaveBeenCalled();
   });
 
-  it("stop() before the URL resolves prevents Audio from ever being constructed", async () => {
-    const handle = startAmbient("398496", 0.4);
-    handle!.stop();
-    // Drain enough microtasks that the URL loader would have fired.
-    for (let i = 0; i < 50; i += 1) await Promise.resolve();
-    expect(createdAudios.length).toBe(0);
-  });
-
-  it("stop() is idempotent", async () => {
-    const handle = startAmbient("398496", 0.4);
-    const audio = await waitForAudio();
-    handle!.stop();
-    expect(() => handle!.stop()).not.toThrow();
-    expect(audio.pause).toHaveBeenCalledTimes(1);
-  });
-});
-
-describe("previewAmbient", () => {
-  beforeEach(() => {
-    installFakeAudio();
-  });
-
-  afterEach(() => {
-    vi.useRealTimers();
-    restoreAudio();
-  });
-
-  it("returns null when volume is zero", () => {
-    expect(previewAmbient("398496", 0)).toBeNull();
-    expect(createdAudios.length).toBe(0);
-  });
-
-  it("starts looping audio at the requested volume", async () => {
-    const handle = previewAmbient("398496", 0.6, 2, 0.5);
-    expect(handle).not.toBeNull();
-    const audio = await waitForAudio();
-    expect(audio.volume).toBe(0.6);
-    expect(audio.loop).toBe(true);
-  });
-
-  it("auto-stops after maxSecs by fading volume to zero and calling pause", async () => {
-    // Use a small maxSecs so we can just wait wall-clock for it.
-    // Fake timers can't drive Vite's lazy URL loader, so real timers
-    // throughout this test.
-    const maxSecs = 0.15;
-    const fadeSecs = 0.05;
-    const handle = previewAmbient("398496", 0.6, maxSecs, fadeSecs);
-    const audio = await waitForAudio();
-    expect(handle).not.toBeNull();
-
-    await new Promise((r) => setTimeout(r, (maxSecs + 0.1) * 1000));
-    expect(audio.pause).toHaveBeenCalled();
-    expect(audio.volume).toBeCloseTo(0, 1);
-  });
-
-  it("manual stop() before fade clears the pending fade (single pause())", async () => {
-    // Long maxSecs so the fade never fires on its own during this test.
-    const handle = previewAmbient("398496", 0.6, 10, 0.5);
-    const audio = await waitForAudio();
-    handle!.stop();
-    expect(audio.pause).toHaveBeenCalledTimes(1);
-
-    // Wait a beat — if stop() failed to cancel the pending fade timer,
-    // the fade would later fire and call pause() a second time.
-    await new Promise((r) => setTimeout(r, 50));
-    expect(audio.pause).toHaveBeenCalledTimes(1);
-  });
-});
-
-// -- Custom-file (Supporter-pack) variants. Same playback semantics as
-//    the bundled-id variants above, but the URL is resolved through
-//    `convertFileSrc` (mocked to `mocked-asset://${path}` at the top of
-//    this file) instead of Vite's lazy URL loader.
-
-describe("playCustomSound", () => {
-  beforeEach(() => {
-    installFakeAudio();
-  });
-
-  afterEach(() => {
-    restoreAudio();
-  });
-
-  it("is a no-op when volume is zero", async () => {
-    await playCustomSound("/Users/me/chime.mp3", 0);
-    expect(createdAudios.length).toBe(0);
-  });
-
-  it("is a no-op when the path is empty", async () => {
-    await playCustomSound("", 0.5);
-    expect(createdAudios.length).toBe(0);
-  });
-
-  it("resolves the path through the asset protocol and plays once", async () => {
-    const promise = playCustomSound("/Users/me/chime.mp3", 0.5);
-    const audio = await waitForAudio();
-    expect(audio.src).toBe("mocked-asset:///Users/me/chime.mp3");
-    expect(audio.volume).toBe(0.5);
-    audio.fire("ended");
-    await expect(promise).resolves.toBeUndefined();
+  it("handle.stop() invokes stop_ambient, and is idempotent", () => {
+    const handle = startAmbient("180732", 0.4);
+    invoke.mockClear();
+    handle?.stop();
+    handle?.stop();
+    expect(invoke).toHaveBeenCalledTimes(1);
+    expect(invoke).toHaveBeenCalledWith("stop_ambient");
   });
 });
 
 describe("startCustomAmbient", () => {
-  beforeEach(() => {
-    installFakeAudio();
+  it("invokes start_custom_ambient with the path", () => {
+    const handle = startCustomAmbient("/tmp/rain.ogg", 0.6);
+    expect(handle).not.toBeNull();
+    expect(invoke).toHaveBeenCalledWith("start_custom_ambient", {
+      path: "/tmp/rain.ogg",
+      volume: 0.6,
+    });
   });
 
-  afterEach(() => {
-    restoreAudio();
+  it("returns null when volume is zero or the path is empty", () => {
+    expect(startCustomAmbient("/tmp/rain.ogg", 0)).toBeNull();
+    expect(startCustomAmbient("", 0.6)).toBeNull();
+    expect(invoke).not.toHaveBeenCalled();
+  });
+});
+
+describe("previewAmbient", () => {
+  it("invokes preview_ambient and returns a stoppable handle", () => {
+    const handle = previewAmbient("180732", 0.5);
+    expect(invoke).toHaveBeenCalledWith("preview_ambient", {
+      soundId: "180732",
+      volume: 0.5,
+    });
+    invoke.mockClear();
+    handle?.stop();
+    expect(invoke).toHaveBeenCalledWith("stop_ambient");
   });
 
   it("returns null when volume is zero", () => {
-    expect(startCustomAmbient("/Users/me/loop.mp3", 0)).toBeNull();
-    expect(createdAudios.length).toBe(0);
-  });
-
-  it("returns null when the path is empty", () => {
-    expect(startCustomAmbient("", 0.4)).toBeNull();
-    expect(createdAudios.length).toBe(0);
-  });
-
-  it("loops the asset-protocol URL at the requested volume", async () => {
-    const handle = startCustomAmbient("/Users/me/loop.mp3", 0.3);
-    expect(handle).not.toBeNull();
-    const audio = await waitForAudio();
-    expect(audio.src).toBe("mocked-asset:///Users/me/loop.mp3");
-    expect(audio.loop).toBe(true);
-    expect(audio.volume).toBe(0.3);
-    handle!.stop();
-  });
-
-  it("stop() pauses the audio and clears src", async () => {
-    const handle = startCustomAmbient("/Users/me/loop.mp3", 0.3);
-    const audio = await waitForAudio();
-    handle!.stop();
-    expect(audio.pause).toHaveBeenCalled();
-    expect(audio.src).toBe("");
+    expect(previewAmbient("180732", 0)).toBeNull();
+    expect(invoke).not.toHaveBeenCalled();
   });
 });
 
 describe("previewCustomAmbient", () => {
-  beforeEach(() => {
-    installFakeAudio();
+  it("invokes preview_custom_ambient with the path", () => {
+    previewCustomAmbient("/tmp/rain.ogg", 0.5);
+    expect(invoke).toHaveBeenCalledWith("preview_custom_ambient", {
+      path: "/tmp/rain.ogg",
+      volume: 0.5,
+    });
   });
 
-  afterEach(() => {
-    vi.useRealTimers();
-    restoreAudio();
-  });
-
-  it("returns null when volume is zero", () => {
-    expect(previewCustomAmbient("/Users/me/loop.mp3", 0)).toBeNull();
-    expect(createdAudios.length).toBe(0);
-  });
-
-  it("returns null when the path is empty", () => {
-    expect(previewCustomAmbient("", 0.6)).toBeNull();
-    expect(createdAudios.length).toBe(0);
-  });
-
-  it("starts looping the asset-protocol URL at the requested volume", async () => {
-    const handle = previewCustomAmbient("/Users/me/loop.mp3", 0.6, 2, 0.5);
-    expect(handle).not.toBeNull();
-    const audio = await waitForAudio();
-    expect(audio.src).toBe("mocked-asset:///Users/me/loop.mp3");
-    expect(audio.loop).toBe(true);
-    expect(audio.volume).toBe(0.6);
-    handle!.stop();
-  });
-
-  it("auto-stops after maxSecs by fading and pausing", async () => {
-    const maxSecs = 0.15;
-    const fadeSecs = 0.05;
-    const handle = previewCustomAmbient(
-      "/Users/me/loop.mp3",
-      0.6,
-      maxSecs,
-      fadeSecs,
-    );
-    const audio = await waitForAudio();
-    expect(handle).not.toBeNull();
-    await new Promise((r) => setTimeout(r, (maxSecs + 0.1) * 1000));
-    expect(audio.pause).toHaveBeenCalled();
-    expect(audio.volume).toBeCloseTo(0, 1);
+  it("returns null when volume is zero or the path is empty", () => {
+    expect(previewCustomAmbient("/tmp/rain.ogg", 0)).toBeNull();
+    expect(previewCustomAmbient("", 0.5)).toBeNull();
+    expect(invoke).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/sounds.ts
+++ b/src/lib/sounds.ts
@@ -1,4 +1,4 @@
-import { convertFileSrc } from "@tauri-apps/api/core";
+import { invoke } from "@tauri-apps/api/core";
 import credits from "../assets/sounds/credits.json";
 
 /** Buckets the bundled sounds fall into. Drives which sounds are
@@ -27,18 +27,6 @@ export function soundDisplayName(s: Sound): string {
 /** Full bundled sound catalogue. */
 const SOUNDS: Sound[] = credits as Sound[];
 
-const urlLoaders = import.meta.glob("../assets/sounds/*.mp3", {
-  eager: false,
-  query: "?url",
-  import: "default",
-}) as Record<string, () => Promise<string>>;
-
-const loaderByFile: Record<string, () => Promise<string>> = {};
-for (const [path, loader] of Object.entries(urlLoaders)) {
-  const file = path.split("/").pop();
-  if (file) loaderByFile[file] = loader;
-}
-
 /** Short, single-event tracks suitable as an end-of-break chime. */
 const END_CHIME_CATEGORIES: readonly SoundCategory[] = ["chime", "bowl"];
 
@@ -60,101 +48,48 @@ export function soundById(id: string): Sound | undefined {
   return SOUNDS.find((s) => s.id === id);
 }
 
-/** Vite-resolved URL for the audio file backing `id`, or `undefined`
- * when the id isn't in the catalogue. Lazily loads the chunk on first
- * call so unused chimes stay out of the initial bundle. */
-async function soundUrl(id: string): Promise<string | undefined> {
-  const sound = soundById(id);
-  if (!sound) return undefined;
-  const loader = loaderByFile[sound.file];
-  if (!loader) return undefined;
-  return loader();
-}
+// Playback runs natively in Rust (see `src-tauri/src/audio.rs`): the webview
+// decodes MP3 inconsistently across platforms — WebKitGTK on Linux can't play
+// it at all without system codecs (#114) — so these are thin wrappers around
+// Tauri commands that hand the work to an in-process `rodio` audio thread.
+// Volume is clamped and the catalogue is resolved on the Rust side; the
+// `volume <= 0` / empty-path short-circuits here just avoid a pointless IPC
+// round-trip.
 
-/** Tauri asset URL for a user-supplied sound file (Supporter pack).
- * `path` must be an absolute filesystem path returned by the dialog
- * plugin. Returns the empty string for empty input so callers can
- * short-circuit. */
-function customSoundUrl(path: string): string {
-  if (!path) return "";
-  return convertFileSrc(path);
-}
-
-function clampVolume(volume: number): number {
-  return Math.min(1, Math.max(0, volume));
-}
-
-const livePlaybacks = new Set<HTMLAudioElement>();
-const PLAYBACK_TIMEOUT_MS = 2500;
-
-function teardownPlayback(audio: HTMLAudioElement): void {
+/** Fire a sound command without waiting for it. Sound is best-effort: a
+ * backend hiccup — or no Tauri runtime at all, as in unit tests — must never
+ * surface as an unhandled rejection in the overlay. The command is dispatched
+ * synchronously so callers can assert it fired; only the result is swallowed. */
+function fire(cmd: string, args?: Record<string, unknown>): void {
   try {
-    audio.pause();
-    audio.currentTime = 0;
-    audio.src = "";
+    const result = (
+      args === undefined ? invoke(cmd) : invoke(cmd, args)
+    ) as unknown;
+    if (result instanceof Promise) result.catch(() => {});
   } catch {
-    // ignore — element may already be torn down
+    // No IPC available (e.g. test/jsdom) — nothing to play, nothing to do.
   }
 }
 
-async function playUrlOnce(url: string, volume: number): Promise<void> {
-  const audio = new Audio(url);
-  audio.volume = clampVolume(volume);
-  livePlaybacks.add(audio);
-  return new Promise<void>((resolve) => {
-    let settled = false;
-    // `stop` is true when we're giving up on a playback that never
-    // finished cleanly (safety timeout, or `play()` rejected). A break
-    // overlay can suspend its webview's media when it hides; an
-    // untorn-down element with a deferred `play()` then resumes and the
-    // chime bleeds into the *start* of the next break. Tearing it down
-    // here makes a missed chime stay missed instead of mistimed.
-    const finish = (stop: boolean) => {
-      if (settled) return;
-      settled = true;
-      if (stop) teardownPlayback(audio);
-      livePlaybacks.delete(audio);
-      resolve();
-    };
-    audio.addEventListener("ended", () => finish(false), { once: true });
-    audio.addEventListener("error", () => finish(false), { once: true });
-    const timeoutId = setTimeout(() => finish(true), PLAYBACK_TIMEOUT_MS);
-    audio.addEventListener("ended", () => clearTimeout(timeoutId), {
-      once: true,
-    });
-    audio.play().catch(() => finish(true));
-  });
-}
-
-/** Immediately stop and discard any one-shot playbacks still in flight.
- * Called when a new break overlay opens so a chime that's still playing
- * (or was deferred by the previous overlay hiding) can't bleed into the
- * new break. Ambient loops manage their own lifecycle and are untouched. */
-export function stopAllSounds(): void {
-  for (const audio of livePlaybacks) {
-    teardownPlayback(audio);
-  }
-  livePlaybacks.clear();
-}
-
-/** Play a sound once. Resolves when the audio ends, errors, or the
- * 2.5s safety timeout fires (whichever comes first). No-op when
- * `volume <= 0` or the id is unknown. */
-export async function playSound(id: string, volume: number): Promise<void> {
+/** Play a bundled sound once (end-of-break chime, or an audition). No-op
+ * when `volume <= 0`; an unknown id is ignored by the backend. */
+export function playSound(id: string, volume: number): void {
   if (volume <= 0) return;
-  const url = await soundUrl(id);
-  if (!url) return;
-  return playUrlOnce(url, volume);
+  fire("play_sound", { soundId: id, volume });
 }
 
-/** Play a user-supplied audio file once. Same semantics as
- * {@link playSound} but resolves the URL via Tauri's asset protocol. */
-export async function playCustomSound(
-  path: string,
-  volume: number,
-): Promise<void> {
+/** Play a user-supplied audio file once (Supporter pack). `path` is an
+ * absolute filesystem path the backend opens directly. */
+export function playCustomSound(path: string, volume: number): void {
   if (volume <= 0 || !path) return;
-  return playUrlOnce(customSoundUrl(path), volume);
+  fire("play_custom_sound", { path, volume });
+}
+
+/** Stop any one-shot sounds still playing. Called when a new break overlay
+ * opens so a lingering chime can't bleed into the next break. Ambient loops
+ * manage their own lifecycle and are untouched. */
+export function stopAllSounds(): void {
+  fire("stop_all_sounds");
 }
 
 /** Handle returned by ambient-play functions — call `stop()` to end
@@ -163,129 +98,54 @@ export type AmbientHandle = {
   stop(): void;
 };
 
-function startLoop(
-  urlPromise: Promise<string | undefined>,
-  volume: number,
-): AmbientHandle {
+/** A handle whose `stop()` asks the backend to end the single ambient loop.
+ * Idempotent: repeated calls send at most one stop. */
+function ambientHandle(): AmbientHandle {
   let stopped = false;
-  let audio: HTMLAudioElement | null = null;
-  void urlPromise.then((url) => {
-    if (stopped || !url) return;
-    audio = new Audio(url);
-    audio.volume = clampVolume(volume);
-    audio.loop = true;
-    audio.play().catch(() => {});
-  });
   return {
     stop() {
       if (stopped) return;
       stopped = true;
-      if (!audio) return;
-      try {
-        audio.pause();
-        audio.currentTime = 0;
-        audio.src = "";
-      } catch {
-        // ignore — audio may already be torn down
-      }
+      fire("stop_ambient");
     },
   };
 }
 
-/** Start looping ambient audio. Returns `null` when volume is zero.
- * The URL is resolved lazily — `stop()` is safe to call before the
- * audio actually starts playing. */
+/** Start looping ambient audio. Returns `null` when volume is zero. */
 export function startAmbient(id: string, volume: number): AmbientHandle | null {
   if (volume <= 0) return null;
-  return startLoop(soundUrl(id), volume);
+  fire("start_ambient", { soundId: id, volume });
+  return ambientHandle();
 }
 
-/** Start looping a user-supplied audio file. Same semantics as
- * {@link startAmbient} but resolves the URL via Tauri's asset protocol. */
+/** Start looping a user-supplied audio file (Supporter pack). */
 export function startCustomAmbient(
   path: string,
   volume: number,
 ): AmbientHandle | null {
   if (volume <= 0 || !path) return null;
-  return startLoop(Promise.resolve(customSoundUrl(path)), volume);
+  fire("start_custom_ambient", { path, volume });
+  return ambientHandle();
 }
 
-function previewLoop(
-  urlPromise: Promise<string | undefined>,
-  volume: number,
-  maxSecs: number,
-  fadeSecs: number,
-): AmbientHandle {
-  const targetVolume = clampVolume(volume);
-  let stopped = false;
-  let audio: HTMLAudioElement | null = null;
-  let fadeTimer: ReturnType<typeof setInterval> | null = null;
-  let fadeStartTimer: ReturnType<typeof setTimeout> | null = null;
-  const stop = () => {
-    if (stopped) return;
-    stopped = true;
-    if (fadeTimer !== null) clearInterval(fadeTimer);
-    if (fadeStartTimer !== null) clearTimeout(fadeStartTimer);
-    if (!audio) return;
-    try {
-      audio.pause();
-      audio.currentTime = 0;
-      audio.src = "";
-    } catch {
-      // ignore
-    }
-  };
-  void urlPromise.then((url) => {
-    if (stopped || !url) return;
-    audio = new Audio(url);
-    audio.volume = targetVolume;
-    audio.loop = true;
-    audio.play().catch(() => {});
-    const fadeStartMs = Math.max(0, (maxSecs - fadeSecs) * 1000);
-    fadeStartTimer = setTimeout(() => {
-      if (stopped || !audio) return;
-      const steps = 10;
-      const stepMs = (fadeSecs * 1000) / steps;
-      let i = 0;
-      fadeTimer = setInterval(() => {
-        i += 1;
-        if (audio) audio.volume = Math.max(0, targetVolume * (1 - i / steps));
-        if (i >= steps) {
-          if (fadeTimer !== null) clearInterval(fadeTimer);
-          stop();
-        }
-      }, stepMs);
-    }, fadeStartMs);
-  });
-  return { stop };
-}
-
-/** Preview an ambient sound on the Settings page with a hard time
- * cap (default 6s) and a brief fade-out (default 0.5s) so the page
- * never leaks audio that lasts "forever". */
+/** Audition an ambient sound on the Settings page. The backend caps the
+ * preview at a few seconds so it never loops forever. */
 export function previewAmbient(
   id: string,
   volume: number,
-  maxSecs = 6,
-  fadeSecs = 0.5,
 ): AmbientHandle | null {
   if (volume <= 0) return null;
-  return previewLoop(soundUrl(id), volume, maxSecs, fadeSecs);
+  fire("preview_ambient", { soundId: id, volume });
+  return ambientHandle();
 }
 
-/** Preview a user-supplied ambient file with the same time/fade caps
- * as {@link previewAmbient}. */
+/** Audition a user-supplied ambient file with the same time cap as
+ * {@link previewAmbient}. */
 export function previewCustomAmbient(
   path: string,
   volume: number,
-  maxSecs = 6,
-  fadeSecs = 0.5,
 ): AmbientHandle | null {
   if (volume <= 0 || !path) return null;
-  return previewLoop(
-    Promise.resolve(customSoundUrl(path)),
-    volume,
-    maxSecs,
-    fadeSecs,
-  );
+  fire("preview_custom_ambient", { path, volume });
+  return ambientHandle();
 }


### PR DESCRIPTION
## Summary

Fixes #114. Chimes and ambient tracks were **silent on Linux** (e.g. Ubuntu 24.04 / Wayland / GNOME). The root cause: playback went through the webview's `HTMLAudioElement`, and WebKitGTK can't decode the bundled MP3s without system GStreamer codecs that aren't installed by default. macOS (WKWebView) and Windows (WebView2) decode MP3 natively, so only Linux fell silent — and the `play().catch(() => {})` swallowed the failure.

### Approach: native, webview-independent playback

Playback now runs **in-process in Rust** via [`rodio`](https://docs.rs/rodio) (Symphonia decoder). It decodes MP3/OGG/FLAC/WAV/M4A itself — independent of the webview or any OS codec — and plays through the platform audio stack (CoreAudio / WASAPI / ALSA→PipeWire/PulseAudio).

- `src-tauri/src/audio.rs` — a dedicated audio thread (rodio's device handle and players are `!Send`) fed by a command channel, plus pure helpers (catalogue id→file lookup, volume clamp).
- New Tauri commands: `play_sound`, `play_custom_sound`, `start_ambient`, `start_custom_ambient`, `preview_ambient`, `preview_custom_ambient`, `stop_ambient`, `stop_all_sounds`.
- Bundled sounds ship as **Tauri resources** (resolved by id on the Rust side); the MP3s leave the webview bundle. Custom files (Supporter pack) are opened directly by absolute path.
- `src/lib/sounds.ts` keeps the catalogue half unchanged and becomes thin `invoke` wrappers for the playback half. Audio is **best-effort**: a backend hiccup or missing output device is logged, never thrown (a `fire()` helper swallows sync throws and rejections).

### Packaging / CI

rodio links `libasound` on Linux, so:
- every CI workflow that compiles the crate now installs `libasound2-dev`;
- the `.deb`/`.rpm` bundles depend on `libasound2` / `alsa-lib` (without it the **app wouldn't start** on a minimal system, not just lose audio).

## Trade-off

Ambient **auditions on the Settings page** now hard-cut after ~6s instead of the previous 0.5s fade-out (rodio's `fade_out` ramps from the start, not the end). Functional behaviour during real breaks is unchanged.

## Test plan

- **Rust** (`cargo test --lib`): **753 pass**, incl. new `audio` tests — catalogue parse, id→file resolve, unknown-id `None`, volume clamp, missing-file decode `None`, and a **real bundled-MP3 decode** (proves the Symphonia MP3 path; no device needed). `cargo fmt` + `cargo clippy --all-targets` clean.
- **Frontend** (`vitest`): **538 pass**, no unhandled errors. `sounds.test.ts` rewritten to assert each wrapper fires the right command with the right args and that `volume<=0`/empty-path short-circuit IPC; ambient `handle.stop()` is idempotent.
- `npm run typecheck`, `eslint`, `cspell`, and `vite build` all clean. Build also validates the new `tauri.conf.json` (`resources` + `linux.deb/rpm.depends`) via tauri-build.
- ⚠️ Actual audio output on a real Linux device / bundled installer still wants a manual smoke check (no audio device in CI); the decode path and command wiring are covered by unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)