### PR TITLE
feat(quiet): warn when fullscreen-video pause is unreliable (#103)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Versions on the `0.0.X` line are public beta releases; `0.1.X` and onwards will 
 
 ## [Unreleased]
 
+### Added
+
+- **"Fullscreen video is playing" now warns where detection is unreliable.** The Quiet times → Auto-pause toggle that suppresses breaks during fullscreen video carries a caution marker on Linux Wayland, where there is no portable way to confirm a fullscreen window: detection there falls back to "any media is keeping the display awake", so it can suppress breaks for a small background video. macOS, Windows and X11 Linux confirm a real fullscreen window and show a plain info tip. ([#103](https://github.com/drmowinckels/entracte/issues/103))
+
 ### Changed
 
 - **Choosing which break ideas appear is now free.** The Micro (Physical / Psychological / Both) and Long (Solo / Social / Both) **Mix** selectors moved out from behind the Supporter pack, so anyone can drop the "social" prompts (e.g. "walk over to a coworker's desk for a chat") by picking **Solo only** — handy when you work alone. Editing the hint pool text remains a Supporter pack feature. ([#118](https://github.com/drmowinckels/entracte/issues/118))

--- a/docs/guide/settings.md
+++ b/docs/guide/settings.md
@@ -49,7 +49,7 @@ The Breaks tab covers what breaks look and sound like, and the escape hatches.
 
 The Quiet times tab covers when breaks should _not_ fire.
 
-- **Auto-pause** — suppress breaks while Do Not Disturb / Focus is on (macOS, Windows), while the camera is in use (all OSes), or while fullscreen video is playing.
+- **Auto-pause** — suppress breaks while Do Not Disturb / Focus is on (macOS, Windows), while the camera is in use (all OSes), or while fullscreen video is playing. On macOS, Windows and X11 Linux the fullscreen-video check confirms a real fullscreen window, so a small background video won't hold your breaks. On Linux Wayland there is no portable way to confirm a fullscreen window, so the toggle shows a caution marker: detection falls back to "any media is keeping the display awake" and may suppress breaks for a small background video.
 - **During breaks** — _Pause media while a break is showing_ quiets whatever is playing (video or audio) when a break starts and resumes it when the break ends. On Linux this targets your media players precisely (via MPRIS); on macOS and Windows it sends a play/pause media key as a best-effort, so it works for most players but can't guarantee the exact app.
 - **Pause for specific apps** — toggle on and list app name fragments (one per line, partial case-insensitive match). Whenever any listed app is running, breaks are suppressed. A quick-add chip row offers common candidates for your platform.
 - **Manual pause** — shows the current pause state and a Resume button when you've paused from the tray icon.

--- a/src-tauri/src/platform.rs
+++ b/src-tauri/src/platform.rs
@@ -55,21 +55,25 @@ fn capabilities_for(os: &str, wayland: bool) -> PlatformCapabilities {
     }
 }
 
-/// Whether the given session env signals Wayland. Mirrors the probe in
-/// `video.rs` / `overlay.rs`: `XDG_SESSION_TYPE=wayland` or a
-/// `WAYLAND_DISPLAY` set. Pure so the parsing is unit-testable without
-/// mutating process env.
-fn wayland_session_from_env(session_type: Option<&str>, wayland_display: bool) -> bool {
+/// Whether the given OS + session env signals a Wayland session. Off
+/// Linux the Wayland env vars are irrelevant to video detection, so this
+/// is always false there. On Linux it mirrors the probe in `video.rs` /
+/// `overlay.rs`: `XDG_SESSION_TYPE=wayland` or a `WAYLAND_DISPLAY` set.
+/// Kept pure (OS + env passed in) so every branch — including the
+/// off-Linux short-circuit — is unit-testable on the single Linux
+/// coverage runner.
+fn wayland_session_from_env(os: &str, session_type: Option<&str>, wayland_display: bool) -> bool {
+    if os != "linux" {
+        return false;
+    }
     session_type.is_some_and(|s| s.eq_ignore_ascii_case("wayland")) || wayland_display
 }
 
-/// Whether the current Linux session is Wayland. Always false off Linux,
-/// where the Wayland env vars are irrelevant to video detection.
+/// Whether the current session is Wayland. Thin shim that reads the host
+/// OS and session env vars and defers to [`wayland_session_from_env`].
 fn is_wayland_session() -> bool {
-    if std::env::consts::OS != "linux" {
-        return false;
-    }
     wayland_session_from_env(
+        std::env::consts::OS,
         std::env::var("XDG_SESSION_TYPE").ok().as_deref(),
         std::env::var("WAYLAND_DISPLAY").is_ok(),
     )
@@ -159,25 +163,24 @@ mod tests {
 
     #[test]
     fn wayland_session_from_env_detects_session_type() {
-        assert!(wayland_session_from_env(Some("wayland"), false));
-        assert!(wayland_session_from_env(Some("Wayland"), false));
-        assert!(!wayland_session_from_env(Some("x11"), false));
-        assert!(!wayland_session_from_env(None, false));
+        assert!(wayland_session_from_env("linux", Some("wayland"), false));
+        assert!(wayland_session_from_env("linux", Some("Wayland"), false));
+        assert!(!wayland_session_from_env("linux", Some("x11"), false));
+        assert!(!wayland_session_from_env("linux", None, false));
     }
 
     #[test]
     fn wayland_session_from_env_detects_wayland_display() {
-        assert!(wayland_session_from_env(None, true));
-        assert!(wayland_session_from_env(Some("x11"), true));
+        assert!(wayland_session_from_env("linux", None, true));
+        assert!(wayland_session_from_env("linux", Some("x11"), true));
     }
 
     #[test]
-    fn is_wayland_session_is_false_off_linux() {
-        // The session helper is a no-op anywhere but Linux, regardless of
-        // any inherited Wayland env vars.
-        if std::env::consts::OS != "linux" {
-            assert!(!is_wayland_session());
-        }
+    fn wayland_session_from_env_is_false_off_linux() {
+        // Off Linux the Wayland env vars don't apply, even if inherited.
+        assert!(!wayland_session_from_env("macos", Some("wayland"), true));
+        assert!(!wayland_session_from_env("windows", Some("wayland"), true));
+        assert!(!wayland_session_from_env("freebsd", None, true));
     }
 
     #[test]

--- a/src-tauri/src/platform.rs
+++ b/src-tauri/src/platform.rs
@@ -32,25 +32,55 @@ pub struct PlatformCapabilities {
     /// Whether the installer is unsigned and the OS will show a
     /// reputation warning (Windows SmartScreen) on update.
     pub installer_unsigned_warning: bool,
+    /// Whether fullscreen-video detection (the "pause during fullscreen
+    /// video" setting) is reliable on this host. True on macOS, Windows
+    /// and X11 Linux, where the app enumerates on-screen windows to
+    /// confirm a real fullscreen window. False on Linux Wayland, where
+    /// no portable window enumeration exists and detection degrades to
+    /// an assertion-only signal that fires on any media keeping the
+    /// display awake — see `video.rs`.
+    pub video_pause_reliable: bool,
 }
 
-/// Derive the capability flags for a given target-OS string. Kept pure
-/// and `os`-parameterised so every branch is unit-testable on a single
-/// host; the `#[tauri::command]` wrapper feeds it the real target.
-fn capabilities_for(os: &str) -> PlatformCapabilities {
+/// Derive the capability flags for a given target-OS string and whether
+/// the session is Wayland. Kept pure and parameterised so every branch
+/// is unit-testable on a single host; the `#[tauri::command]` wrapper
+/// feeds it the real target and session type.
+fn capabilities_for(os: &str, wayland: bool) -> PlatformCapabilities {
     PlatformCapabilities {
         supports_dnd_read: matches!(os, "macos" | "windows" | "linux"),
         media_pause_granular: os == "linux",
         installer_unsigned_warning: os == "windows",
+        video_pause_reliable: matches!(os, "macos" | "windows") || (os == "linux" && !wayland),
     }
 }
 
+/// Whether the given session env signals Wayland. Mirrors the probe in
+/// `video.rs` / `overlay.rs`: `XDG_SESSION_TYPE=wayland` or a
+/// `WAYLAND_DISPLAY` set. Pure so the parsing is unit-testable without
+/// mutating process env.
+fn wayland_session_from_env(session_type: Option<&str>, wayland_display: bool) -> bool {
+    session_type.is_some_and(|s| s.eq_ignore_ascii_case("wayland")) || wayland_display
+}
+
+/// Whether the current Linux session is Wayland. Always false off Linux,
+/// where the Wayland env vars are irrelevant to video detection.
+fn is_wayland_session() -> bool {
+    if std::env::consts::OS != "linux" {
+        return false;
+    }
+    wayland_session_from_env(
+        std::env::var("XDG_SESSION_TYPE").ok().as_deref(),
+        std::env::var("WAYLAND_DISPLAY").is_ok(),
+    )
+}
+
 /// Return the host's platform capability flags, derived from the
-/// compile-time target OS. The renderer caches the result through its
-/// `usePlatformCapabilities()` hook.
+/// compile-time target OS and the runtime session type. The renderer
+/// caches the result through its `usePlatformCapabilities()` hook.
 #[tauri::command]
 pub fn get_platform_capabilities() -> PlatformCapabilities {
-    capabilities_for(std::env::consts::OS)
+    capabilities_for(std::env::consts::OS, is_wayland_session())
 }
 
 #[cfg(test)]
@@ -71,26 +101,48 @@ mod tests {
 
     #[test]
     fn macos_capabilities() {
-        let c = capabilities_for("macos");
+        let c = capabilities_for("macos", false);
         assert!(c.supports_dnd_read);
         assert!(!c.media_pause_granular);
         assert!(!c.installer_unsigned_warning);
+        assert!(c.video_pause_reliable);
     }
 
     #[test]
     fn windows_capabilities() {
-        let c = capabilities_for("windows");
+        let c = capabilities_for("windows", false);
         assert!(c.supports_dnd_read);
         assert!(!c.media_pause_granular);
         assert!(c.installer_unsigned_warning);
+        assert!(c.video_pause_reliable);
     }
 
     #[test]
-    fn linux_capabilities() {
-        let c = capabilities_for("linux");
+    fn linux_x11_capabilities() {
+        let c = capabilities_for("linux", false);
         assert!(c.supports_dnd_read);
         assert!(c.media_pause_granular);
         assert!(!c.installer_unsigned_warning);
+        assert!(c.video_pause_reliable);
+    }
+
+    #[test]
+    fn linux_wayland_video_pause_is_unreliable() {
+        // Wayland can't enumerate windows, so fullscreen-video detection
+        // degrades to assertion-only — the renderer must warn there.
+        let c = capabilities_for("linux", true);
+        assert!(c.supports_dnd_read);
+        assert!(c.media_pause_granular);
+        assert!(!c.installer_unsigned_warning);
+        assert!(!c.video_pause_reliable);
+    }
+
+    #[test]
+    fn wayland_flag_only_affects_video_pause_on_linux() {
+        // A stray Wayland signal off Linux (shouldn't happen, but the
+        // flag is a plain bool) must not flip video_pause_reliable.
+        assert!(capabilities_for("macos", true).video_pause_reliable);
+        assert!(capabilities_for("windows", true).video_pause_reliable);
     }
 
     #[test]
@@ -98,21 +150,46 @@ mod tests {
         // Anything outside the supported targets gets every flag off so
         // the renderer hides platform-specific copy rather than showing
         // a claim we can't back.
-        let c = capabilities_for("freebsd");
+        let c = capabilities_for("freebsd", false);
         assert!(!c.supports_dnd_read);
         assert!(!c.media_pause_granular);
         assert!(!c.installer_unsigned_warning);
+        assert!(!c.video_pause_reliable);
+    }
+
+    #[test]
+    fn wayland_session_from_env_detects_session_type() {
+        assert!(wayland_session_from_env(Some("wayland"), false));
+        assert!(wayland_session_from_env(Some("Wayland"), false));
+        assert!(!wayland_session_from_env(Some("x11"), false));
+        assert!(!wayland_session_from_env(None, false));
+    }
+
+    #[test]
+    fn wayland_session_from_env_detects_wayland_display() {
+        assert!(wayland_session_from_env(None, true));
+        assert!(wayland_session_from_env(Some("x11"), true));
+    }
+
+    #[test]
+    fn is_wayland_session_is_false_off_linux() {
+        // The session helper is a no-op anywhere but Linux, regardless of
+        // any inherited Wayland env vars.
+        if std::env::consts::OS != "linux" {
+            assert!(!is_wayland_session());
+        }
     }
 
     #[test]
     fn command_matches_host_target() {
         let c = get_platform_capabilities();
-        let expected = capabilities_for(std::env::consts::OS);
+        let expected = capabilities_for(std::env::consts::OS, is_wayland_session());
         assert_eq!(c.supports_dnd_read, expected.supports_dnd_read);
         assert_eq!(c.media_pause_granular, expected.media_pause_granular);
         assert_eq!(
             c.installer_unsigned_warning,
             expected.installer_unsigned_warning
         );
+        assert_eq!(c.video_pause_reliable, expected.video_pause_reliable);
     }
 }

--- a/src/lib/platform.test.ts
+++ b/src/lib/platform.test.ts
@@ -189,6 +189,7 @@ describe("usePlatformCapabilities", () => {
       supportsDndRead: true,
       mediaPauseGranular: true,
       installerUnsignedWarning: false,
+      videoPauseReliable: false,
     });
 
     const { usePlatformCapabilities } = await import("./platform");
@@ -196,8 +197,10 @@ describe("usePlatformCapabilities", () => {
 
     expect(result.current.installerUnsignedWarning).toBe(true); // UA fallback
     expect(result.current.mediaPauseGranular).toBe(false);
+    expect(result.current.videoPauseReliable).toBe(true); // UA fallback (Windows)
     await waitFor(() => expect(result.current.mediaPauseGranular).toBe(true));
     expect(result.current.installerUnsignedWarning).toBe(false);
+    expect(result.current.videoPauseReliable).toBe(false); // Rust: Linux Wayland
     expect(invokeMock).toHaveBeenCalledWith("get_platform_capabilities");
   });
 
@@ -212,9 +215,12 @@ describe("usePlatformCapabilities", () => {
     const { result } = renderHook(() => usePlatformCapabilities());
 
     // Linux fallback: DnD read + granular media pause, no installer warning.
+    // The UA fallback can't see the session type, so it optimistically
+    // reports video pause as reliable on Linux.
     expect(result.current.supportsDndRead).toBe(true);
     expect(result.current.mediaPauseGranular).toBe(true);
     expect(result.current.installerUnsignedWarning).toBe(false);
+    expect(result.current.videoPauseReliable).toBe(true);
     await act(async () => {
       await Promise.resolve();
     });

--- a/src/lib/platform.ts
+++ b/src/lib/platform.ts
@@ -96,6 +96,7 @@ export interface PlatformCapabilities {
   supportsDndRead: boolean;
   mediaPauseGranular: boolean;
   installerUnsignedWarning: boolean;
+  videoPauseReliable: boolean;
 }
 
 /** Derive the conservative fallback capabilities from a UA-guessed
@@ -108,6 +109,11 @@ function fallbackCapabilities(platform: Platform): PlatformCapabilities {
       platform === "macos" || platform === "windows" || platform === "linux",
     mediaPauseGranular: platform === "linux",
     installerUnsignedWarning: platform === "windows",
+    // The UA fallback can't see the Linux session type (X11 vs Wayland),
+    // so it optimistically assumes reliable on the known desktops; the
+    // authoritative Rust answer downgrades Linux Wayland once it resolves.
+    videoPauseReliable:
+      platform === "macos" || platform === "windows" || platform === "linux",
   };
 }
 

--- a/src/views/settings/tabs/about-tab.test.tsx
+++ b/src/views/settings/tabs/about-tab.test.tsx
@@ -33,6 +33,7 @@ let currentCaps: PlatformCapabilities = {
   supportsDndRead: true,
   mediaPauseGranular: false,
   installerUnsignedWarning: false,
+  videoPauseReliable: true,
 };
 vi.mock("../../../lib/platform", async () => {
   const actual = await vi.importActual<typeof import("../../../lib/platform")>(
@@ -88,6 +89,7 @@ afterEach(() => {
     supportsDndRead: true,
     mediaPauseGranular: false,
     installerUnsignedWarning: false,
+    videoPauseReliable: true,
   };
   mockUpdate = {
     info: null,

--- a/src/views/settings/tabs/quiet-tab.test.tsx
+++ b/src/views/settings/tabs/quiet-tab.test.tsx
@@ -1,0 +1,101 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, within } from "@testing-library/react";
+
+import type { Platform, PlatformCapabilities } from "../../../lib/platform";
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn().mockResolvedValue(undefined),
+}));
+
+let currentPlatform: Platform = "linux";
+let currentCaps: PlatformCapabilities = {
+  supportsDndRead: true,
+  mediaPauseGranular: true,
+  installerUnsignedWarning: false,
+  videoPauseReliable: true,
+};
+vi.mock("../../../lib/platform", async () => {
+  const actual = await vi.importActual<typeof import("../../../lib/platform")>(
+    "../../../lib/platform",
+  );
+  return {
+    ...actual,
+    usePlatform: () => currentPlatform,
+    usePlatformCapabilities: () => currentCaps,
+  };
+});
+
+const { QuietTab } = await import("./quiet-tab");
+import type { SchedulerSettings } from "../types";
+
+const baseSettings = {
+  pause_during_dnd: false,
+  pause_during_camera: false,
+  pause_during_video: false,
+  pause_media_during_breaks: false,
+  app_pause_enabled: false,
+  app_pause_list: [],
+} as unknown as SchedulerSettings;
+
+function renderTab(over: Partial<SchedulerSettings> = {}) {
+  return render(
+    <QuietTab
+      settings={{ ...baseSettings, ...over } as SchedulerSettings}
+      update={vi.fn() as unknown as Parameters<typeof QuietTab>[0]["update"]}
+      pauseInfo={{ paused: false, remaining_secs: null }}
+    />,
+  );
+}
+
+function videoRow() {
+  return screen.getByText("Fullscreen video is playing").closest("label")!;
+}
+
+afterEach(() => {
+  cleanup();
+  currentPlatform = "linux";
+  currentCaps = {
+    supportsDndRead: true,
+    mediaPauseGranular: true,
+    installerUnsignedWarning: false,
+    videoPauseReliable: true,
+  };
+  vi.clearAllMocks();
+});
+
+describe("QuietTab — fullscreen video reliability warning", () => {
+  it("shows a warning tip on the video row when detection is unreliable", () => {
+    currentCaps = { ...currentCaps, videoPauseReliable: false };
+    renderTab();
+    const row = within(videoRow());
+    const tip = row.getByRole("button", { name: /warning/i });
+    expect(tip.className).toContain("info-tip-warn");
+    expect(row.getByRole("tooltip").textContent).toMatch(/unreliable/i);
+  });
+
+  it("shows a plain info tip on the video row when detection is reliable", () => {
+    currentCaps = { ...currentCaps, videoPauseReliable: true };
+    renderTab();
+    const row = within(videoRow());
+    expect(row.queryByRole("button", { name: /warning/i })).toBeNull();
+    const tip = row.getByRole("button", { name: /more information/i });
+    expect(tip.className).not.toContain("info-tip-warn");
+  });
+
+  it("dispatches the pause_during_video setting when toggled", () => {
+    const update = vi.fn();
+    render(
+      <QuietTab
+        settings={baseSettings}
+        update={update as unknown as Parameters<typeof QuietTab>[0]["update"]}
+        pauseInfo={{ paused: false, remaining_secs: null }}
+      />,
+    );
+    const checkbox = within(videoRow()).getByRole(
+      "checkbox",
+    ) as HTMLInputElement;
+    checkbox.click();
+    expect(update).toHaveBeenCalledWith("pause_during_video", true);
+  });
+});

--- a/src/views/settings/tabs/quiet-tab.tsx
+++ b/src/views/settings/tabs/quiet-tab.tsx
@@ -59,7 +59,12 @@ export function QuietTab({
           label="Fullscreen video is playing"
           value={settings.pause_during_video}
           onChange={(v) => update("pause_during_video", v)}
-          tip="Suppresses breaks while a fullscreen video is detected."
+          tipWarn={!caps.videoPauseReliable}
+          tip={
+            caps.videoPauseReliable
+              ? "Suppresses breaks while a fullscreen video is detected. Confirms a real fullscreen window, so a small background video won't hold your breaks."
+              : "Suppresses breaks while a fullscreen video is detected. On Wayland there is no way to confirm a fullscreen window, so detection is unreliable: it falls back to any media keeping the display awake, which may suppress breaks for a small background video."
+          }
         />
       </section>
 


### PR DESCRIPTION
## Summary

Makes the **Quiet times → Auto-pause → "Fullscreen video is playing"** toggle carry an OS-reliability warning, completing issue #103. The setting field (`pause_during_video`) and its toggle already existed; this PR adds the missing warning.

The issue text said video pausing is "hit and miss on win/macos", but the authoritative truth is in `src-tauri/src/video.rs`: macOS (`CGWindowListCopyWindowInfo`), Windows (`EnumWindows`) and X11 Linux (`xprop _NET_WM_STATE_FULLSCREEN`) all confirm a *real fullscreen window* before pausing. The one documented degraded case is **Linux Wayland**, where there is no portable way to enumerate windows, so detection falls back to assertion-only (`pause_decision(assertion, Unknowable) → true`) — i.e. any media keeping the display awake suppresses breaks, even a small background video. The warning therefore shows on Linux Wayland and nowhere else.

### Changes
- **`src-tauri/src/platform.rs`**: new `video_pause_reliable` capability. Added a `wayland: bool` parameter to the pure `capabilities_for(os, wayland)` so the branch stays unit-testable on any host; a runtime `is_wayland_session()` (mirroring `video.rs` / `overlay.rs`, delegating to a pure `wayland_session_from_env`) feeds the real session type at the `#[tauri::command]` layer. Reliable on macOS/Windows/X11 Linux, false on Linux Wayland.
- **`src/lib/platform.ts`**: added `videoPauseReliable` to the `PlatformCapabilities` type and the UA fallback (optimistic on the three known desktops, since UA can't see the Linux session type; the authoritative Rust answer downgrades Wayland once it resolves).
- **`src/views/settings/tabs/quiet-tab.tsx`**: `tipWarn={!caps.videoPauseReliable}` plus a conditional `tip`, matching the existing media-pause row pattern.
- Docs: `CHANGELOG.md` (Unreleased → Added) and `docs/guide/settings.md` (Quiet times).
- Tests: new Rust cases (X11 vs Wayland Linux, off-Linux Wayland no-op, env parsing) and a new `quiet-tab.test.tsx` asserting the warning shows/hides per capability; extended `platform.test.ts` and `about-tab.test.tsx` for the new field.

## Test Plan
- `cargo fmt` clean, `cargo clippy --all-targets` clean, `cargo test --lib` → 766 passed.
- `npm run typecheck` clean, `npm run lint` clean (one pre-existing unrelated warning in `use-local-draft.ts`), `npm run format:check` clean.
- `npx vitest run` → 543 passed (54 files).
- cspell clean on changed files (verified with an override config, since the worktree lives under `.claude/**` which the repo's cspell `ignorePaths` excludes — not an issue in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)