### PR TITLE
chore(release): prep v0.0.6 — version bump + CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Versions on the `0.0.X` line are public beta releases; `0.1.X` and onwards will 
 
 ## [Unreleased]
 
+## [0.0.6] — 2026-06-06
+
 ### Added
 
 - **Postponing and skipping can now be turned on or off per break type.** The Breaks tab gains separate toggles for micro and long breaks, so you can (for example) allow skipping a micro break but never a long one, or postpone long breaks while micro breaks stay fixed. When a break type can't be skipped, its overlay drops the Skip button and Escape no longer dismisses it. Existing settings are preserved on upgrade — your current postpone and skip behaviour is unchanged until you touch the new switches. ([#132](https://github.com/drmowinckels/entracte/issues/132))

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "entracte-desktop",
   "private": true,
-  "version": "0.0.5",
+  "version": "0.0.6",
   "type": "module",
   "engines": {
     "node": ">=20"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1235,7 +1235,7 @@ checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
 
 [[package]]
 name = "entracte"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "entracte"
-version = "0.0.5"
+version = "0.0.6"
 description = "Cross-platform break reminder"
 authors = ["Athanasia Mowinckel"]
 license = "Apache-2.0"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Entracte",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "identifier": "io.drmowinckels.entracte",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary

Release prep for **v0.0.6** (next beta on the `0.0.X` line). Bumps the version across `package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`, and `src-tauri/Cargo.lock`, and dates the CHANGELOG `[Unreleased]` section as `[0.0.6] — 2026-06-06` (fresh empty `[Unreleased]` retained on top).

### Shipping in v0.0.6
**Added**
- Per-break-type postpone/skip toggles (#132)
- First-run onboarding wizard (#142)

**Changed**
- `entracte settings set …` now clamps out-of-range values like the GUI

**Fixed**
- Pre-break notifications now appear on macOS (#135)
- Break overlays no longer pile two windows onto one monitor on Wayland (#67)
- Resuming after a pause no longer fires a break instantly / shows `0:00` (#134)
- A wedged system tool can no longer stall break detection
- Break/pause hooks no longer leave stray processes behind
- Restoring a backup from a newer Entracte no longer fails wholesale (#137)
- Preferences window controls respond immediately on GNOME/Wayland (#139)
- Tray icon visible on dark Linux/Windows panels (#86)

## Test Plan
- `cargo check` (lib): compiles as `entracte v0.0.6`, lockfile consistent
- Full suite on the merged `main` ahead of this prep: `cargo test --lib` 838 passed; `vitest` 597 passed (58 files)
- No code changes here — version + changelog only.

After merge, push the annotated `v0.0.6` tag to trigger the release build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)