### PR TITLE
fix(ipc): clamp settings written via the CLI/IPC path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Versions on the `0.0.X` line are public beta releases; `0.1.X` and onwards will 
 
 ## [Unreleased]
 
+### Changed
+
+- **`entracte settings set …` now clamps out-of-range values like the Settings window.** Writing a setting through the CLI (or the underlying IPC channel) previously skipped the range-clamping and `custom_css`/fixed-time sanitisation the GUI applies, so e.g. `entracte settings set micro_interval_secs 0` persisted a 0-second interval that fired a break every tick. The CLI/IPC path now runs the same normalisation — flooring intervals at 30s, capping durations, and scrubbing custom CSS.
+
 ### Fixed
 
 - **Tray icon is now visible on dark Linux/Windows panels.** The menu-bar glyph is a black template image that only macOS recolours for its menu bar; on Linux and Windows the raw black pixels were drawn as-is and disappeared against a dark panel — notably the GNOME top bar, which is black whatever the GTK theme. Off macOS the glyph is now recoloured at runtime to a near-white body with a near-black outline, so it reads on both dark and light panels. ([#86](https://github.com/drmowinckels/entracte/issues/86))

--- a/src-tauri/src/ipc.rs
+++ b/src-tauri/src/ipc.rs
@@ -295,12 +295,16 @@ async fn dispatch(app: &AppHandle, req: IpcRequest) -> IpcResponse {
 /// Merge a single `key`/`value` override into `current` and return the
 /// resulting `Settings`, ready to store.
 ///
-/// Pure (no locks, no runtime), so the JSON round-trip + cache rebuild is
+/// Pure (no locks, no runtime), so the JSON round-trip + clamp is
 /// unit-testable without driving the production `AppHandle<Wry>` IPC path.
 /// Serialises `current` to JSON, validates the key exists, swaps in
-/// `value`, deserialises back, and rebuilds the `#[serde(skip)]` `derived`
-/// cache (which arrives empty from a wholesale deserialise). Errors are the
-/// user-facing strings the IPC handler returns verbatim.
+/// `value`, deserialises back, and runs `clamp()` — the same normalisation
+/// the GUI `update_settings` command applies. Without it the IPC/CLI path
+/// could persist out-of-range values the GUI forbids (e.g. a 0s interval
+/// that makes a break fire every tick) and skip `custom_css`/fixed-time
+/// sanitisation. `clamp()` rebuilds the `#[serde(skip)]` `derived` cache as
+/// its final step, so the wholesale-deserialise's empty cache is repopulated.
+/// Errors are the user-facing strings the IPC handler returns verbatim.
 fn apply_settings_key(
     current: &Settings,
     key: &str,
@@ -313,7 +317,7 @@ fn apply_settings_key(
     v[key] = value;
     let mut next: Settings =
         serde_json::from_value(v).map_err(|e| format!("type mismatch: {e}"))?;
-    next.rebuild_derived();
+    next.clamp();
     Ok(next)
 }
 
@@ -644,6 +648,19 @@ mod tests {
         assert_eq!(next.micro_fixed_times, vec!["09:30", "14:00"]);
         // "09:30" → 570, "14:00" → 840.
         assert_eq!(next.derived.micro_fixed_minutes, vec![570, 840]);
+    }
+
+    #[test]
+    fn apply_settings_key_clamps_out_of_range_value() {
+        // A 0s interval would make the run loop fire a break every tick;
+        // the IPC path must clamp it to the same 30s floor the GUI enforces.
+        let next = apply_settings_key(
+            &Settings::default(),
+            "micro_interval_secs",
+            serde_json::json!(0),
+        )
+        .expect("valid key + value");
+        assert_eq!(next.micro_interval_secs, 30);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

From the whole-codebase critical review (finding #3, Required).

`apply_settings_key` — the handler behind `entracte settings set <key> <value>` and the IPC `SettingsSet` request — only called `rebuild_derived()` after merging the new value, **skipping the `clamp()`** that the GUI `update_settings` command runs on every write.

Consequences of the bypass:
- `entracte settings set micro_interval_secs 0` persisted a 0s interval, making `interval_break_due` perpetually true → the run loop fires a break **every tick** (a local self-DoS).
- `custom_css` sanitisation and fixed-time normalisation were skipped on this path.

Fix: route through `next.clamp()`, which floors/caps every numeric field and runs `rebuild_derived()` as its final step — so the IPC/CLI path now matches the GUI path exactly.

## Test Plan

- New `apply_settings_key_clamps_out_of_range_value` asserts a `0` interval is clamped to the 30s floor.
- Existing `apply_settings_key_*` tests (sets value + rebuilds derived, rejects unknown key, rejects type mismatch) still pass.
- `cargo fmt` + `cargo clippy --all-targets` clean; `cargo test --lib ipc::` green (25 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)