### PR TITLE
fix(overlay): validate IPC payloads with zod instead of blind casts

### DIFF
--- a/src/views/break-overlay/hooks/use-break-state.test.ts
+++ b/src/views/break-overlay/hooks/use-break-state.test.ts
@@ -158,4 +158,76 @@ describe("useBreakState", () => {
       expect(unlistens.get("break:end")).toHaveBeenCalled();
     });
   });
+
+  it("ignores a malformed break:start payload", async () => {
+    const invoke = vi.fn(async (cmd: string) => {
+      if (cmd === "get_current_break") return null;
+      if (cmd === "get_settings") return DEFAULT_OVERLAY_SETTINGS;
+      return null;
+    });
+    const { listen, emit } = makeListener();
+    const { result } = renderHook(() =>
+      useBreakState({
+        invoke:
+          invoke as unknown as typeof import("@tauri-apps/api/core").invoke,
+        listen:
+          listen as unknown as typeof import("@tauri-apps/api/event").listen,
+      }),
+    );
+    await waitFor(() => expect(listen).toHaveBeenCalledTimes(2));
+    await act(async () => {
+      // duration_secs as a string, missing fields — must not drive the UI.
+      emit("break:start", { kind: "micro", duration_secs: "soon" });
+    });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(result.current.active).toBeNull();
+    expect(result.current.remaining).toBe(0);
+  });
+
+  it("keeps default appearance when get_settings is malformed", async () => {
+    const invoke = vi.fn(async (cmd: string) => {
+      if (cmd === "get_current_break") return null;
+      // Missing the overlay fields entirely — validation fails, fall back.
+      if (cmd === "get_settings") return { unexpected: true };
+      if (cmd === "get_postpone_state")
+        return { count: 0, max: 3, remaining: 3 };
+      return null;
+    });
+    const { listen, emit } = makeListener();
+    const { result } = renderHook(() =>
+      useBreakState({
+        invoke:
+          invoke as unknown as typeof import("@tauri-apps/api/core").invoke,
+        listen:
+          listen as unknown as typeof import("@tauri-apps/api/event").listen,
+      }),
+    );
+    await waitFor(() => expect(listen).toHaveBeenCalledTimes(2));
+    await act(async () => {
+      emit("break:start", sampleBreak);
+    });
+    // A valid break still shows; appearance stays at the safe default.
+    await waitFor(() => expect(result.current.active).not.toBeNull());
+    expect(result.current.appearance).toEqual(DEFAULT_OVERLAY_SETTINGS);
+  });
+
+  it("drops postpone state when the response is malformed", async () => {
+    const invoke = vi.fn(async (cmd: string) => {
+      if (cmd === "get_settings") return DEFAULT_OVERLAY_SETTINGS;
+      if (cmd === "get_current_break") return sampleBreak;
+      if (cmd === "get_postpone_state") return { garbage: "yes" };
+      return null;
+    });
+    const { listen } = makeListener();
+    const { result } = renderHook(() =>
+      useBreakState({
+        invoke:
+          invoke as unknown as typeof import("@tauri-apps/api/core").invoke,
+        listen:
+          listen as unknown as typeof import("@tauri-apps/api/event").listen,
+      }),
+    );
+    await waitFor(() => expect(result.current.active).not.toBeNull());
+    expect(result.current.postponeState).toBeNull();
+  });
 });

--- a/src/views/break-overlay/hooks/use-break-state.test.ts
+++ b/src/views/break-overlay/hooks/use-break-state.test.ts
@@ -211,6 +211,27 @@ describe("useBreakState", () => {
     expect(result.current.appearance).toEqual(DEFAULT_OVERLAY_SETTINGS);
   });
 
+  it("falls back gracefully when the settings/postpone fetches reject", async () => {
+    const invoke = vi.fn(async (cmd: string) => {
+      if (cmd === "get_current_break") return sampleBreak;
+      // get_settings and get_postpone_state both reject (IPC down).
+      throw new Error("ipc unavailable");
+    });
+    const { listen } = makeListener();
+    const { result } = renderHook(() =>
+      useBreakState({
+        invoke:
+          invoke as unknown as typeof import("@tauri-apps/api/core").invoke,
+        listen:
+          listen as unknown as typeof import("@tauri-apps/api/event").listen,
+      }),
+    );
+    await waitFor(() => expect(result.current.active).not.toBeNull());
+    // The break still shows; appearance stays default, postpone is cleared.
+    expect(result.current.appearance).toEqual(DEFAULT_OVERLAY_SETTINGS);
+    expect(result.current.postponeState).toBeNull();
+  });
+
   it("drops postpone state when the response is malformed", async () => {
     const invoke = vi.fn(async (cmd: string) => {
       if (cmd === "get_settings") return DEFAULT_OVERLAY_SETTINGS;

--- a/src/views/break-overlay/hooks/use-break-state.ts
+++ b/src/views/break-overlay/hooks/use-break-state.ts
@@ -9,6 +9,11 @@ import {
   type OverlaySettings,
   type PostponeState,
 } from "../types";
+import {
+  breakEventSchema,
+  overlaySettingsSchema,
+  postponeStateSchema,
+} from "../schemas";
 
 function resolveTheme(setting: string, previous: string): string {
   if (setting === "rotate") return pickRotationTheme(previous);
@@ -61,47 +66,47 @@ export function useBreakState(deps: BreakStateDeps = {}): BreakStateApi {
 
   useEffect(() => {
     let cancelled = false;
-    const applyBreak = async (payload: BreakEvent) => {
+    const applyBreak = async (rawPayload: unknown) => {
+      // The payload arrives untrusted (a backend event or get_current_break
+      // response). Validate before driving the overlay; a malformed one is
+      // dropped rather than rendered.
+      const parsedPayload = breakEventSchema.safeParse(rawPayload);
+      if (!parsedPayload.success || cancelled) return;
+      const payload = parsedPayload.data;
+
       // Flush any chime still in flight from a previous break before the
       // new overlay takes over, so a deferred end-sound can't play here.
       stopAllSoundsFn();
       try {
-        const s = await invokeFn<OverlaySettings>("get_settings");
+        const raw = await invokeFn("get_settings");
         if (cancelled) return;
-        const next: OverlaySettings = {
-          overlay_opacity: s.overlay_opacity,
-          overlay_color: s.overlay_color,
-          overlay_custom_rgb: s.overlay_custom_rgb,
-          overlay_high_contrast: s.overlay_high_contrast,
-          overlay_font_scale: s.overlay_font_scale,
-          show_hint: s.show_hint,
-          show_current_time: s.show_current_time,
-          clock_format: s.clock_format,
-          micro_sound: s.micro_sound,
-          long_sound: s.long_sound,
-          sound_volume: s.sound_volume,
-          pause_countdown_if_typing: s.pause_countdown_if_typing,
-          strict_mode: s.strict_mode,
-          custom_css: s.custom_css,
-        };
-        setAppearance(next);
-        setResolvedTheme((prev) => resolveTheme(next.overlay_color, prev));
+        // get_settings returns the full Settings; the schema validates and
+        // keeps only the overlay-relevant subset.
+        const parsed = overlaySettingsSchema.safeParse(raw);
+        if (parsed.success) {
+          const next: OverlaySettings = parsed.data;
+          setAppearance(next);
+          setResolvedTheme((prev) => resolveTheme(next.overlay_color, prev));
+        }
+        // on parse failure keep the previous (or default) appearance
       } catch {
         // keep previous settings if the IPC fetch fails
       }
       if (cancelled) return;
-      const hints = Array.isArray(payload.hints) ? payload.hints : [];
       const initialIndex =
-        hints.length > 0 ? Math.floor(Math.random() * hints.length) : 0;
+        payload.hints.length > 0
+          ? Math.floor(Math.random() * payload.hints.length)
+          : 0;
       setHintIndex(initialIndex);
       setFinished(false);
-      setActive({ ...payload, hints });
+      setActive(payload);
       setRemaining(payload.duration_secs);
       try {
-        const ps = await invokeFn<PostponeState>("get_postpone_state", {
+        const raw = await invokeFn("get_postpone_state", {
           kind: payload.kind,
         });
-        if (!cancelled) setPostponeState(ps);
+        const parsed = postponeStateSchema.safeParse(raw);
+        if (!cancelled) setPostponeState(parsed.success ? parsed.data : null);
       } catch {
         if (!cancelled) setPostponeState(null);
       }
@@ -114,10 +119,10 @@ export function useBreakState(deps: BreakStateDeps = {}): BreakStateApi {
     let unlistenStartFn: UnlistenFn | undefined;
     let unlistenEndFn: UnlistenFn | undefined;
 
-    listenFn<BreakEvent>("break:start", (e) => {
-      console.info(
-        `[overlay] break:start kind=${e.payload.kind} duration=${e.payload.duration_secs}`,
-      );
+    // Payloads are validated inside applyBreak, so the listener and the
+    // bootstrap fetch both hand it the raw value untyped rather than casting.
+    listenFn("break:start", (e) => {
+      console.info("[overlay] break:start");
       applyBreak(e.payload);
     }).then((fn) => {
       if (cancelled) fn();
@@ -131,9 +136,9 @@ export function useBreakState(deps: BreakStateDeps = {}): BreakStateApi {
       else unlistenEndFn = fn;
     });
 
-    invokeFn<BreakEvent | null>("get_current_break")
+    invokeFn("get_current_break")
       .then((cur) => {
-        if (!cancelled && cur) applyBreak(cur);
+        if (!cancelled) applyBreak(cur);
       })
       .catch(() => {});
 

--- a/src/views/break-overlay/schemas.test.ts
+++ b/src/views/break-overlay/schemas.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import {
+  breakEventSchema,
+  overlaySettingsSchema,
+  postponeStateSchema,
+} from "./schemas";
+import { DEFAULT_OVERLAY_SETTINGS } from "./types";
+
+describe("overlaySettingsSchema", () => {
+  it("accepts the default overlay settings", () => {
+    expect(
+      overlaySettingsSchema.safeParse(DEFAULT_OVERLAY_SETTINGS).success,
+    ).toBe(true);
+  });
+
+  it("strips the non-overlay fields from a full Settings payload", () => {
+    // get_settings returns the whole Settings object; only the overlay
+    // subset should survive validation.
+    const fullSettings = {
+      ...DEFAULT_OVERLAY_SETTINGS,
+      micro_interval_secs: 1200,
+      long_interval_secs: 3000,
+      hooks_enabled: false,
+      work_start_minutes: 540,
+    };
+    const parsed = overlaySettingsSchema.safeParse(fullSettings);
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data).not.toHaveProperty("micro_interval_secs");
+      expect(parsed.data).not.toHaveProperty("hooks_enabled");
+      expect(parsed.data.overlay_opacity).toBe(
+        DEFAULT_OVERLAY_SETTINGS.overlay_opacity,
+      );
+    }
+  });
+
+  it("accepts sound config that includes custom_path", () => {
+    const withCustom = {
+      ...DEFAULT_OVERLAY_SETTINGS,
+      micro_sound: { mode: "ambient", sound_id: "custom", custom_path: "/x" },
+    };
+    expect(overlaySettingsSchema.safeParse(withCustom).success).toBe(true);
+  });
+
+  it("rejects a wrong field type", () => {
+    const bad = { ...DEFAULT_OVERLAY_SETTINGS, overlay_opacity: "lots" };
+    expect(overlaySettingsSchema.safeParse(bad).success).toBe(false);
+  });
+
+  it("rejects an out-of-range clock_format", () => {
+    const bad = { ...DEFAULT_OVERLAY_SETTINGS, clock_format: "36h" };
+    expect(overlaySettingsSchema.safeParse(bad).success).toBe(false);
+  });
+});
+
+describe("breakEventSchema", () => {
+  const valid = {
+    kind: "long",
+    duration_secs: 300,
+    enforceable: true,
+    manual_finish: false,
+    postpone_available: true,
+    hints: ["a", "b"],
+    hint_rotate_seconds: 10,
+    health_intensity: 0.5,
+  };
+
+  it("accepts a valid break event", () => {
+    expect(breakEventSchema.safeParse(valid).success).toBe(true);
+  });
+
+  it("rejects a non-numeric duration", () => {
+    expect(
+      breakEventSchema.safeParse({ ...valid, duration_secs: "soon" }).success,
+    ).toBe(false);
+  });
+
+  it("rejects an unknown kind", () => {
+    expect(
+      breakEventSchema.safeParse({ ...valid, kind: "siesta" }).success,
+    ).toBe(false);
+  });
+});
+
+describe("postponeStateSchema", () => {
+  it("accepts a valid postpone state", () => {
+    expect(
+      postponeStateSchema.safeParse({ count: 1, max: 3, remaining: 2 }).success,
+    ).toBe(true);
+  });
+
+  it("rejects missing fields", () => {
+    expect(postponeStateSchema.safeParse({ count: 1 }).success).toBe(false);
+  });
+});

--- a/src/views/break-overlay/schemas.ts
+++ b/src/views/break-overlay/schemas.ts
@@ -1,0 +1,56 @@
+import { z } from "zod";
+import type { BreakSound } from "../../lib/break-sound";
+import type { BreakEvent, OverlaySettings, PostponeState } from "./types";
+
+// Runtime schemas for the payloads the overlay reads over IPC. The overlay
+// renders untrusted backend data directly (countdown, theme, sounds), so it
+// validates rather than blind-casting; on a parse failure each caller falls
+// back to a safe default (keep previous settings / no break / null postpone)
+// rather than feeding a malformed value into the UI. `satisfies z.ZodType<T>`
+// makes the compiler check each schema against its TS type, and those types
+// are kept in parity with the Rust serde structs (see `ipc-parity.test.ts`).
+
+// Rust `BreakSound.custom_path` is a plain `String` (empty when unused), so
+// the backend always sends it — but the TS type and DEFAULT_OVERLAY_SETTINGS
+// treat it as optional, so accept it absent too.
+const breakSoundSchema = z.object({
+  mode: z.enum(["off", "end_chime", "ambient"]),
+  sound_id: z.string(),
+  custom_path: z.string().optional(),
+}) satisfies z.ZodType<BreakSound>;
+
+// `get_settings` returns the full Settings object; z.object strips the
+// non-overlay fields, leaving exactly the overlay subset.
+export const overlaySettingsSchema = z.object({
+  overlay_opacity: z.number(),
+  overlay_color: z.string(),
+  overlay_custom_rgb: z.string(),
+  overlay_high_contrast: z.boolean(),
+  overlay_font_scale: z.number(),
+  show_hint: z.boolean(),
+  show_current_time: z.boolean(),
+  clock_format: z.enum(["12h", "24h"]),
+  micro_sound: breakSoundSchema,
+  long_sound: breakSoundSchema,
+  sound_volume: z.number(),
+  pause_countdown_if_typing: z.boolean(),
+  strict_mode: z.boolean(),
+  custom_css: z.string(),
+}) satisfies z.ZodType<OverlaySettings>;
+
+export const breakEventSchema = z.object({
+  kind: z.enum(["micro", "long", "sleep"]),
+  duration_secs: z.number(),
+  enforceable: z.boolean(),
+  manual_finish: z.boolean(),
+  postpone_available: z.boolean(),
+  hints: z.array(z.string()),
+  hint_rotate_seconds: z.number(),
+  health_intensity: z.number(),
+}) satisfies z.ZodType<BreakEvent>;
+
+export const postponeStateSchema = z.object({
+  count: z.number(),
+  max: z.number(),
+  remaining: z.number(),
+}) satisfies z.ZodType<PostponeState>;


### PR DESCRIPTION
## Summary

From the whole-codebase critical review (finding #4, Required). Independent of the other open PRs — branches off `main`.

The break overlay rendered untrusted backend data **directly** via generic `invoke` casts — `invokeFn<OverlaySettings>("get_settings")`, `invokeFn<BreakEvent | null>("get_current_break")`, and the `break:start` event payload. A malformed response could drive overlay state unchecked (e.g. `setRemaining(payload.duration_secs)` with a non-number). The lone defensive check (`Array.isArray(payload.hints)`) showed the payload was known to be untrusted — but only one field was guarded.

### Change

- New `src/views/break-overlay/schemas.ts` — zod schemas for `OverlaySettings`, `BreakEvent`, `PostponeState`, each `satisfies z.ZodType<T>` so the **compiler** checks them against the TS types (which are kept in parity with the Rust serde structs — `BreakEvent`/`PostponeState` are in `ipc-parity.test.ts`).
- `applyBreak` validates the event payload before driving the UI; `get_settings` (the full Settings object — z.object **strips** the non-overlay fields) and `get_postpone_state` are `safeParse`'d.
- Every parse failure falls back to the **existing** safe path: drop the break / keep the prior appearance / null postpone. So a too-strict schema can only degrade to defaults, never crash the overlay.
- Dropped the now-redundant `Array.isArray(hints)` guard and the manual 14-field copy (the schema does both).

### De-risking

The schemas were checked against the **actual Rust serde**, not just the TS types — notably `BreakSound.custom_path` is a plain `String` in Rust (always sent) but optional in TS and omitted from `DEFAULT_OVERLAY_SETTINGS`, so it's `z.string().optional()` to accept both. `clock_format` is clamp-guaranteed to `12h`/`24h`. Validation kept **inline** (not routed through `lib/ipc`) to preserve the hook's dependency-injection test seam.

## Test Plan

- New `schemas.test.ts` — each schema accepts valid fixtures, **strips extra fields** from a full-Settings payload, accepts `custom_path`, and rejects wrong types / unknown enums / missing fields.
- New `use-break-state.test.ts` cases: malformed `break:start` is ignored (no UI driven), malformed `get_settings` keeps the default appearance while a valid break still shows, malformed `get_postpone_state` → null.
- Existing 5 overlay-state tests unchanged and green (schemas accept the real fixtures).
- `vitest` (break-overlay): 118 passed. `tsc --noEmit` (incl. `satisfies` checks), `eslint`, `prettier --check`: clean.

No user-facing behaviour change for valid payloads (defense-in-depth), so no CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)