### PR TITLE
refactor(tray): simplify is_body bounds check

### DIFF
--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -427,10 +427,11 @@ fn outline_glyph(
     let w = width as i32;
     let h = height as i32;
     let is_body = |x: i32, y: i32| -> bool {
-        if x < 0 || y < 0 || x >= w || y >= h {
-            return false;
-        }
-        rgba[((y * w + x) as usize) * 4 + 3] >= TRAY_ALPHA_THRESHOLD
+        x >= 0
+            && y >= 0
+            && x < w
+            && y < h
+            && rgba[((y * w + x) as usize) * 4 + 3] >= TRAY_ALPHA_THRESHOLD
     };
     let r2 = radius * radius;
     let mut out = vec![0u8; rgba.len()];


### PR DESCRIPTION
## Summary

Cleanup from a `/simplify` review of the #128 tray recolouring. Folds the explicit `if … { return false }` bounds guard in `outline_glyph`'s `is_body` closure into a single short-circuiting boolean expression. No behaviour change.

> Scope note: this PR originally also added a `OnceLock` cache for the recoloured icons. That was dropped — it saved well under a millisecond on infrequent icon-state transitions while adding a cache + two call-site changes in untestable Tauri-runtime glue (`setup`/ticker) that couldn't meet the 100% codecov/patch gate. Not worth the complexity; can revisit if profiling ever justifies it.

## Test Plan

- Existing `outline_glyph_*` tests cover the closure (body fill, alpha preservation, real-glyph output) and still pass.
- `cargo fmt` + `cargo clippy --all-targets` clean; `cargo test --lib tray::` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)