### PR TITLE
docs(overlay): document the countdown as authoritative for break end

### DIFF
--- a/src/views/break-overlay/hooks/use-countdown.ts
+++ b/src/views/break-overlay/hooks/use-countdown.ts
@@ -49,6 +49,24 @@ function endChimeConfig(
  * `clearBreak()` runs. The end-chime config is captured via a ref so
  * mid-break setting changes are picked up without re-arming the
  * 1-second timer on every appearance change.
+ *
+ * This countdown is **authoritative** for when an auto-completing break
+ * ends — there is no backend watchdog. Reaching zero here is what fires the
+ * `end_break` IPC (via `dismiss`), which emits `break:end`. The number is
+ * deliberately a plain per-second decrement, NOT a wall-clock
+ * `remaining = end - now`, because the decrement makes the typing-pause free
+ * — a paused second is just a skipped tick (see `paused` below) — whereas an
+ * `end - now` model would keep counting through a pause and need separate
+ * paused-time accounting to stay correct.
+ *
+ * The trade-off: if the OS throttles the renderer's timers — the machine
+ * sleeps mid-break, or a non-enforcing overlay is backgrounded — the tick
+ * stretches, so the break can end *late* by roughly the throttled gap.
+ * Enforcing breaks hold the foreground (not throttled); the residual case is
+ * sleep during a break. A robust fix would be a backend deadline that ends
+ * the break regardless of the renderer; see issue tracker. Until then this is
+ * a known limitation, documented so a "fix" that switches to wall-clock
+ * doesn't silently reintroduce the typing-pause bug.
  */
 export function useCountdown(
   active: BreakEvent | null,


### PR DESCRIPTION
## Summary

From the whole-codebase critical review (finding #9), **corrected after a critical-review pass caught a factual error in the first version.**

The review flagged that the break-overlay countdown drifts under timer throttling. My first attempt documented it as "cosmetic, backend authoritative" — which is **wrong**: there is no backend watchdog. Tracing the code:

- `break:end` is emitted only by the `end_break` / `postpone_break` commands (`breaks.rs:263,287`).
- `end_break` is invoked by the **renderer** when the countdown reaches zero (`use-countdown.ts` → `dismiss`).
- The run loop only *starts* breaks and enforces *pause* deadlines; it never auto-ends an active break.

So the countdown **is authoritative** for when an auto-completing break ends. This PR documents that accurately, including:
- why it's a plain per-second decrement and not a wall-clock `end - now` (the decrement makes the typing-pause free — a paused second is a skipped tick; wall-clock would count through a pause and need separate paused-time accounting);
- the real trade-off — under renderer timer throttling (machine asleep mid-break; enforcing breaks hold the foreground and aren't throttled) the break can end **late**;
- that the robust fix is a backend deadline (follow-up), and a warning so a naive wall-clock "fix" doesn't silently reintroduce the pause bug.

> **Note:** this re-frames #9 from "cosmetic, won't-fix" to "a real (if limited-impact) late-end limitation, documented." A proper fix — a backend watchdog that ends a break at its deadline regardless of the renderer — is worth a follow-up issue.

## Test Plan

Comment-only; no behaviour change. `use-countdown.test.ts` green (11). `prettier`/`eslint`/`cspell` clean. No CHANGELOG (not user-facing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)