### PR TITLE
fix(probes): bound external detection commands with a timeout

### DIFF
--- a/.github/audit/cspell/project-words.txt
+++ b/.github/audit/cspell/project-words.txt
@@ -66,6 +66,7 @@ pmset
 geninfo
 gdbus
 systemd
+xprop
 XDG
 DBus
 Wayland

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Versions on the `0.0.X` line are public beta releases; `0.1.X` and onwards will 
 
 ## [Unreleased]
 
+### Changed
+
+- **`entracte settings set …` now clamps out-of-range values like the Settings window.** Writing a setting through the CLI (or the underlying IPC channel) previously skipped the range-clamping and `custom_css`/fixed-time sanitisation the GUI applies, so e.g. `entracte settings set micro_interval_secs 0` persisted a 0-second interval that fired a break every tick. The CLI/IPC path now runs the same normalisation — flooring intervals at 30s, capping durations, and scrubbing custom CSS.
+
 ### Fixed
 
 - **Tray icon is now visible on dark Linux/Windows panels.** The menu-bar glyph is a black template image that only macOS recolours for its menu bar; on Linux and Windows the raw black pixels were drawn as-is and disappeared against a dark panel — notably the GNOME top bar, which is black whatever the GTK theme. Off macOS the glyph is now recoloured at runtime to a near-white body with a near-black outline, so it reads on both dark and light panels. ([#86](https://github.com/drmowinckels/entracte/issues/86))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Versions on the `0.0.X` line are public beta releases; `0.1.X` and onwards will 
 
 ### Fixed
 
+- **A wedged system tool can no longer stall break detection.** The Do-Not-Disturb, camera, and fullscreen-video probes shell out to OS tools (`pmset`, `powercfg`, `xprop`, `gsettings`, `gdbus`, `systemd-inhibit`); if one hung — an unresponsive X server, a stuck session bus — it blocked the detection loop indefinitely and froze the guard signal at its last value. Each probe now runs under a 2-second timeout and is killed if it overruns, degrading to "signal absent" instead of wedging.
 - **Tray icon is now visible on dark Linux/Windows panels.** The menu-bar glyph is a black template image that only macOS recolours for its menu bar; on Linux and Windows the raw black pixels were drawn as-is and disappeared against a dark panel — notably the GNOME top bar, which is black whatever the GTK theme. Off macOS the glyph is now recoloured at runtime to a near-white body with a near-black outline, so it reads on both dark and light panels. ([#86](https://github.com/drmowinckels/entracte/issues/86))
 
 ## [0.0.5] — 2026-06-04

--- a/src-tauri/src/dnd.rs
+++ b/src-tauri/src/dnd.rs
@@ -180,6 +180,7 @@ mod linux {
     use std::process::Command;
 
     use super::{parse_gnome_show_banners_dnd, parse_kde_inhibited};
+    use crate::proc::{CommandTimeoutExt, PROBE_TIMEOUT};
 
     // Absolute paths so a planted `gsettings` / `gdbus` earlier in `$PATH`
     // can't intercept the probe. These are the canonical locations on the
@@ -199,7 +200,7 @@ mod linux {
     fn gnome_dnd_active() -> bool {
         let Ok(output) = Command::new(GSETTINGS_BIN)
             .args(["get", "org.gnome.desktop.notifications", "show-banners"])
-            .output()
+            .output_timeout(PROBE_TIMEOUT)
         else {
             return false;
         };
@@ -226,7 +227,7 @@ mod linux {
                 "org.freedesktop.Notifications",
                 "Inhibited",
             ])
-            .output()
+            .output_timeout(PROBE_TIMEOUT)
         else {
             return false;
         };

--- a/src-tauri/src/ipc.rs
+++ b/src-tauri/src/ipc.rs
@@ -295,12 +295,16 @@ async fn dispatch(app: &AppHandle, req: IpcRequest) -> IpcResponse {
 /// Merge a single `key`/`value` override into `current` and return the
 /// resulting `Settings`, ready to store.
 ///
-/// Pure (no locks, no runtime), so the JSON round-trip + cache rebuild is
+/// Pure (no locks, no runtime), so the JSON round-trip + clamp is
 /// unit-testable without driving the production `AppHandle<Wry>` IPC path.
 /// Serialises `current` to JSON, validates the key exists, swaps in
-/// `value`, deserialises back, and rebuilds the `#[serde(skip)]` `derived`
-/// cache (which arrives empty from a wholesale deserialise). Errors are the
-/// user-facing strings the IPC handler returns verbatim.
+/// `value`, deserialises back, and runs `clamp()` — the same normalisation
+/// the GUI `update_settings` command applies. Without it the IPC/CLI path
+/// could persist out-of-range values the GUI forbids (e.g. a 0s interval
+/// that makes a break fire every tick) and skip `custom_css`/fixed-time
+/// sanitisation. `clamp()` rebuilds the `#[serde(skip)]` `derived` cache as
+/// its final step, so the wholesale-deserialise's empty cache is repopulated.
+/// Errors are the user-facing strings the IPC handler returns verbatim.
 fn apply_settings_key(
     current: &Settings,
     key: &str,
@@ -313,7 +317,7 @@ fn apply_settings_key(
     v[key] = value;
     let mut next: Settings =
         serde_json::from_value(v).map_err(|e| format!("type mismatch: {e}"))?;
-    next.rebuild_derived();
+    next.clamp();
     Ok(next)
 }
 
@@ -644,6 +648,19 @@ mod tests {
         assert_eq!(next.micro_fixed_times, vec!["09:30", "14:00"]);
         // "09:30" → 570, "14:00" → 840.
         assert_eq!(next.derived.micro_fixed_minutes, vec![570, 840]);
+    }
+
+    #[test]
+    fn apply_settings_key_clamps_out_of_range_value() {
+        // A 0s interval would make the run loop fire a break every tick;
+        // the IPC path must clamp it to the same 30s floor the GUI enforces.
+        let next = apply_settings_key(
+            &Settings::default(),
+            "micro_interval_secs",
+            serde_json::json!(0),
+        )
+        .expect("valid key + value");
+        assert_eq!(next.micro_interval_secs, 30);
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -10,6 +10,7 @@ mod license_redact;
 mod media;
 mod pause_store;
 mod platform;
+mod proc;
 mod renderer_log;
 mod scheduler;
 mod screen_time_store;

--- a/src-tauri/src/media.rs
+++ b/src-tauri/src/media.rs
@@ -287,6 +287,8 @@ fn platform_resume(_token: &ResumeToken) {}
 mod linux {
     use std::process::Command;
 
+    use crate::proc::{CommandTimeoutExt, PROBE_TIMEOUT};
+
     // Absolute path so a planted `gdbus` earlier in `$PATH` can't
     // intercept the session-bus calls. `/usr/bin/gdbus` ships in
     // glib2/libglib2.0-bin on every distro we target.
@@ -317,7 +319,7 @@ mod linux {
         for arg in args {
             cmd.arg(arg);
         }
-        let out = cmd.output().ok()?;
+        let out = cmd.output_timeout(PROBE_TIMEOUT).ok()?;
         if !out.status.success() {
             return None;
         }

--- a/src-tauri/src/proc.rs
+++ b/src-tauri/src/proc.rs
@@ -1,0 +1,156 @@
+//! Run external commands with a hard timeout.
+//!
+//! `std::process::Command::output()` blocks until the child exits with no
+//! upper bound. The OS-integration probes (`pmset`, `powercfg`, `xprop`,
+//! `gsettings`, `gdbus`, `systemd-inhibit`) run inside ~10s detection poll
+//! loops and on the break-overlay open path, so a wedged tool — an
+//! unresponsive X server, a dead session bus — would stall the calling
+//! thread forever and freeze the guard flag (DND / camera / video) at its
+//! last value. [`CommandTimeoutExt::output_timeout`] bounds the wait and
+//! kills the child if it overruns, degrading to a probe error the callers
+//! already treat as "signal absent".
+
+use std::io::{self, Read};
+use std::process::{Command, Output, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
+
+/// Upper bound for a single detection probe. The tools normally answer in
+/// well under 100 ms; 2 s is comfortably above any healthy run while still
+/// far below the poll cadence it guards, so a hung probe costs one slow
+/// tick rather than a permanently stuck signal.
+pub const PROBE_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// How often to check whether the child has exited while waiting. 10 ms is
+/// fine-grained next to a 2 s timeout and a 10 s poll loop, and keeps the
+/// wait off a busy spin.
+const POLL_INTERVAL: Duration = Duration::from_millis(10);
+
+/// Drop-in replacement for [`Command::output`] that bounds the wait.
+pub trait CommandTimeoutExt {
+    /// Run the command to completion, capturing its output, but kill it and
+    /// return a `TimedOut` error if it runs longer than `timeout`.
+    fn output_timeout(&mut self, timeout: Duration) -> io::Result<Output>;
+}
+
+impl CommandTimeoutExt for Command {
+    fn output_timeout(&mut self, timeout: Duration) -> io::Result<Output> {
+        self.stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        let mut child = self.spawn()?;
+
+        let mut child_stdout = child.stdout.take().expect("stdout piped above");
+        let mut child_stderr = child.stderr.take().expect("stderr piped above");
+        let stdout_reader = thread::spawn(move || {
+            let mut buf = Vec::new();
+            let _ = child_stdout.read_to_end(&mut buf);
+            buf
+        });
+        let stderr_reader = thread::spawn(move || {
+            let mut buf = Vec::new();
+            let _ = child_stderr.read_to_end(&mut buf);
+            buf
+        });
+
+        let deadline = Instant::now() + timeout;
+        let status = loop {
+            if let Some(status) = child.try_wait()? {
+                break status;
+            }
+            if Instant::now() >= deadline {
+                let _ = child.kill();
+                let _ = child.wait();
+                // Deliberately don't join the reader threads here: a killed
+                // process whose child inherited the stdout/stderr pipe (e.g.
+                // a shell that spawned the real tool) can keep them blocked
+                // on `read_to_end`, and the caller must not wait on that.
+                // The threads EOF and exit on their own once the pipe finally
+                // closes; dropping the handles detaches them.
+                return Err(io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    "command exceeded timeout",
+                ));
+            }
+            thread::sleep(POLL_INTERVAL);
+        };
+
+        let stdout = stdout_reader.join().unwrap_or_default();
+        let stderr = stderr_reader.join().unwrap_or_default();
+        Ok(Output {
+            status,
+            stdout,
+            stderr,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn echo_hello() -> Command {
+        #[cfg(unix)]
+        {
+            let mut cmd = Command::new("/bin/echo");
+            cmd.arg("hello");
+            cmd
+        }
+        #[cfg(windows)]
+        {
+            let mut cmd = Command::new("cmd");
+            cmd.args(["/C", "echo hello"]);
+            cmd
+        }
+    }
+
+    fn sleep_five_seconds() -> Command {
+        #[cfg(unix)]
+        {
+            let mut cmd = Command::new("/bin/sleep");
+            cmd.arg("5");
+            cmd
+        }
+        #[cfg(windows)]
+        {
+            // ping spaces its probes ~1s apart, so -n 6 sleeps ~5s without
+            // needing a console the way `timeout` does.
+            let mut cmd = Command::new("cmd");
+            cmd.args(["/C", "ping", "-n", "6", "127.0.0.1"]);
+            cmd
+        }
+    }
+
+    #[test]
+    fn returns_captured_output_for_a_fast_command() {
+        let out = echo_hello().output_timeout(Duration::from_secs(5)).unwrap();
+        assert!(out.status.success());
+        assert!(
+            String::from_utf8_lossy(&out.stdout).contains("hello"),
+            "stdout was {:?}",
+            out.stdout
+        );
+    }
+
+    #[test]
+    fn kills_and_errors_when_the_command_overruns() {
+        let started = Instant::now();
+        let err = sleep_five_seconds()
+            .output_timeout(Duration::from_millis(150))
+            .unwrap_err();
+        let elapsed = started.elapsed();
+        assert_eq!(err.kind(), io::ErrorKind::TimedOut);
+        assert!(
+            elapsed < Duration::from_secs(3),
+            "should return shortly after the timeout, took {elapsed:?}"
+        );
+    }
+
+    #[test]
+    fn propagates_a_spawn_failure() {
+        let err = Command::new("/nonexistent/entracte-probe-binary")
+            .output_timeout(Duration::from_secs(1))
+            .unwrap_err();
+        assert_ne!(err.kind(), io::ErrorKind::TimedOut);
+    }
+}

--- a/src-tauri/src/proc.rs
+++ b/src-tauri/src/proc.rs
@@ -65,8 +65,12 @@ impl CommandTimeoutExt for Command {
                 // process whose child inherited the stdout/stderr pipe (e.g.
                 // a shell that spawned the real tool) can keep them blocked
                 // on `read_to_end`, and the caller must not wait on that.
-                // The threads EOF and exit on their own once the pipe finally
-                // closes; dropping the handles detaches them.
+                // Dropping the handles detaches them; a reader then outlives
+                // this call until its pipe write-end finally closes — for a
+                // wedged pipe-holding grandchild, only when that process dies
+                // or the app exits. An accepted, bounded cost on the probe
+                // path (the probed tools don't fork such children), not a
+                // guarantee of prompt cleanup.
                 return Err(io::Error::new(
                     io::ErrorKind::TimedOut,
                     "command exceeded timeout",

--- a/src-tauri/src/video.rs
+++ b/src-tauri/src/video.rs
@@ -235,6 +235,8 @@ mod macos {
     use std::sync::Arc;
     use std::thread;
 
+    use crate::proc::CommandTimeoutExt;
+
     use core_foundation::array::{CFArray, CFArrayRef};
     use core_foundation::base::{TCFType, ToVoid};
     use core_foundation::dictionary::CFDictionary;
@@ -274,7 +276,10 @@ mod macos {
     }
 
     pub(super) fn display_assertion_active() -> bool {
-        let Ok(output) = Command::new(PMSET_BIN).args(["-g", "assertions"]).output() else {
+        let Ok(output) = Command::new(PMSET_BIN)
+            .args(["-g", "assertions"])
+            .output_timeout(crate::proc::PROBE_TIMEOUT)
+        else {
             return false;
         };
         if !output.status.success() {
@@ -375,6 +380,8 @@ mod macos {
 mod windows {
     use std::process::Command;
     use std::sync::atomic::{AtomicBool, Ordering};
+
+    use crate::proc::CommandTimeoutExt;
     use std::sync::Arc;
     use std::thread;
 
@@ -412,7 +419,10 @@ mod windows {
     }
 
     pub(super) fn display_request_active() -> bool {
-        let Ok(output) = Command::new(POWERCFG_BIN).arg("/requests").output() else {
+        let Ok(output) = Command::new(POWERCFG_BIN)
+            .arg("/requests")
+            .output_timeout(crate::proc::PROBE_TIMEOUT)
+        else {
             return false;
         };
         if !output.status.success() {
@@ -504,6 +514,8 @@ mod windows {
 mod linux {
     use std::env;
     use std::process::Command;
+
+    use crate::proc::CommandTimeoutExt;
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::Arc;
     use std::sync::OnceLock;
@@ -549,7 +561,7 @@ mod linux {
     fn inhibitor_active() -> bool {
         let Ok(output) = Command::new(SYSTEMD_INHIBIT_BIN)
             .args(["--list", "--no-pager", "--no-legend"])
-            .output()
+            .output_timeout(crate::proc::PROBE_TIMEOUT)
         else {
             return false;
         };
@@ -594,7 +606,7 @@ mod linux {
     fn xprop_active_window_id() -> Option<String> {
         let out = Command::new(XPROP_BIN)
             .args(["-root", "_NET_ACTIVE_WINDOW"])
-            .output()
+            .output_timeout(crate::proc::PROBE_TIMEOUT)
             .ok()?;
         if !out.status.success() {
             return None;
@@ -606,7 +618,7 @@ mod linux {
     fn xprop_window_state(id: &str) -> Option<String> {
         let out = Command::new(XPROP_BIN)
             .args(["-id", id, "_NET_WM_STATE"])
-            .output()
+            .output_timeout(crate::proc::PROBE_TIMEOUT)
             .ok()?;
         if !out.status.success() {
             return None;


### PR DESCRIPTION
## Summary

From the whole-codebase critical review (finding #1, Required). **Stacked on #130** (`fix/ipc-settings-clamp`) — review that first.

`std::process::Command::output()` blocks until the child exits with **no upper bound**. The OS-integration probes run inside ~10s detection poll loops (and, for the MPRIS `gdbus` call, on the break-overlay open path), so a wedged tool — an unresponsive X server, a dead session bus — would stall the calling thread forever and freeze the guard flag (DND / camera / video) at its last value.

### Change

- New `src-tauri/src/proc.rs` → `CommandTimeoutExt::output_timeout(timeout)`, a drop-in for `Command::output()`:
  - drains `stdout`/`stderr` on dedicated reader threads so a child that writes more than a pipe buffer holds can't deadlock the wait;
  - polls `try_wait()` to a deadline, then **kills + reaps** the child and returns `ErrorKind::TimedOut` if it overruns;
  - `PROBE_TIMEOUT = 2s` — far above a healthy probe (<100ms), far below the poll cadence it guards.
- The **seven** blocking probes change only their terminal call from `.output()` to `.output_timeout(PROBE_TIMEOUT)`: `gsettings` + `gdbus` (dnd), `pmset` + `powercfg` + `systemd-inhibit` + `xprop` ×2 (video), MPRIS `gdbus` (media). A timeout degrades to the same "signal absent" the callers already handle.

`camera.rs`'s `log stream` reader is a long-lived stream, not a bounded `.output()` probe — out of scope (separate review item).

## Test Plan

- New `proc::tests` (run on every OS via cfg-gated commands, so all three merge in codecov):
  - `returns_captured_output_for_a_fast_command`, `kills_and_errors_when_the_command_overruns` (5s sleep / 150ms timeout returns `TimedOut` in <3s), `propagates_a_spawn_failure`.
- `cargo fmt` + `cargo clippy --all-targets` clean; `cargo test --lib` green (789 passed).

## Coverage note

`codecov/patch` will not reach 100% here. The only uncovered changed lines are the `.output_timeout(...)` invocations themselves, inside probe functions that shell out to real OS daemons (`pmset`/`xprop`/`gdbus`/…). No CI test can execute those, and the line *is* the shell-out — there's no extractable logic left to cover (the parsers are already separately tested). This is the repo's documented **OS-FFI-shim carve-out**; the new timeout logic in `proc.rs` is itself fully covered. Needs an admin-merge accepting these shim lines (same class as the #128 tray call-site precedent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)