### PR TITLE
chore(deny): enforce `unsound` advisories (scope = all)

### DIFF
--- a/src-tauri/deny.toml
+++ b/src-tauri/deny.toml
@@ -11,6 +11,12 @@ all-features = false
 version = 2
 yanked = "deny"
 unmaintained = "workspace"
+# Enforce `unsound` informational advisories. "all" (not "workspace") so
+# transitive crates are covered — the unsound advisory we actually care
+# about (glib, RUSTSEC-2024-0429, below) reaches us only transitively via
+# Tauri's GTK3 backend, so a workspace-only scope would never surface it
+# and the ignore below would be dead config.
+unsound = "all"
 ignore = [
   # RUSTSEC-2024-0429: glib's VariantStrIter has unsound Iterator /
   # DoubleEndedIterator impls. No patched glib version exists yet; it is a


### PR DESCRIPTION
## Summary

cargo-deny wasn't enforcing `unsound` informational advisories — the `unsound` key was unset in `deny.toml`, so it defaulted to off. The side effect: the existing `RUSTSEC-2024-0429` (glib) ignore was **dead config**. cargo-deny never evaluated the advisory, so the ignore was never used (it reported `advisory-not-detected: no crate matched`), and any *new* unsound advisory would have passed the audit silently.

This sets `unsound = "all"`.

## Why scope `"all"`

The glib advisory reaches us only **transitively** (Tauri's Linux GTK3 backend → gtk 0.18 → glib 0.18.5). A `"workspace"` scope — like the repo uses for `unmaintained` — would never surface a transitive advisory, leaving the ignore dead and the enforcement toothless. `"all"` is what makes both the existing ignore meaningful and future transitive unsound advisories visible.

## Verification

- `cargo deny check` → `advisories ok, bans ok, licenses ok, sources ok` (no warnings; the `advisory-not-detected` warning is gone because glib is now actually matched and ignored).
- Removing the glib ignore now makes the check **fail** with `error[unsound]: ... glib::VariantStrIter`, confirming enforcement is live rather than silently passing.

The `advisory` CI job is `continue-on-error` (advisory-only, surfaced in the sticky comment), so this doesn't newly block merges — it just stops the whole `unsound` class from being ignored.

Context: surfaced while triaging #125.

🤖 Generated with [Claude Code](https://claude.com/claude-code)