### PR TITLE
feat(about): cross-link to Cairn companion app

### DIFF
--- a/src/views/settings/tabs/about-tab.test.tsx
+++ b/src/views/settings/tabs/about-tab.test.tsx
@@ -211,4 +211,11 @@ describe("AboutTab — diagnostics & author links", () => {
       "https://buymeacoffee.com/drmowinckels",
     );
   });
+
+  it("opens the Cairn companion-app link", async () => {
+    const user = userEvent.setup();
+    render(<AboutTab supporter={supporterStub()} />);
+    await user.click(screen.getByRole("button", { name: /try cairn/i }));
+    expect(openUrlMock).toHaveBeenCalledWith("https://cairn.drmowinckels.io/");
+  });
 });

--- a/src/views/settings/tabs/about-tab.tsx
+++ b/src/views/settings/tabs/about-tab.tsx
@@ -180,6 +180,20 @@ export function AboutTab({ supporter }: { supporter: UseSupporter }) {
         </p>
       </section>
 
+      <h2>Companion app</h2>
+      <section>
+        <p className="about-meta">
+          Tracking your work hours too? <strong>Cairn</strong> is Entracte's
+          sibling — local-first time tracking that quietly notices what you work
+          on.
+        </p>
+        <div className="actions inline">
+          <button onClick={() => openUrl("https://cairn.drmowinckels.io/")}>
+            Try Cairn →
+          </button>
+        </div>
+      </section>
+
       <div className="section-heading">
         <h2>Diagnostics</h2>
         <button onClick={onCopyDiagnosticsReport}>


### PR DESCRIPTION
## Summary

Adds a **Companion app** section to the About tab that points users at [Cairn](https://cairn.drmowinckels.io/), Entracte's sibling local-first time tracker. A **Try Cairn →** button opens the Cairn site. This is one half of a reciprocal cross-link — the matching PR in Cairn points back to Entracte as a break reminder.

## Test Plan

- Added `about-tab.test.tsx` case asserting the **Try Cairn** button calls `openUrl` with `https://cairn.drmowinckels.io/`.
- `vitest run` on the about-tab suite: 12 passed.
- `prettier --write` + `eslint`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)