### PR TITLE
chore(release): prep v0.0.5 — version bump + CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Versions on the `0.0.X` line are public beta releases; `0.1.X` and onwards will 
 
 ## [Unreleased]
 
+## [0.0.5] — 2026-06-04
+
+Cross-platform fixes from beta feedback: camera detection keeps pausing breaks on macOS 26, break sounds finally play on Linux, picking which break ideas you see is now free, and the fullscreen-video auto-pause flags where it's unreliable.
+
 ### Added
 
 - **"Fullscreen video is playing" now warns where detection is unreliable.** The Quiet times → Auto-pause toggle that suppresses breaks during fullscreen video carries a caution marker on Linux Wayland, where there is no portable way to confirm a fullscreen window: detection there falls back to "any media is keeping the display awake", so it can suppress breaks for a small background video. macOS, Windows and X11 Linux confirm a real fullscreen window and show a plain info tip. ([#103](https://github.com/drmowinckels/entracte/issues/103))

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "entracte-desktop",
   "private": true,
-  "version": "0.0.4",
+  "version": "0.0.5",
   "type": "module",
   "engines": {
     "node": ">=20"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1235,7 +1235,7 @@ checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
 
 [[package]]
 name = "entracte"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "entracte"
-version = "0.0.4"
+version = "0.0.5"
 description = "Cross-platform break reminder"
 authors = ["Athanasia Mowinckel"]
 license = "Apache-2.0"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Entracte",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "identifier": "io.drmowinckels.entracte",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary

Release prep for **v0.0.5**. Bumps the version in `package.json`, `src-tauri/Cargo.toml`, `src-tauri/tauri.conf.json`, and `src-tauri/Cargo.lock` to `0.0.5`, and finalizes the CHANGELOG (`[Unreleased]` → `[0.0.5] — 2026-06-04`).

### What's in 0.0.5
- **#113** — camera-in-use detection works again on macOS 26 (Apple Silicon) via Control Center's aggregate signal
- **#114** — break sounds play on Linux: native in-process audio (rodio/Symphonia), no longer dependent on WebKitGTK codecs
- **#118** — choosing which break ideas appear (Solo/Social/Both mix) is now free; editing pools stays Supporter
- **#103** — the fullscreen-video auto-pause toggle warns where detection is unreliable (Linux Wayland)
- **#99** — internal `BreakKindSettings` scheduler refactor (no user-facing change; wire shape unchanged)

## Test plan

- Version strings consistent across all four manifests.
- CHANGELOG renders with a dated 0.0.5 section and a fresh empty `[Unreleased]`.
- Tagging `v0.0.5` after merge triggers the release build (installers + signed updater manifest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)