### PR TITLE
feat(onboarding): first-run guided setup wizard

### DIFF
--- a/.github/audit/cspell/project-words.txt
+++ b/.github/audit/cspell/project-words.txt
@@ -180,3 +180,4 @@ ALSA
 GStreamer
 Symphonia
 textareas
+winddown

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Versions on the `0.0.X` line are public beta releases; `0.1.X` and onwards will 
 
 ### Added
 
-- **First-run onboarding wizard.** A new install now opens a short guided setup over the Settings window — start-at-login, working hours, wellness-hint mix, and wind-down — with every control writing through the same settings the tabs use, so finishing leaves the app configured. It shows once: completion (or skipping) is persisted, and any existing install — including settings files written before this version — is treated as already onboarded, so upgraders never see it.
+- **First-run onboarding wizard.** A new install now opens a short guided setup over the Settings window — start-at-login, working hours, wellness-hint mix, and wind-down — with every control writing through the same settings the tabs use, so finishing leaves the app configured. It shows once: completion (or skipping) is persisted, and any existing install — including settings files written before this version — is treated as already onboarded, so people upgrading never see it.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Versions on the `0.0.X` line are public beta releases; `0.1.X` and onwards will 
 
 ## [Unreleased]
 
+### Added
+
+- **First-run onboarding wizard.** A new install now opens a short guided setup over the Settings window — start-at-login, working hours, wellness-hint mix, and wind-down — with every control writing through the same settings the tabs use, so finishing leaves the app configured. It shows once: completion (or skipping) is persisted, and any existing install — including settings files written before this version — is treated as already onboarded, so upgraders never see it.
+
 ### Changed
 
 - **`entracte settings set …` now clamps out-of-range values like the Settings window.** Writing a setting through the CLI (or the underlying IPC channel) previously skipped the range-clamping and `custom_css`/fixed-time sanitisation the GUI applies, so e.g. `entracte settings set micro_interval_secs 0` persisted a 0-second interval that fired a break every tick. The CLI/IPC path now runs the same normalisation — flooring intervals at 30s, capping durations, and scrubbing custom CSS.

--- a/scripts/audit-a11y.mjs
+++ b/scripts/audit-a11y.mjs
@@ -103,6 +103,10 @@ const TAURI_SHIM = `
   const responses = {
     get_settings: DEFAULT_SETTINGS,
     update_settings: null,
+    // Already onboarded, so the first-run wizard never overlays the tabs
+    // this audit walks. (Wizard a11y is exercised by its own component test.)
+    get_onboarding_completed: true,
+    complete_onboarding: null,
     get_platform: "macos",
     get_platform_capabilities: {
       supportsDndRead: true,

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -85,15 +85,34 @@ impl<'de> Deserialize<'de> for Profile {
 pub struct ProfilesFile {
     pub profiles: Vec<Profile>,
     pub active: String,
+    /// Whether the first-run onboarding wizard has been completed (or
+    /// skipped). App-global rather than per-profile: onboarding is about
+    /// the install, not a single profile. A fresh install starts `false`
+    /// so the wizard shows once; any file that already exists on disk —
+    /// including one upgraded from a version that predates this field —
+    /// loads as `true` so existing users are never re-onboarded.
+    pub onboarding_completed: bool,
 }
 
 impl Default for ProfilesFile {
     fn default() -> Self {
-        Self::single(DEFAULT_PROFILE_NAME.to_string(), Settings::default())
+        // Reached when no settings file exists yet (genuine first run), so
+        // onboarding has not been completed.
+        Self {
+            profiles: vec![Profile {
+                name: DEFAULT_PROFILE_NAME.to_string(),
+                settings: Settings::default(),
+            }],
+            active: DEFAULT_PROFILE_NAME.to_string(),
+            onboarding_completed: false,
+        }
     }
 }
 
 impl ProfilesFile {
+    /// Wrap a single profile. Used when migrating an existing flat/legacy
+    /// settings file, so `onboarding_completed` is `true`: the user already
+    /// has settings on disk and should not be onboarded.
     pub fn single(name: String, settings: Settings) -> Self {
         Self {
             profiles: vec![Profile {
@@ -101,6 +120,7 @@ impl ProfilesFile {
                 settings,
             }],
             active: name,
+            onboarding_completed: true,
         }
     }
 
@@ -156,7 +176,18 @@ impl<'de> Deserialize<'de> for ProfilesFile {
                         .map(String::from)
                         .or_else(|| profiles.first().map(|p| p.name.clone()))
                         .unwrap_or_else(|| DEFAULT_PROFILE_NAME.to_string());
-                    Ok(ProfilesFile { profiles, active })
+                    // A file already on disk means the user has used the app
+                    // before; default to onboarded when the field is absent
+                    // (file written before onboarding existed).
+                    let onboarding_completed = raw_value
+                        .get("onboarding_completed")
+                        .and_then(|v| v.as_bool())
+                        .unwrap_or(true);
+                    Ok(ProfilesFile {
+                        profiles,
+                        active,
+                        onboarding_completed,
+                    })
                 } else {
                     let mut raw_value = raw_value;
                     migrate_legacy_settings(&mut raw_value);
@@ -255,6 +286,7 @@ mod tests {
                 },
             ],
             active: "Home".to_string(),
+            ..ProfilesFile::default()
         };
         save(&path, &file).unwrap();
         let loaded = load(&path);
@@ -518,6 +550,67 @@ mod tests {
     }
 
     #[test]
+    fn load_missing_marks_onboarding_incomplete() {
+        let dir = temp_dir();
+        let path = dir.path().join("does-not-exist.json");
+        assert!(
+            !load(&path).onboarding_completed,
+            "a genuine first run must show onboarding"
+        );
+    }
+
+    #[test]
+    fn load_legacy_flat_settings_marks_onboarding_complete() {
+        let (_dir, path) = temp_file();
+        fs::write(&path, r#"{"micro_interval_secs": 99}"#).unwrap();
+        assert!(
+            load(&path).onboarding_completed,
+            "an existing legacy file must not re-onboard the user"
+        );
+    }
+
+    #[test]
+    fn load_profiles_file_without_flag_marks_onboarding_complete() {
+        let (_dir, path) = temp_file();
+        fs::write(
+            &path,
+            r#"{"profiles":[{"name":"Default","settings":{}}],"active":"Default"}"#,
+        )
+        .unwrap();
+        assert!(
+            load(&path).onboarding_completed,
+            "a pre-onboarding profiles file must not re-onboard the user"
+        );
+    }
+
+    #[test]
+    fn load_profiles_file_honours_explicit_flag() {
+        let (_dir, path) = temp_file();
+        fs::write(
+            &path,
+            r#"{"profiles":[{"name":"Default","settings":{}}],"active":"Default","onboarding_completed":false}"#,
+        )
+        .unwrap();
+        assert!(
+            !load(&path).onboarding_completed,
+            "an explicit false must be honoured (onboarding still pending)"
+        );
+    }
+
+    #[test]
+    fn onboarding_flag_round_trips_through_save() {
+        let (_dir, path) = temp_file();
+        let mut file = ProfilesFile::default();
+        assert!(!file.onboarding_completed);
+        file.onboarding_completed = true;
+        save(&path, &file).unwrap();
+        assert!(load(&path).onboarding_completed);
+
+        let text = fs::read_to_string(&path).unwrap();
+        assert!(text.contains("\"onboarding_completed\""));
+    }
+
+    #[test]
     fn active_settings_falls_back_to_first_when_missing() {
         let file = ProfilesFile {
             profiles: vec![Profile {
@@ -525,6 +618,7 @@ mod tests {
                 settings: Settings::default(),
             }],
             active: "Missing".to_string(),
+            ..ProfilesFile::default()
         };
         let s = file.active_settings();
         assert_eq!(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -134,6 +134,8 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![
             scheduler::get_settings,
             scheduler::update_settings,
+            scheduler::get_onboarding_completed,
+            scheduler::complete_onboarding,
             scheduler::set_hooks,
             scheduler::pause,
             scheduler::resume,

--- a/src-tauri/src/scheduler/commands/backup.rs
+++ b/src-tauri/src/scheduler/commands/backup.rs
@@ -496,6 +496,10 @@ async fn apply_bundle_to_scheduler<R: Runtime>(
         let mut active = scheduler.active_profile_name.lock().await;
         *active = profiles_file.active.clone();
     }
+    scheduler.onboarding_completed.store(
+        profiles_file.onboarding_completed,
+        std::sync::atomic::Ordering::Relaxed,
+    );
     {
         let mut settings = scheduler.settings.lock().await;
         // `active_settings` rebuilds the `#[serde(skip)]` `derived` cache
@@ -690,6 +694,7 @@ mod tests {
         bundle.files.settings_json = serde_json::to_string(&ProfilesFile {
             profiles: vec![],
             active: String::new(),
+            ..ProfilesFile::default()
         })
         .unwrap();
         let err = validate_bundle(&bundle).expect_err("empty profiles is rejected");
@@ -705,6 +710,7 @@ mod tests {
                 settings: Settings::default(),
             }],
             active: "Nonexistent".to_string(),
+            ..ProfilesFile::default()
         })
         .unwrap();
         let err = validate_bundle(&bundle).expect_err("dangling active profile is rejected");

--- a/src-tauri/src/scheduler/commands/settings.rs
+++ b/src-tauri/src/scheduler/commands/settings.rs
@@ -113,7 +113,8 @@ mod tests {
     use super::*;
     use crate::config::DEFAULT_PROFILE_NAME;
     use crate::hooks::{Hook, HookEvent};
-    use crate::test_support::test_scheduler_with_profiles;
+    use crate::test_support::{test_scheduler_with_profiles, wrap_in_mock_app};
+    use tauri::Manager;
 
     fn one_profile() -> Vec<config::Profile> {
         vec![config::Profile {
@@ -144,6 +145,43 @@ mod tests {
         complete_onboarding_impl(&sched).await;
         complete_onboarding_impl(&sched).await;
         assert!(sched.onboarding_completed.load(Ordering::Relaxed));
+    }
+
+    #[tokio::test]
+    async fn get_onboarding_completed_command_reflects_the_flag() {
+        let (_dir, sched) = test_scheduler_with_profiles(one_profile(), DEFAULT_PROFILE_NAME);
+        sched.onboarding_completed.store(false, Ordering::Relaxed);
+        let app = wrap_in_mock_app(sched.clone());
+
+        assert!(
+            !get_onboarding_completed(app.state::<Scheduler>())
+                .await
+                .unwrap(),
+            "a pending install reports incomplete"
+        );
+
+        sched.onboarding_completed.store(true, Ordering::Relaxed);
+        assert!(
+            get_onboarding_completed(app.state::<Scheduler>())
+                .await
+                .unwrap(),
+            "once flipped, the command reports complete"
+        );
+    }
+
+    #[tokio::test]
+    async fn complete_onboarding_command_sets_and_persists_the_flag() {
+        let (_dir, sched) = test_scheduler_with_profiles(one_profile(), DEFAULT_PROFILE_NAME);
+        sched.onboarding_completed.store(false, Ordering::Relaxed);
+        let app = wrap_in_mock_app(sched.clone());
+
+        complete_onboarding(app.state::<Scheduler>()).await.unwrap();
+
+        assert!(sched.onboarding_completed.load(Ordering::Relaxed));
+        assert!(
+            config::load(&sched.config_path).onboarding_completed,
+            "the command persists completion to disk"
+        );
     }
 
     #[test]

--- a/src-tauri/src/scheduler/commands/settings.rs
+++ b/src-tauri/src/scheduler/commands/settings.rs
@@ -1,3 +1,5 @@
+use std::sync::atomic::Ordering;
+
 use crate::config;
 use crate::supporter;
 use crate::SupporterAppState;
@@ -62,6 +64,31 @@ pub async fn update_settings(
     Ok(())
 }
 
+/// Whether the first-run onboarding wizard still needs to be shown. The
+/// renderer calls this on mount and only mounts the wizard when it
+/// returns `false`.
+#[tauri::command]
+pub async fn get_onboarding_completed(
+    scheduler: tauri::State<'_, Scheduler>,
+) -> Result<bool, String> {
+    Ok(scheduler.onboarding_completed.load(Ordering::Relaxed))
+}
+
+/// Mark onboarding as done (the user finished or skipped the wizard) and
+/// persist it so the wizard never shows again. Idempotent.
+#[tauri::command]
+pub async fn complete_onboarding(scheduler: tauri::State<'_, Scheduler>) -> Result<(), String> {
+    complete_onboarding_impl(scheduler.inner()).await;
+    Ok(())
+}
+
+async fn complete_onboarding_impl(scheduler: &Scheduler) {
+    scheduler
+        .onboarding_completed
+        .store(true, Ordering::Relaxed);
+    super::super::persist_profiles(scheduler).await;
+}
+
 // Hooks must never be set through `update_settings` — they require explicit
 // confirmation. Anything coming over the renderer IPC has its hook fields
 // overwritten with whatever is currently persisted before merge.
@@ -84,7 +111,40 @@ fn gate_custom_css(mut new: Settings, current: &Settings, is_supporter: bool) ->
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::DEFAULT_PROFILE_NAME;
     use crate::hooks::{Hook, HookEvent};
+    use crate::test_support::test_scheduler_with_profiles;
+
+    fn one_profile() -> Vec<config::Profile> {
+        vec![config::Profile {
+            name: DEFAULT_PROFILE_NAME.to_string(),
+            settings: Settings::default(),
+        }]
+    }
+
+    #[tokio::test]
+    async fn complete_onboarding_sets_flag_and_persists() {
+        let (_dir, sched) = test_scheduler_with_profiles(one_profile(), DEFAULT_PROFILE_NAME);
+        // Simulate a fresh install where onboarding is still pending.
+        sched.onboarding_completed.store(false, Ordering::Relaxed);
+
+        complete_onboarding_impl(&sched).await;
+
+        assert!(sched.onboarding_completed.load(Ordering::Relaxed));
+        let reloaded = config::load(&sched.config_path);
+        assert!(
+            reloaded.onboarding_completed,
+            "completion must survive a reload from disk"
+        );
+    }
+
+    #[tokio::test]
+    async fn complete_onboarding_is_idempotent() {
+        let (_dir, sched) = test_scheduler_with_profiles(one_profile(), DEFAULT_PROFILE_NAME);
+        complete_onboarding_impl(&sched).await;
+        complete_onboarding_impl(&sched).await;
+        assert!(sched.onboarding_completed.load(Ordering::Relaxed));
+    }
 
     #[test]
     fn strip_hooks_keeps_current_hook_fields_and_takes_other_fields_from_new() {

--- a/src-tauri/src/scheduler/commands/settings.rs
+++ b/src-tauri/src/scheduler/commands/settings.rs
@@ -113,8 +113,7 @@ mod tests {
     use super::*;
     use crate::config::DEFAULT_PROFILE_NAME;
     use crate::hooks::{Hook, HookEvent};
-    use crate::test_support::{test_scheduler_with_profiles, wrap_in_mock_app};
-    use tauri::Manager;
+    use crate::test_support::test_scheduler_with_profiles;
 
     fn one_profile() -> Vec<config::Profile> {
         vec![config::Profile {
@@ -145,43 +144,6 @@ mod tests {
         complete_onboarding_impl(&sched).await;
         complete_onboarding_impl(&sched).await;
         assert!(sched.onboarding_completed.load(Ordering::Relaxed));
-    }
-
-    #[tokio::test]
-    async fn get_onboarding_completed_command_reflects_the_flag() {
-        let (_dir, sched) = test_scheduler_with_profiles(one_profile(), DEFAULT_PROFILE_NAME);
-        sched.onboarding_completed.store(false, Ordering::Relaxed);
-        let app = wrap_in_mock_app(sched.clone());
-
-        assert!(
-            !get_onboarding_completed(app.state::<Scheduler>())
-                .await
-                .unwrap(),
-            "a pending install reports incomplete"
-        );
-
-        sched.onboarding_completed.store(true, Ordering::Relaxed);
-        assert!(
-            get_onboarding_completed(app.state::<Scheduler>())
-                .await
-                .unwrap(),
-            "once flipped, the command reports complete"
-        );
-    }
-
-    #[tokio::test]
-    async fn complete_onboarding_command_sets_and_persists_the_flag() {
-        let (_dir, sched) = test_scheduler_with_profiles(one_profile(), DEFAULT_PROFILE_NAME);
-        sched.onboarding_completed.store(false, Ordering::Relaxed);
-        let app = wrap_in_mock_app(sched.clone());
-
-        complete_onboarding(app.state::<Scheduler>()).await.unwrap();
-
-        assert!(sched.onboarding_completed.load(Ordering::Relaxed));
-        assert!(
-            config::load(&sched.config_path).onboarding_completed,
-            "the command persists completion to disk"
-        );
     }
 
     #[test]
@@ -300,5 +262,62 @@ mod tests {
         };
         let merged = gate_custom_css(incoming, &current, true);
         assert_eq!(merged.custom_css, "");
+    }
+}
+
+// Drive the onboarding `#[tauri::command]` wrappers end-to-end through a
+// mock app `State`. Gated off Windows for the same reason as
+// `profiles::rig_smoke_tests`: the `tauri` test feature (MockRuntime)
+// isn't compiled there. Coverage still counts — codecov merges the
+// macOS + Linux jobs.
+#[cfg(all(test, not(target_os = "windows")))]
+mod onboarding_command_rig {
+    use super::*;
+    use crate::config::DEFAULT_PROFILE_NAME;
+    use crate::test_support::{test_scheduler_with_profiles, wrap_in_mock_app};
+    use tauri::Manager;
+
+    fn one_profile() -> Vec<config::Profile> {
+        vec![config::Profile {
+            name: DEFAULT_PROFILE_NAME.to_string(),
+            settings: Settings::default(),
+        }]
+    }
+
+    #[tokio::test]
+    async fn get_onboarding_completed_command_reflects_the_flag() {
+        let (_dir, sched) = test_scheduler_with_profiles(one_profile(), DEFAULT_PROFILE_NAME);
+        sched.onboarding_completed.store(false, Ordering::Relaxed);
+        let app = wrap_in_mock_app(sched.clone());
+
+        assert!(
+            !get_onboarding_completed(app.state::<Scheduler>())
+                .await
+                .unwrap(),
+            "a pending install reports incomplete"
+        );
+
+        sched.onboarding_completed.store(true, Ordering::Relaxed);
+        assert!(
+            get_onboarding_completed(app.state::<Scheduler>())
+                .await
+                .unwrap(),
+            "once flipped, the command reports complete"
+        );
+    }
+
+    #[tokio::test]
+    async fn complete_onboarding_command_sets_and_persists_the_flag() {
+        let (_dir, sched) = test_scheduler_with_profiles(one_profile(), DEFAULT_PROFILE_NAME);
+        sched.onboarding_completed.store(false, Ordering::Relaxed);
+        let app = wrap_in_mock_app(sched.clone());
+
+        complete_onboarding(app.state::<Scheduler>()).await.unwrap();
+
+        assert!(sched.onboarding_completed.load(Ordering::Relaxed));
+        assert!(
+            config::load(&sched.config_path).onboarding_completed,
+            "the command persists completion to disk"
+        );
     }
 }

--- a/src-tauri/src/scheduler/mod.rs
+++ b/src-tauri/src/scheduler/mod.rs
@@ -11,7 +11,7 @@ mod tray_countdown;
 mod types;
 
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicBool, AtomicU8};
+use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 use std::sync::Arc;
 
 use log::warn;
@@ -142,6 +142,11 @@ pub struct Scheduler {
     pub profiles: Arc<Mutex<Vec<Profile>>>,
     pub active_profile_name: Arc<Mutex<String>>,
     pub hook_dialog_busy: Arc<AtomicBool>,
+    /// Whether first-run onboarding has been completed. Mirrors
+    /// `ProfilesFile::onboarding_completed`; persisted back to disk via
+    /// `snapshot_profiles_file`. Atomic so the IPC commands can read and
+    /// flip it without taking the profiles lock.
+    pub onboarding_completed: Arc<AtomicBool>,
     /// Set by the backup-import flow while it's mid-restore. The run
     /// loop short-circuits each tick while this is true so it can't
     /// fire a break with mid-write state (e.g. new events.jsonl on
@@ -189,6 +194,7 @@ impl Scheduler {
             screen_time: Arc::new(Mutex::new(screen_time)),
             current_break: Arc::new(std::sync::Mutex::new(None)),
             logger,
+            onboarding_completed: Arc::new(AtomicBool::new(profiles_file.onboarding_completed)),
             profiles: Arc::new(Mutex::new(profiles_file.profiles)),
             active_profile_name: Arc::new(Mutex::new(active_name)),
             hook_dialog_busy: Arc::new(AtomicBool::new(false)),
@@ -242,6 +248,7 @@ impl Scheduler {
             ))),
             current_break: Arc::new(std::sync::Mutex::new(None)),
             logger: Logger::spawn(events_path),
+            onboarding_completed: Arc::new(AtomicBool::new(true)),
             profiles: Arc::new(Mutex::new(profiles)),
             active_profile_name: Arc::new(Mutex::new(active.to_string())),
             hook_dialog_busy: Arc::new(AtomicBool::new(false)),
@@ -255,6 +262,7 @@ impl Scheduler {
         ProfilesFile {
             profiles: self.profiles.lock().await.clone(),
             active: self.active_profile_name.lock().await.clone(),
+            onboarding_completed: self.onboarding_completed.load(Ordering::Relaxed),
         }
     }
 }

--- a/src-tauri/src/scheduler/tray_countdown.rs
+++ b/src-tauri/src/scheduler/tray_countdown.rs
@@ -335,6 +335,7 @@ mod tests {
             }])),
             active_profile_name: Arc::new(TokioMutex::new(DEFAULT_PROFILE_NAME.to_string())),
             hook_dialog_busy: Arc::new(AtomicBool::new(false)),
+            onboarding_completed: Arc::new(AtomicBool::new(true)),
             import_in_progress: Arc::new(AtomicBool::new(false)),
         };
         (dir, sched)

--- a/src/views/settings/components/onboarding/onboarding-wizard.test.tsx
+++ b/src/views/settings/components/onboarding/onboarding-wizard.test.tsx
@@ -100,6 +100,22 @@ describe("OnboardingWizard", () => {
     expect(screen.getByText("End of day")).toBeTruthy();
   });
 
+  it("editing the working-hours times commits the new minutes", async () => {
+    const user = userEvent.setup();
+    const { update } = renderWizard({ work_window_enabled: true });
+    await advanceTo(user, 2);
+    const start = screen.getByDisplayValue("09:00");
+    await user.clear(start);
+    await user.type(start, "10:30");
+    await user.tab();
+    expect(update).toHaveBeenCalledWith("work_start_minutes", 10 * 60 + 30);
+    const end = screen.getByDisplayValue("17:00");
+    await user.clear(end);
+    await user.type(end, "18:00");
+    await user.tab();
+    expect(update).toHaveBeenCalledWith("work_end_minutes", 18 * 60);
+  });
+
   it("choosing the solo worker option updates long_hint_mix", async () => {
     const user = userEvent.setup();
     const { update } = renderWizard();
@@ -113,6 +129,72 @@ describe("OnboardingWizard", () => {
     renderWizard({ show_hint: false });
     await advanceTo(user, 3);
     expect(screen.queryByRole("combobox")).toBeNull();
+  });
+
+  it("toggling the wellness-hint checkbox updates show_hint", async () => {
+    const user = userEvent.setup();
+    const { update } = renderWizard();
+    await advanceTo(user, 3);
+    await user.click(
+      screen.getByRole("checkbox", {
+        name: /Show a wellness hint during breaks/,
+      }),
+    );
+    expect(update).toHaveBeenCalledWith("show_hint", false);
+  });
+
+  it("enabling wind-down reminders updates bedtime_enabled", async () => {
+    const user = userEvent.setup();
+    const { update } = renderWizard();
+    await advanceTo(user, 4);
+    expect(screen.queryByText("Wind-down starts")).toBeNull();
+    await user.click(
+      screen.getByRole("checkbox", {
+        name: /Remind me to wind down before bed/,
+      }),
+    );
+    expect(update).toHaveBeenCalledWith("bedtime_enabled", true);
+  });
+
+  it("shows the wind-down time fields when bedtime is already enabled", async () => {
+    const user = userEvent.setup();
+    renderWizard({ bedtime_enabled: true });
+    await advanceTo(user, 4);
+    expect(screen.getByText("Wind-down starts")).toBeTruthy();
+    expect(screen.getByText("Wind-down ends")).toBeTruthy();
+  });
+
+  it("editing the wind-down times commits the new minutes", async () => {
+    const user = userEvent.setup();
+    const { update } = renderWizard({ bedtime_enabled: true });
+    await advanceTo(user, 4);
+    const start = screen.getByDisplayValue("22:00");
+    await user.clear(start);
+    await user.type(start, "21:15");
+    await user.tab();
+    expect(update).toHaveBeenCalledWith("bedtime_start_minutes", 21 * 60 + 15);
+    const end = screen.getByDisplayValue("23:00");
+    await user.clear(end);
+    await user.type(end, "23:30");
+    await user.tab();
+    expect(update).toHaveBeenCalledWith("bedtime_end_minutes", 23 * 60 + 30);
+  });
+
+  it("marks completed steps as done in the progress dots", async () => {
+    const user = userEvent.setup();
+    const { container } = render(
+      <OnboardingWizard
+        settings={baseSettings()}
+        update={vi.fn()}
+        setAutostart={vi.fn()}
+        onFinish={vi.fn()}
+      />,
+    );
+    await advanceTo(user, 2);
+    expect(container.querySelectorAll(".onboarding-dot.done")).toHaveLength(2);
+    expect(container.querySelectorAll(".onboarding-dot.current")).toHaveLength(
+      1,
+    );
   });
 
   it("toggling strict mode on the wind-down step updates the setting", async () => {

--- a/src/views/settings/components/onboarding/onboarding-wizard.test.tsx
+++ b/src/views/settings/components/onboarding/onboarding-wizard.test.tsx
@@ -1,0 +1,148 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { SchedulerSettings } from "../../types";
+import { OnboardingWizard } from "./onboarding-wizard";
+
+function baseSettings(
+  over: Partial<SchedulerSettings> = {},
+): SchedulerSettings {
+  return {
+    autostart_enabled: false,
+    work_window_enabled: false,
+    work_start_minutes: 9 * 60,
+    work_end_minutes: 17 * 60,
+    clock_format: "24h",
+    show_hint: true,
+    long_hint_mix: "both",
+    bedtime_enabled: false,
+    bedtime_start_minutes: 22 * 60,
+    bedtime_end_minutes: 23 * 60,
+    strict_mode: false,
+    ...over,
+  } as SchedulerSettings;
+}
+
+function renderWizard(over: Partial<SchedulerSettings> = {}) {
+  const update = vi.fn();
+  const setAutostart = vi.fn();
+  const onFinish = vi.fn();
+  render(
+    <OnboardingWizard
+      settings={baseSettings(over)}
+      update={update}
+      setAutostart={setAutostart}
+      onFinish={onFinish}
+    />,
+  );
+  return { update, setAutostart, onFinish };
+}
+
+async function advanceTo(
+  user: ReturnType<typeof userEvent.setup>,
+  times: number,
+) {
+  for (let i = 0; i < times; i++) {
+    await user.click(screen.getByRole("button", { name: "Next" }));
+  }
+}
+
+describe("OnboardingWizard", () => {
+  it("opens on the welcome step as a labelled modal dialog", () => {
+    renderWizard();
+    const dialog = screen.getByRole("dialog");
+    expect(dialog.getAttribute("aria-modal")).toBe("true");
+    expect(screen.getByText("Step 1 of 6")).toBeTruthy();
+    expect(
+      screen.getByRole("heading", { name: "Welcome to Entracte" }),
+    ).toBeTruthy();
+  });
+
+  it("Next advances and Back returns through the steps", async () => {
+    const user = userEvent.setup();
+    renderWizard();
+    await user.click(screen.getByRole("button", { name: "Next" }));
+    expect(screen.getByText("Step 2 of 6")).toBeTruthy();
+    await user.click(screen.getByRole("button", { name: "Back" }));
+    expect(screen.getByText("Step 1 of 6")).toBeTruthy();
+    // Back is hidden on the first step.
+    expect(screen.queryByRole("button", { name: "Back" })).toBeNull();
+  });
+
+  it("toggling start-at-login calls setAutostart", async () => {
+    const user = userEvent.setup();
+    const { setAutostart } = renderWizard();
+    await advanceTo(user, 1);
+    await user.click(
+      screen.getByRole("checkbox", { name: /Start Entracte when I log in/ }),
+    );
+    expect(setAutostart).toHaveBeenCalledWith(true);
+  });
+
+  it("enabling working hours reveals the start/end time fields", async () => {
+    const user = userEvent.setup();
+    const { update } = renderWizard();
+    await advanceTo(user, 2);
+    expect(screen.queryByText("Start of day")).toBeNull();
+    await user.click(
+      screen.getByRole("checkbox", {
+        name: /Only remind me during working hours/,
+      }),
+    );
+    expect(update).toHaveBeenCalledWith("work_window_enabled", true);
+  });
+
+  it("shows the working-hours fields when the window is already enabled", async () => {
+    const user = userEvent.setup();
+    renderWizard({ work_window_enabled: true });
+    await advanceTo(user, 2);
+    expect(screen.getByText("Start of day")).toBeTruthy();
+    expect(screen.getByText("End of day")).toBeTruthy();
+  });
+
+  it("choosing the solo worker option updates long_hint_mix", async () => {
+    const user = userEvent.setup();
+    const { update } = renderWizard();
+    await advanceTo(user, 3);
+    await user.selectOptions(screen.getByRole("combobox"), "solo");
+    expect(update).toHaveBeenCalledWith("long_hint_mix", "solo");
+  });
+
+  it("hides the long-break mix selector when hints are off", async () => {
+    const user = userEvent.setup();
+    renderWizard({ show_hint: false });
+    await advanceTo(user, 3);
+    expect(screen.queryByRole("combobox")).toBeNull();
+  });
+
+  it("toggling strict mode on the wind-down step updates the setting", async () => {
+    const user = userEvent.setup();
+    const { update } = renderWizard();
+    await advanceTo(user, 4);
+    await user.click(screen.getByRole("checkbox", { name: /Strict mode/ }));
+    expect(update).toHaveBeenCalledWith("strict_mode", true);
+  });
+
+  it("Finish on the last step calls onFinish", async () => {
+    const user = userEvent.setup();
+    const { onFinish } = renderWizard();
+    await advanceTo(user, 5);
+    expect(screen.getByText("Step 6 of 6")).toBeTruthy();
+    await user.click(screen.getByRole("button", { name: "Finish" }));
+    expect(onFinish).toHaveBeenCalledTimes(1);
+  });
+
+  it("Skip setup finishes immediately from any step", async () => {
+    const user = userEvent.setup();
+    const { onFinish } = renderWizard();
+    await user.click(screen.getByRole("button", { name: "Skip setup" }));
+    expect(onFinish).toHaveBeenCalledTimes(1);
+  });
+
+  it("Escape dismisses the wizard", async () => {
+    const user = userEvent.setup();
+    const { onFinish } = renderWizard();
+    await user.keyboard("{Escape}");
+    expect(onFinish).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/views/settings/components/onboarding/onboarding-wizard.tsx
+++ b/src/views/settings/components/onboarding/onboarding-wizard.tsx
@@ -1,0 +1,274 @@
+import { useEffect, useRef, useState } from "react";
+import type { UseSettings } from "../../hooks/use-settings";
+import type { SchedulerSettings } from "../../types";
+import { CheckboxRow, TimeRow } from "../rows";
+import { InfoTip } from "../info-tip";
+import "./onboarding.css";
+
+type StepId = "welcome" | "login" | "window" | "hints" | "winddown" | "done";
+
+const STEPS: { id: StepId; title: string }[] = [
+  { id: "welcome", title: "Welcome" },
+  { id: "login", title: "Start at login" },
+  { id: "window", title: "Working hours" },
+  { id: "hints", title: "Wellness hints" },
+  { id: "winddown", title: "Wind down" },
+  { id: "done", title: "All set" },
+];
+
+export type OnboardingWizardProps = {
+  settings: SchedulerSettings;
+  update: UseSettings["update"];
+  setAutostart: UseSettings["setAutostart"];
+  /** Persist completion and dismiss the wizard (finish or skip). */
+  onFinish: () => void;
+};
+
+/** First-run guided setup. A modal over the Settings window that walks a
+ * new user through the handful of settings most worth choosing up front;
+ * every control writes through the same `update`/`setAutostart` helpers
+ * the real tabs use, so finishing leaves the app configured. */
+export function OnboardingWizard({
+  settings,
+  update,
+  setAutostart,
+  onFinish,
+}: OnboardingWizardProps) {
+  const [index, setIndex] = useState(0);
+  const step = STEPS[index];
+  const isFirst = index === 0;
+  const isLast = index === STEPS.length - 1;
+  const dialogRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    dialogRef.current?.focus();
+  }, []);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onFinish();
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [onFinish]);
+
+  const back = () => setIndex((i) => Math.max(0, i - 1));
+  const next = () => {
+    if (isLast) onFinish();
+    else setIndex((i) => Math.min(STEPS.length - 1, i + 1));
+  };
+
+  return (
+    <div className="onboarding-backdrop">
+      <div
+        className="onboarding-card"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="onboarding-title"
+        tabIndex={-1}
+        ref={dialogRef}
+      >
+        <header className="onboarding-head">
+          <p className="onboarding-step-count">
+            Step {index + 1} of {STEPS.length}
+          </p>
+          <ol className="onboarding-dots" aria-hidden="true">
+            {STEPS.map((s, i) => (
+              <li
+                key={s.id}
+                className={`onboarding-dot${i === index ? " current" : ""}${
+                  i < index ? " done" : ""
+                }`}
+              />
+            ))}
+          </ol>
+        </header>
+
+        <div className="onboarding-body">
+          <StepContent
+            step={step.id}
+            settings={settings}
+            update={update}
+            setAutostart={setAutostart}
+          />
+        </div>
+
+        <footer className="onboarding-foot">
+          <button type="button" className="link" onClick={onFinish}>
+            {isLast ? "Close" : "Skip setup"}
+          </button>
+          <div className="onboarding-nav">
+            {!isFirst && (
+              <button type="button" className="secondary" onClick={back}>
+                Back
+              </button>
+            )}
+            <button type="button" onClick={next}>
+              {isLast ? "Finish" : "Next"}
+            </button>
+          </div>
+        </footer>
+      </div>
+    </div>
+  );
+}
+
+function StepContent({
+  step,
+  settings,
+  update,
+  setAutostart,
+}: {
+  step: StepId;
+  settings: SchedulerSettings;
+  update: UseSettings["update"];
+  setAutostart: UseSettings["setAutostart"];
+}) {
+  switch (step) {
+    case "welcome":
+      return (
+        <>
+          <h2 id="onboarding-title">Welcome to Entracte</h2>
+          <p>
+            Entracte nudges you to step away from the screen with short micro
+            breaks and longer rest breaks. Let’s tune a few things so the
+            reminders fit how you work — it takes under a minute, and you can
+            change everything later in Settings.
+          </p>
+        </>
+      );
+    case "login":
+      return (
+        <>
+          <h2 id="onboarding-title">Start Entracte at login</h2>
+          <p>
+            Break reminders only work while Entracte is running. Starting it
+            automatically means you don’t have to remember to launch it each
+            day.
+          </p>
+          <CheckboxRow
+            label="Start Entracte when I log in"
+            value={settings.autostart_enabled}
+            onChange={(v) => setAutostart(v)}
+          />
+        </>
+      );
+    case "window":
+      return (
+        <>
+          <h2 id="onboarding-title">When should breaks fire?</h2>
+          <p>
+            Limit reminders to your working hours so Entracte stays quiet
+            evenings and weekends. Leave this off to be reminded around the
+            clock.
+          </p>
+          <CheckboxRow
+            label="Only remind me during working hours"
+            value={settings.work_window_enabled}
+            onChange={(v) => update("work_window_enabled", v)}
+          />
+          {settings.work_window_enabled && (
+            <>
+              <TimeRow
+                label="Start of day"
+                value={settings.work_start_minutes}
+                format={settings.clock_format}
+                onChange={(v) => update("work_start_minutes", v)}
+              />
+              <TimeRow
+                label="End of day"
+                value={settings.work_end_minutes}
+                format={settings.clock_format}
+                onChange={(v) => update("work_end_minutes", v)}
+              />
+            </>
+          )}
+        </>
+      );
+    case "hints":
+      return (
+        <>
+          <h2 id="onboarding-title">Wellness hints</h2>
+          <p>
+            Each break can show a suggestion — a stretch, a breath, a moment
+            away from the desk. Long-break ideas come in two flavours.
+          </p>
+          <CheckboxRow
+            label="Show a wellness hint during breaks"
+            value={settings.show_hint}
+            onChange={(v) => update("show_hint", v)}
+          />
+          {settings.show_hint && (
+            <label className="row">
+              <span>
+                Long-break suggestions
+                <InfoTip text="Solo: things to do on your own (stretch, fresh air, snack). Social: things to do with someone (call, walk together). Working alone? Pick Solo only to drop the social prompts." />
+              </span>
+              <select
+                value={settings.long_hint_mix}
+                onChange={(e) =>
+                  update(
+                    "long_hint_mix",
+                    e.target.value as SchedulerSettings["long_hint_mix"],
+                  )
+                }
+              >
+                <option value="both">Mix of solo and social</option>
+                <option value="solo">Solo only — I work alone</option>
+                <option value="social">Social only</option>
+              </select>
+            </label>
+          )}
+        </>
+      );
+    case "winddown":
+      return (
+        <>
+          <h2 id="onboarding-title">Wind down &amp; focus</h2>
+          <p>
+            Bedtime prompts gently remind you to log off as the evening winds
+            down. Strict mode removes the skip and postpone buttons so breaks
+            always happen — handy if you tend to dismiss them.
+          </p>
+          <CheckboxRow
+            label="Remind me to wind down before bed"
+            value={settings.bedtime_enabled}
+            onChange={(v) => update("bedtime_enabled", v)}
+          />
+          {settings.bedtime_enabled && (
+            <>
+              <TimeRow
+                label="Wind-down starts"
+                value={settings.bedtime_start_minutes}
+                format={settings.clock_format}
+                onChange={(v) => update("bedtime_start_minutes", v)}
+              />
+              <TimeRow
+                label="Wind-down ends"
+                value={settings.bedtime_end_minutes}
+                format={settings.clock_format}
+                onChange={(v) => update("bedtime_end_minutes", v)}
+              />
+            </>
+          )}
+          <CheckboxRow
+            label="Strict mode (breaks can’t be skipped or postponed)"
+            value={settings.strict_mode}
+            onChange={(v) => update("strict_mode", v)}
+            tip="Disables every escape hatch on the overlay. You can turn this off any time on the Breaks tab."
+          />
+        </>
+      );
+    case "done":
+      return (
+        <>
+          <h2 id="onboarding-title">You’re all set</h2>
+          <p>
+            That’s the essentials. Everything you picked — plus break intervals,
+            sounds, overlay appearance, profiles and more — lives in Settings,
+            ready whenever you want to fine-tune it.
+          </p>
+        </>
+      );
+  }
+}

--- a/src/views/settings/components/onboarding/onboarding.css
+++ b/src/views/settings/components/onboarding/onboarding.css
@@ -1,0 +1,102 @@
+.onboarding-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 1100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  background: rgb(0 0 0 / 55%);
+  backdrop-filter: blur(2px);
+}
+
+.onboarding-card {
+  display: flex;
+  flex-direction: column;
+  width: min(520px, 100%);
+  max-height: 100%;
+  background: var(--bg);
+  color: var(--fg);
+  border: 1px solid var(--tab-border);
+  border-radius: 12px;
+  box-shadow: 0 18px 48px rgb(0 0 0 / 45%);
+  overflow: hidden;
+}
+
+.onboarding-card:focus {
+  outline: none;
+}
+
+.onboarding-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem 1.5rem 0;
+}
+
+.onboarding-step-count {
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--faint-fg);
+}
+
+.onboarding-dots {
+  display: flex;
+  gap: 0.4rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.onboarding-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--input-border);
+  transition: background 120ms ease-out;
+}
+
+.onboarding-dot.done {
+  background: var(--pop-soft, var(--accent));
+}
+
+.onboarding-dot.current {
+  background: var(--accent-strong, var(--accent));
+}
+
+.onboarding-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0.75rem 1.5rem 1.25rem;
+}
+
+.onboarding-body h2 {
+  margin: 0.25rem 0 0.75rem;
+}
+
+.onboarding-body p {
+  margin: 0 0 1rem;
+  color: var(--muted-fg);
+  line-height: 1.5;
+}
+
+.onboarding-foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem 1.5rem;
+  border-top: 1px solid var(--tab-border);
+}
+
+.onboarding-nav {
+  display: flex;
+  gap: 0.6rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .onboarding-dot {
+    transition: none;
+  }
+}

--- a/src/views/settings/hooks/use-onboarding.test.ts
+++ b/src/views/settings/hooks/use-onboarding.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
+
+const invoke = vi.fn();
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (...args: unknown[]) => invoke(...args),
+}));
+
+const { useOnboarding } = await import("./use-onboarding");
+
+afterEach(() => {
+  invoke.mockReset();
+  vi.restoreAllMocks();
+});
+
+describe("useOnboarding", () => {
+  it("needs onboarding when the backend reports it incomplete", async () => {
+    invoke.mockResolvedValueOnce(false);
+    const { result } = renderHook(() => useOnboarding());
+    await waitFor(() => expect(result.current.needed).toBe(true));
+  });
+
+  it("stays hidden when onboarding is already complete", async () => {
+    invoke.mockResolvedValueOnce(true);
+    const { result } = renderHook(() => useOnboarding());
+    await waitFor(() =>
+      expect(invoke).toHaveBeenCalledWith(
+        "get_onboarding_completed",
+        undefined,
+      ),
+    );
+    expect(result.current.needed).toBe(false);
+  });
+
+  it("complete() hides the wizard and persists via complete_onboarding", async () => {
+    invoke.mockResolvedValueOnce(false).mockResolvedValueOnce(undefined);
+    const { result } = renderHook(() => useOnboarding());
+    await waitFor(() => expect(result.current.needed).toBe(true));
+
+    await act(async () => {
+      await result.current.complete();
+    });
+
+    expect(result.current.needed).toBe(false);
+    expect(invoke).toHaveBeenCalledWith("complete_onboarding");
+  });
+
+  it("keeps the wizard hidden if the status query fails", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    invoke.mockRejectedValueOnce(new Error("ipc down"));
+    const { result } = renderHook(() => useOnboarding());
+    await waitFor(() => expect(console.error).toHaveBeenCalled());
+    expect(result.current.needed).toBe(false);
+  });
+
+  it("swallows a persistence failure in complete()", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    invoke
+      .mockResolvedValueOnce(false)
+      .mockRejectedValueOnce(new Error("write failed"));
+    const { result } = renderHook(() => useOnboarding());
+    await waitFor(() => expect(result.current.needed).toBe(true));
+
+    await act(async () => {
+      await result.current.complete();
+    });
+
+    expect(result.current.needed).toBe(false);
+    expect(console.error).toHaveBeenCalled();
+  });
+});

--- a/src/views/settings/hooks/use-onboarding.ts
+++ b/src/views/settings/hooks/use-onboarding.ts
@@ -1,0 +1,50 @@
+import { useCallback, useEffect, useState } from "react";
+import { invoke as tauriInvoke } from "@tauri-apps/api/core";
+import { z } from "zod";
+import { invoke } from "../../../lib/ipc";
+
+/** Shape returned by {@link useOnboarding}. `needed` is `false` until the
+ * backend confirms onboarding is still pending, so the wizard never
+ * flashes for returning users while the IPC round-trip is in flight. */
+export type UseOnboarding = {
+  needed: boolean;
+  complete: () => Promise<void>;
+};
+
+/** Tracks whether the first-run onboarding wizard should be shown. Reads
+ * `get_onboarding_completed` once on mount; `complete` persists the
+ * finished/skipped state via `complete_onboarding` and hides the wizard
+ * locally so it disappears immediately. */
+export function useOnboarding(): UseOnboarding {
+  const [needed, setNeeded] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const completed = await invoke(
+          "get_onboarding_completed",
+          undefined,
+          z.boolean(),
+        );
+        if (!cancelled) setNeeded(!completed);
+      } catch (e) {
+        console.error("get_onboarding_completed failed", e);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const complete = useCallback(async () => {
+    setNeeded(false);
+    try {
+      await tauriInvoke("complete_onboarding");
+    } catch (e) {
+      console.error("complete_onboarding failed", e);
+    }
+  }, []);
+
+  return { needed, complete };
+}

--- a/src/views/settings/index.test.tsx
+++ b/src/views/settings/index.test.tsx
@@ -4,6 +4,7 @@ import userEvent from "@testing-library/user-event";
 import type { SchedulerSettings } from "./types";
 
 let mockSettings: SchedulerSettings | null = null;
+let mockOnboardingNeeded = false;
 
 vi.mock("./hooks/use-settings", () => ({
   useSettings: () => ({
@@ -13,6 +14,9 @@ vi.mock("./hooks/use-settings", () => ({
     reloadFromActive: vi.fn(),
     setAutostart: vi.fn(),
   }),
+}));
+vi.mock("./hooks/use-onboarding", () => ({
+  useOnboarding: () => ({ needed: mockOnboardingNeeded, complete: vi.fn() }),
 }));
 vi.mock("./hooks/use-pause", () => ({ usePause: () => ({ paused: false }) }));
 vi.mock("./hooks/use-stats", () => ({
@@ -237,6 +241,30 @@ describe("Settings shell ARIA + keyboard", () => {
       expect(panel?.textContent).toBe(expected);
     },
   );
+
+  it("shows the onboarding wizard when needed and settings are loaded", () => {
+    mockSettings = hydratedSettings;
+    mockOnboardingNeeded = true;
+    render(<Settings />);
+    expect(screen.getByRole("dialog")).toBeTruthy();
+    expect(screen.getByText("Step 1 of 6")).toBeTruthy();
+    mockOnboardingNeeded = false;
+  });
+
+  it("does not show the wizard before settings have loaded", () => {
+    mockSettings = null;
+    mockOnboardingNeeded = true;
+    render(<Settings />);
+    expect(screen.queryByRole("dialog")).toBeNull();
+    mockOnboardingNeeded = false;
+  });
+
+  it("does not show the wizard for a returning user", () => {
+    mockSettings = hydratedSettings;
+    mockOnboardingNeeded = false;
+    render(<Settings />);
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
 
   // Held-arrow-key regression — fireEvent because userEvent always
   // waits for React to flush between events.

--- a/src/views/settings/index.tsx
+++ b/src/views/settings/index.tsx
@@ -1,7 +1,9 @@
 import { useState } from "react";
 import { useCustomStylesheet } from "../../lib/use-custom-stylesheet";
+import { OnboardingWizard } from "./components/onboarding/onboarding-wizard";
 import { TABS } from "./constants";
 import { useHooks } from "./hooks/use-hooks";
+import { useOnboarding } from "./hooks/use-onboarding";
 import { usePause } from "./hooks/use-pause";
 import { useProfiles } from "./hooks/use-profiles";
 import { useRovingTabList } from "./hooks/use-roving-tab-list";
@@ -35,6 +37,7 @@ export default function Settings() {
   const profiles = useProfiles();
   const hooks = useHooks(settings, reloadFromActive);
   const supporter = useSupporter();
+  const onboarding = useOnboarding();
   useCustomStylesheet(settings?.custom_css ?? "");
   const { tablistProps, tabProps } = useRovingTabList<Tab>({
     ids: TAB_IDS,
@@ -48,6 +51,14 @@ export default function Settings() {
         Skip to settings content
       </a>
       <main className="settings">
+        {settings && onboarding.needed && (
+          <OnboardingWizard
+            settings={settings}
+            update={update}
+            setAutostart={setAutostart}
+            onFinish={onboarding.complete}
+          />
+        )}
         <header className="settings-header">
           <div
             className="tabs"


### PR DESCRIPTION
## Summary

Adds a first-run onboarding wizard: a fresh install opens a short modal over the Settings window walking a new user through the few settings most worth choosing up front — **start at login**, **working hours**, **wellness-hint mix**, and **wind-down**. Every control writes through the same `update` / `setAutostart` helpers the real tabs use, so finishing leaves the app configured. It shows **once**.

(Picked up from in-progress WIP and moved onto its own branch off `main`.)

## How it works

**Persistence & migration (conservative by design):**
- `ProfilesFile` gains `onboarding_completed`, mirrored on the `Scheduler` as an `AtomicBool` and saved with the profiles.
- A genuine first run (no settings file) starts `false` → wizard shows once.
- Any file already on disk — including a legacy flat file or a profiles file written *before* this field existed — loads as `true`, so **existing users are never re-onboarded**.
- Backup import restores the flag from the imported bundle.

**Wiring:**
- Two IPC commands — `get_onboarding_completed` / `complete_onboarding` — back the renderer's `useOnboarding` hook.
- The wizard mounts only when `settings && onboarding.needed`; completing or skipping persists via `complete_onboarding` and dismisses it immediately.

## Test plan

- **Rust:** config migration matrix (missing → incomplete; legacy/flat → complete; profiles-without-flag → complete; explicit flag honoured; round-trips through save), `complete_onboarding` persistence + idempotency. Full suite: **792 pass**, `clippy --all-targets -D warnings` clean.
- **Frontend:** `useOnboarding` hook, wizard component, and settings wiring — **38 tests pass**. Onboarding files lint clean; `typecheck` passes.

## Not covered

No end-to-end run of the wizard in the actual app yet — the logic and component are unit-tested, but a manual click-through on a fresh profile is worth doing before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)