### PR TITLE
feat(plugins): manifest parse/validate + signature core (#156)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -11,6 +11,7 @@ mod media;
 mod notifications;
 mod pause_store;
 mod platform;
+mod plugins;
 mod proc;
 mod renderer_log;
 mod scheduler;

--- a/src-tauri/src/plugins/manifest.rs
+++ b/src-tauri/src/plugins/manifest.rs
@@ -1,0 +1,477 @@
+//! Plugin manifest types, parsing, and validation. Pure — no I/O.
+//!
+//! The manifest is versioned (`MANIFEST_VERSION`) like the content-pack
+//! format. Validation is first-error-wins with user-facing messages, the
+//! same shape as `content_pack::validate_pack`. The load-time half of the
+//! capability model lives here: a code-bearing plugin's declared `imports`
+//! must all be valid capabilities, and a content plugin must declare none.
+//! The runtime half (checking the module's actual wasm import section
+//! against this list, and per-call scope enforcement) lands with the
+//! runtime slice.
+
+use serde::{Deserialize, Serialize};
+
+/// Manifest schema version this build reads and writes. Bumped only on a
+/// breaking change to the manifest shape.
+pub const MANIFEST_VERSION: u32 = 1;
+
+/// Host-function ABI version this build exposes to wasm modules. A module
+/// built against a different ABI is refused rather than mis-bound.
+pub const SUPPORTED_ABI_VERSION: u32 = 1;
+
+/// Defensive caps so a malformed or hostile manifest can't bloat state or
+/// stall the UI. Generous relative to any hand-authored plugin.
+const MAX_STRING_LEN: usize = 1_000;
+const MAX_ID_LEN: usize = 128;
+const MAX_IMPORTS: usize = 16;
+const MAX_SCOPE_LEN: usize = 512;
+
+/// Which extension point a plugin provides. Exactly one per manifest.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum PluginKind {
+    Content,
+    Detector,
+    Export,
+}
+
+impl PluginKind {
+    /// Whether this kind ships an executable wasm module (and therefore must
+    /// declare a `module`, an `abi_version`, and at least one import).
+    fn is_code_bearing(self) -> bool {
+        matches!(self, PluginKind::Detector | PluginKind::Export)
+    }
+}
+
+/// A host-function capability a module imports. Serialised as the
+/// colon-delimited string form used in the manifest's `imports` array and
+/// shown verbatim in the consent dialog. Scoped variants carry the exact
+/// path / origin the grant is bound to.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Capability {
+    /// Read the foreground window title.
+    DetectForegroundWindow,
+    /// Check whether a named process is running (host does the matching).
+    DetectProcesses,
+    /// Read a host-scoped sentinel value under a granted path.
+    DetectFile(String),
+    /// Write break stats to a path under the granted scope.
+    ExportFile(String),
+    /// POST break stats to the granted origin — the only capability that
+    /// can leave the machine.
+    ExportHttp(String),
+}
+
+impl Capability {
+    /// Parse a capability from its manifest string form. Scoped forms carry
+    /// the scope after the second colon (`export:http:<origin>`); the scope
+    /// itself may contain colons (e.g. `host:port`), so we split only twice.
+    pub fn parse(raw: &str) -> Result<Self, String> {
+        let unscoped = match raw {
+            "detect:foreground-window" => Some(Capability::DetectForegroundWindow),
+            "detect:processes" => Some(Capability::DetectProcesses),
+            _ => None,
+        };
+        if let Some(cap) = unscoped {
+            return Ok(cap);
+        }
+
+        let (prefix, scope) = raw
+            .split_once(':')
+            .and_then(|(head, rest)| rest.split_once(':').map(|(mid, tail)| (head, mid, tail)))
+            .map(|(head, mid, tail)| (format!("{head}:{mid}"), tail))
+            .ok_or_else(|| format!("unknown capability '{raw}'"))?;
+
+        if scope.trim().is_empty() {
+            return Err(format!("capability '{raw}' is missing a scope"));
+        }
+        if scope.chars().count() > MAX_SCOPE_LEN {
+            return Err(format!("capability '{prefix}' scope is too long"));
+        }
+        match prefix.as_str() {
+            "detect:file" => Ok(Capability::DetectFile(scope.to_string())),
+            "export:file" => Ok(Capability::ExportFile(scope.to_string())),
+            "export:http" => Ok(Capability::ExportHttp(scope.to_string())),
+            _ => Err(format!("unknown capability '{raw}'")),
+        }
+    }
+
+    /// The canonical manifest/consent string form, round-tripping [`parse`].
+    pub fn as_string(&self) -> String {
+        match self {
+            Capability::DetectForegroundWindow => "detect:foreground-window".to_string(),
+            Capability::DetectProcesses => "detect:processes".to_string(),
+            Capability::DetectFile(s) => format!("detect:file:{s}"),
+            Capability::ExportFile(s) => format!("export:file:{s}"),
+            Capability::ExportHttp(s) => format!("export:http:{s}"),
+        }
+    }
+
+    /// Whether this capability is meaningful for the given plugin kind — a
+    /// detector cannot import an `export:*` function and vice versa.
+    fn allowed_for(&self, kind: PluginKind) -> bool {
+        match self {
+            Capability::DetectForegroundWindow
+            | Capability::DetectProcesses
+            | Capability::DetectFile(_) => kind == PluginKind::Detector,
+            Capability::ExportFile(_) | Capability::ExportHttp(_) => kind == PluginKind::Export,
+        }
+    }
+}
+
+/// The detached signature over `canonical(manifest-without-signature)` plus
+/// the module hash. ed25519; keys and signature are base64.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Signature {
+    pub alg: String,
+    pub public_key: String,
+    pub sig: String,
+}
+
+/// A parsed plugin manifest. The `content` payload is left as a raw JSON
+/// value at this slice; the content-provider slice swaps in the typed
+/// `content_pack::ContentPack` when it wires the merge path.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Manifest {
+    pub manifest_version: u32,
+    pub id: String,
+    pub name: String,
+    pub version: String,
+    #[serde(default)]
+    pub author: String,
+    #[serde(default)]
+    pub description: String,
+    pub kind: PluginKind,
+    #[serde(default)]
+    pub module: Option<String>,
+    #[serde(default)]
+    pub abi_version: Option<u32>,
+    #[serde(default)]
+    pub imports: Vec<String>,
+    #[serde(default)]
+    pub content: Option<serde_json::Value>,
+    pub signature: Signature,
+}
+
+/// Parse a manifest from JSON, mapping serde errors to a user-facing string.
+/// Does not validate beyond shape — call [`validate_manifest`] next.
+pub fn parse_manifest(json: &str) -> Result<Manifest, String> {
+    serde_json::from_str(json).map_err(|e| format!("not a valid plugin manifest: {e}"))
+}
+
+fn check_string(value: &str, what: &str) -> Result<(), String> {
+    if value.chars().count() > MAX_STRING_LEN {
+        return Err(format!("{what} exceeds {MAX_STRING_LEN} characters"));
+    }
+    Ok(())
+}
+
+/// A reverse-DNS-ish id: non-empty, lowercase `[a-z0-9.-]`, at least one
+/// dot, length-capped. Kept pragmatic — it's a uniqueness key, not a
+/// security boundary.
+fn validate_id(id: &str) -> Result<(), String> {
+    if id.trim().is_empty() {
+        return Err("plugin is missing an id".to_string());
+    }
+    if id.chars().count() > MAX_ID_LEN {
+        return Err(format!("plugin id exceeds {MAX_ID_LEN} characters"));
+    }
+    if !id.contains('.') {
+        return Err("plugin id must be reverse-DNS (e.g. com.example.name)".to_string());
+    }
+    if !id
+        .chars()
+        .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '.' || c == '-')
+    {
+        return Err("plugin id may only contain a-z, 0-9, '.', and '-'".to_string());
+    }
+    Ok(())
+}
+
+/// Validate a parsed manifest: supported versions, well-formed id and name,
+/// kind/module/imports consistency, and that every import is a capability
+/// valid for the kind. The signature is verified separately
+/// ([`super::verify_signature`]). Returns a clear, user-facing error on the
+/// first problem.
+pub fn validate_manifest(m: &Manifest) -> Result<(), String> {
+    if m.manifest_version != MANIFEST_VERSION {
+        return Err(format!(
+            "unsupported manifest version {} (this build reads version {MANIFEST_VERSION})",
+            m.manifest_version
+        ));
+    }
+
+    validate_id(&m.id)?;
+
+    if m.name.trim().is_empty() {
+        return Err("plugin is missing a name".to_string());
+    }
+    check_string(&m.name, "plugin name")?;
+    if m.version.trim().is_empty() {
+        return Err("plugin is missing a version".to_string());
+    }
+    check_string(&m.version, "plugin version")?;
+    check_string(&m.author, "plugin author")?;
+    check_string(&m.description, "plugin description")?;
+
+    if m.kind.is_code_bearing() {
+        match &m.module {
+            Some(path) if !path.trim().is_empty() => check_string(path, "module path")?,
+            _ => {
+                return Err(format!("a {:?} plugin must reference a module", m.kind).to_lowercase())
+            }
+        }
+        match m.abi_version {
+            Some(v) if v == SUPPORTED_ABI_VERSION => {}
+            Some(v) => {
+                return Err(format!(
+                "unsupported ABI version {v} (this build exposes version {SUPPORTED_ABI_VERSION})"
+            ))
+            }
+            None => return Err("a code-bearing plugin must declare an abi_version".to_string()),
+        }
+        if m.imports.is_empty() {
+            return Err("a code-bearing plugin must import at least one capability".to_string());
+        }
+    } else {
+        // Content plugins are pure data: no module, no ABI, no capabilities.
+        if m.module.is_some() {
+            return Err("a content plugin must not reference a module".to_string());
+        }
+        if m.abi_version.is_some() {
+            return Err("a content plugin must not declare an abi_version".to_string());
+        }
+        if !m.imports.is_empty() {
+            return Err("a content plugin must not import capabilities".to_string());
+        }
+        if m.content.is_none() {
+            return Err("a content plugin must carry a content payload".to_string());
+        }
+    }
+
+    if m.imports.len() > MAX_IMPORTS {
+        return Err(format!(
+            "plugin imports more than {MAX_IMPORTS} capabilities"
+        ));
+    }
+    let mut seen = std::collections::HashSet::new();
+    for raw in &m.imports {
+        let cap = Capability::parse(raw)?;
+        if !seen.insert(cap.as_string()) {
+            return Err(format!("duplicate capability '{raw}'"));
+        }
+        if !cap.allowed_for(m.kind) {
+            return Err(
+                format!("capability '{raw}' is not valid for a {:?} plugin", m.kind).to_lowercase(),
+            );
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sig() -> Signature {
+        Signature {
+            alg: "ed25519".to_string(),
+            public_key: "AA==".to_string(),
+            sig: "AA==".to_string(),
+        }
+    }
+
+    fn detector_manifest() -> Manifest {
+        Manifest {
+            manifest_version: MANIFEST_VERSION,
+            id: "com.example.focus".to_string(),
+            name: "Focus detector".to_string(),
+            version: "1.0.0".to_string(),
+            author: "Jane".to_string(),
+            description: "Suppress while focused.".to_string(),
+            kind: PluginKind::Detector,
+            module: Some("module.wasm".to_string()),
+            abi_version: Some(SUPPORTED_ABI_VERSION),
+            imports: vec!["detect:foreground-window".to_string()],
+            content: None,
+            signature: sig(),
+        }
+    }
+
+    fn content_manifest() -> Manifest {
+        Manifest {
+            manifest_version: MANIFEST_VERSION,
+            id: "com.example.pack".to_string(),
+            name: "Idea pack".to_string(),
+            version: "1.0.0".to_string(),
+            author: String::new(),
+            description: String::new(),
+            kind: PluginKind::Content,
+            module: None,
+            abi_version: None,
+            imports: vec![],
+            content: Some(serde_json::json!({ "version": 1, "name": "p" })),
+            signature: sig(),
+        }
+    }
+
+    #[test]
+    fn parse_rejects_garbage() {
+        assert!(parse_manifest("{ not json").is_err());
+    }
+
+    #[test]
+    fn manifest_serde_round_trips() {
+        let json = serde_json::to_string(&detector_manifest()).unwrap();
+        let back = parse_manifest(&json).unwrap();
+        assert_eq!(back, detector_manifest());
+        assert!(json.contains("\"kind\":\"detector\""));
+    }
+
+    #[test]
+    fn capability_parse_round_trips_every_form() {
+        for raw in [
+            "detect:foreground-window",
+            "detect:processes",
+            "detect:file:/home/me/.flag",
+            "export:file:/home/me/out.csv",
+            "export:http:127.0.0.1:8080",
+        ] {
+            let cap = Capability::parse(raw).unwrap();
+            assert_eq!(cap.as_string(), raw, "round-trip for {raw}");
+        }
+    }
+
+    #[test]
+    fn capability_parse_rejects_unknown_and_unscoped() {
+        assert!(Capability::parse("detect:webcam")
+            .unwrap_err()
+            .contains("unknown"));
+        assert!(Capability::parse("export:file")
+            .unwrap_err()
+            .contains("unknown"));
+        assert!(Capability::parse("export:file:")
+            .unwrap_err()
+            .contains("missing a scope"));
+    }
+
+    #[test]
+    fn capability_http_scope_keeps_host_and_port() {
+        let cap = Capability::parse("export:http:localhost:9000").unwrap();
+        assert_eq!(cap, Capability::ExportHttp("localhost:9000".to_string()));
+    }
+
+    #[test]
+    fn validate_accepts_a_well_formed_detector() {
+        assert!(validate_manifest(&detector_manifest()).is_ok());
+    }
+
+    #[test]
+    fn validate_accepts_a_well_formed_content_plugin() {
+        assert!(validate_manifest(&content_manifest()).is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_wrong_manifest_version() {
+        let mut m = detector_manifest();
+        m.manifest_version = 99;
+        assert!(validate_manifest(&m)
+            .unwrap_err()
+            .contains("unsupported manifest version 99"));
+    }
+
+    #[test]
+    fn validate_rejects_bad_ids() {
+        let mut m = detector_manifest();
+        m.id = "missing".to_string();
+        assert!(validate_manifest(&m).unwrap_err().contains("reverse-DNS"));
+
+        m.id = "com.Example.Caps".to_string();
+        assert!(validate_manifest(&m).unwrap_err().contains("a-z"));
+
+        m.id = "  ".to_string();
+        assert!(validate_manifest(&m).unwrap_err().contains("missing an id"));
+    }
+
+    #[test]
+    fn validate_rejects_unsupported_abi() {
+        let mut m = detector_manifest();
+        m.abi_version = Some(SUPPORTED_ABI_VERSION + 1);
+        assert!(validate_manifest(&m)
+            .unwrap_err()
+            .contains("unsupported ABI version"));
+    }
+
+    #[test]
+    fn validate_requires_module_and_abi_for_code_bearing() {
+        let mut m = detector_manifest();
+        m.module = None;
+        assert!(validate_manifest(&m)
+            .unwrap_err()
+            .contains("must reference a module"));
+
+        let mut m = detector_manifest();
+        m.abi_version = None;
+        assert!(validate_manifest(&m)
+            .unwrap_err()
+            .contains("must declare an abi_version"));
+
+        let mut m = detector_manifest();
+        m.imports = vec![];
+        assert!(validate_manifest(&m)
+            .unwrap_err()
+            .contains("must import at least one capability"));
+    }
+
+    #[test]
+    fn validate_forbids_module_and_imports_on_content() {
+        let mut m = content_manifest();
+        m.module = Some("x.wasm".to_string());
+        assert!(validate_manifest(&m)
+            .unwrap_err()
+            .contains("must not reference a module"));
+
+        let mut m = content_manifest();
+        m.imports = vec!["detect:processes".to_string()];
+        assert!(validate_manifest(&m)
+            .unwrap_err()
+            .contains("must not import"));
+
+        let mut m = content_manifest();
+        m.content = None;
+        assert!(validate_manifest(&m)
+            .unwrap_err()
+            .contains("must carry a content payload"));
+    }
+
+    #[test]
+    fn validate_rejects_capability_mismatched_to_kind() {
+        let mut m = detector_manifest();
+        m.imports = vec!["export:http:127.0.0.1:8080".to_string()];
+        assert!(validate_manifest(&m)
+            .unwrap_err()
+            .contains("not valid for a detector"));
+    }
+
+    #[test]
+    fn validate_rejects_duplicate_imports() {
+        let mut m = detector_manifest();
+        m.imports = vec![
+            "detect:processes".to_string(),
+            "detect:processes".to_string(),
+        ];
+        assert!(validate_manifest(&m)
+            .unwrap_err()
+            .contains("duplicate capability"));
+    }
+
+    #[test]
+    fn validate_rejects_too_many_imports() {
+        let mut m = detector_manifest();
+        m.imports = (0..(MAX_IMPORTS + 1))
+            .map(|i| format!("detect:file:/p/{i}"))
+            .collect();
+        assert!(validate_manifest(&m).unwrap_err().contains("more than"));
+    }
+}

--- a/src-tauri/src/plugins/manifest.rs
+++ b/src-tauri/src/plugins/manifest.rs
@@ -96,7 +96,7 @@ impl Capability {
         }
     }
 
-    /// The canonical manifest/consent string form, round-tripping [`parse`].
+    /// The canonical manifest/consent string form, round-tripping [`Self::parse`].
     pub fn as_string(&self) -> String {
         match self {
             Capability::DetectForegroundWindow => "detect:foreground-window".to_string(),

--- a/src-tauri/src/plugins/manifest.rs
+++ b/src-tauri/src/plugins/manifest.rs
@@ -474,4 +474,55 @@ mod tests {
             .collect();
         assert!(validate_manifest(&m).unwrap_err().contains("more than"));
     }
+
+    #[test]
+    fn capability_parse_rejects_overlong_scope() {
+        let raw = format!("detect:file:{}", "a".repeat(MAX_SCOPE_LEN + 1));
+        assert!(Capability::parse(&raw).unwrap_err().contains("too long"));
+    }
+
+    #[test]
+    fn capability_parse_rejects_unknown_scoped_prefix() {
+        assert!(Capability::parse("foo:bar:baz")
+            .unwrap_err()
+            .contains("unknown"));
+    }
+
+    #[test]
+    fn validate_rejects_overlong_string_field() {
+        let mut m = detector_manifest();
+        m.description = "a".repeat(MAX_STRING_LEN + 1);
+        assert!(validate_manifest(&m).unwrap_err().contains("exceeds"));
+    }
+
+    #[test]
+    fn validate_rejects_overlong_id() {
+        let mut m = detector_manifest();
+        m.id = format!("com.{}", "a".repeat(MAX_ID_LEN));
+        assert!(validate_manifest(&m).unwrap_err().contains("exceeds"));
+    }
+
+    #[test]
+    fn validate_rejects_empty_name_and_version() {
+        let mut m = detector_manifest();
+        m.name = "   ".to_string();
+        assert!(validate_manifest(&m)
+            .unwrap_err()
+            .contains("missing a name"));
+
+        let mut m = detector_manifest();
+        m.version = String::new();
+        assert!(validate_manifest(&m)
+            .unwrap_err()
+            .contains("missing a version"));
+    }
+
+    #[test]
+    fn validate_forbids_abi_version_on_content() {
+        let mut m = content_manifest();
+        m.abi_version = Some(SUPPORTED_ABI_VERSION);
+        assert!(validate_manifest(&m)
+            .unwrap_err()
+            .contains("must not declare an abi_version"));
+    }
 }

--- a/src-tauri/src/plugins/mod.rs
+++ b/src-tauri/src/plugins/mod.rs
@@ -1,0 +1,32 @@
+//! Local-only plugin API (#156): the parse / validate / signature-verify
+//! core for plugin manifests. This is slice 1 of the staged plan in
+//! `docs/developer/plugin-api-design.md` — pure functions only, no runtime,
+//! no bundle I/O, no IPC. Those land in later slices; keeping this layer
+//! pure mirrors how `scheduler::content_pack` landed before its commands.
+//!
+//! A plugin is a signed bundle whose root is a `manifest.json`. The manifest
+//! declares one `kind` (content / detector / export). Code-bearing kinds
+//! reference a wasm `module` and list the host-function capabilities it
+//! `imports`; each import is a permission request the user must grant. The
+//! signature binds the manifest **and** the module's hash, so a tampered
+//! module fails verification even if the manifest is untouched.
+
+// This is the foundational slice: the parse/validate/verify core has no
+// in-crate callers yet (the install/consent commands and the wasm runtime
+// that consume it land in later slices per the design doc's staging plan),
+// so its items read as dead in the non-test build. The allow is scoped to
+// this module and removed as soon as the next slice wires in a caller.
+#![allow(dead_code)]
+
+mod manifest;
+mod signature;
+
+// The module's public surface, re-exported so this slice defines the API in
+// one place even before anything consumes it.
+#[allow(unused_imports)]
+pub use manifest::{
+    parse_manifest, validate_manifest, Capability, Manifest, PluginKind, Signature,
+    MANIFEST_VERSION, SUPPORTED_ABI_VERSION,
+};
+#[allow(unused_imports)]
+pub use signature::{sha256, verify_signature};

--- a/src-tauri/src/plugins/signature.rs
+++ b/src-tauri/src/plugins/signature.rs
@@ -32,9 +32,10 @@ pub fn sha256(bytes: &[u8]) -> [u8; 32] {
 /// the signer and the verifier produce identical input.
 pub fn signing_payload(manifest: &Manifest, module_sha256: Option<[u8; 32]>) -> Vec<u8> {
     let mut value = serde_json::to_value(manifest).expect("manifest is always serialisable");
-    if let Some(obj) = value.as_object_mut() {
-        obj.remove("signature");
-    }
+    value
+        .as_object_mut()
+        .expect("a manifest always serialises to a JSON object")
+        .remove("signature");
     let mut bytes = serde_json::to_vec(&value).expect("json value is always serialisable");
     if let Some(hash) = module_sha256 {
         bytes.extend_from_slice(&hash);
@@ -202,6 +203,47 @@ mod tests {
         assert!(verify_signature(&m, None)
             .unwrap_err()
             .contains("64-byte ed25519 signature"));
+    }
+
+    #[test]
+    fn rejects_public_key_of_wrong_length() {
+        // Valid base64 but decodes to fewer than 32 bytes.
+        let mut m = unsigned_detector();
+        m.signature.public_key = BASE64_STANDARD.encode([0u8; 10]);
+        m.signature.sig = BASE64_STANDARD.encode([0u8; 64]);
+        assert!(verify_signature(&m, None)
+            .unwrap_err()
+            .contains("not a 32-byte ed25519 key"));
+    }
+
+    #[test]
+    fn rejects_a_32_byte_value_that_is_not_a_valid_curve_point() {
+        use ed25519_dalek::VerifyingKey;
+        // Decodes to 32 bytes (so the length check passes) but is not a
+        // valid compressed Edwards point, so VerifyingKey::from_bytes fails.
+        // Search deterministically for such an encoding — not every 32-byte
+        // value decompresses (e.g. [0xFF; 32] happens to), so pick one that
+        // genuinely doesn't.
+        let invalid = (0u8..=255)
+            .map(|b| [b; 32])
+            .find(|bytes| VerifyingKey::from_bytes(bytes).is_err())
+            .expect("some [b; 32] is not a valid curve point");
+        let mut m = unsigned_detector();
+        m.signature.public_key = BASE64_STANDARD.encode(invalid);
+        m.signature.sig = BASE64_STANDARD.encode([0u8; 64]);
+        assert!(verify_signature(&m, None)
+            .unwrap_err()
+            .contains("not a valid ed25519 key"));
+    }
+
+    #[test]
+    fn rejects_sig_that_is_not_valid_base64() {
+        let mut m = unsigned_detector();
+        m.signature.public_key = BASE64_STANDARD.encode([0u8; 32]);
+        m.signature.sig = "not base64!!!".to_string();
+        assert!(verify_signature(&m, None)
+            .unwrap_err()
+            .contains("sig is not valid base64"));
     }
 
     #[test]

--- a/src-tauri/src/plugins/signature.rs
+++ b/src-tauri/src/plugins/signature.rs
@@ -1,0 +1,220 @@
+//! Manifest signature verification. Pure — no I/O.
+//!
+//! Signing protects integrity and provenance, not authorization (that's the
+//! consent dialog, a later slice). A valid signature means "this manifest
+//! and module are intact and were produced by the holder of this key."
+//!
+//! The signed payload is `canonical(manifest-without-signature) ‖
+//! module_hash`, so the signature binds the wasm module's bytes, not just
+//! the metadata — a swapped module fails verification even with an
+//! untouched manifest. Content plugins carry no module, so their payload
+//! omits the hash. Canonicalisation is `serde_json` over the manifest value
+//! with the `signature` key removed; serde_json's default `Map` is
+//! key-ordered, so the bytes are reproducible by the signing tool.
+
+use base64::prelude::{Engine, BASE64_STANDARD};
+use ed25519_dalek::{Signature as DalekSignature, VerifyingKey};
+use sha2::{Digest, Sha256};
+
+use super::manifest::Manifest;
+
+/// SHA-256 of `bytes`, as a fixed 32-byte array. Used to hash a plugin's
+/// wasm module for inclusion in the signed payload.
+pub fn sha256(bytes: &[u8]) -> [u8; 32] {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    hasher.finalize().into()
+}
+
+/// The exact bytes a manifest's signature is computed over: the manifest
+/// serialised to JSON with its `signature` field removed, followed by the
+/// module hash (when the plugin ships one). Pure and deterministic, so both
+/// the signer and the verifier produce identical input.
+pub fn signing_payload(manifest: &Manifest, module_sha256: Option<[u8; 32]>) -> Vec<u8> {
+    let mut value = serde_json::to_value(manifest).expect("manifest is always serialisable");
+    if let Some(obj) = value.as_object_mut() {
+        obj.remove("signature");
+    }
+    let mut bytes = serde_json::to_vec(&value).expect("json value is always serialisable");
+    if let Some(hash) = module_sha256 {
+        bytes.extend_from_slice(&hash);
+    }
+    bytes
+}
+
+/// Verify a manifest's ed25519 signature over [`signing_payload`]. Pass the
+/// module's [`sha256`] for code-bearing plugins, `None` for content
+/// plugins. Returns a user-facing error string on any failure (wrong alg,
+/// malformed key/signature, or a verification mismatch) — never panics.
+pub fn verify_signature(
+    manifest: &Manifest,
+    module_sha256: Option<[u8; 32]>,
+) -> Result<(), String> {
+    if manifest.signature.alg != "ed25519" {
+        return Err(format!(
+            "unsupported signature algorithm '{}' (expected ed25519)",
+            manifest.signature.alg
+        ));
+    }
+
+    let key_bytes: [u8; 32] = BASE64_STANDARD
+        .decode(manifest.signature.public_key.as_bytes())
+        .map_err(|_| "signature public_key is not valid base64".to_string())?
+        .try_into()
+        .map_err(|_| "signature public_key is not a 32-byte ed25519 key".to_string())?;
+    let verifying_key = VerifyingKey::from_bytes(&key_bytes)
+        .map_err(|_| "signature public_key is not a valid ed25519 key".to_string())?;
+
+    let sig_bytes: [u8; 64] = BASE64_STANDARD
+        .decode(manifest.signature.sig.as_bytes())
+        .map_err(|_| "signature sig is not valid base64".to_string())?
+        .try_into()
+        .map_err(|_| "signature sig is not a 64-byte ed25519 signature".to_string())?;
+    let signature = DalekSignature::from_bytes(&sig_bytes);
+
+    let payload = signing_payload(manifest, module_sha256);
+    verifying_key
+        .verify_strict(&payload, &signature)
+        .map_err(|_| "signature does not match the manifest (tampered or wrong key)".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::plugins::manifest::{
+        PluginKind, Signature, MANIFEST_VERSION, SUPPORTED_ABI_VERSION,
+    };
+    use ed25519_dalek::{Signer, SigningKey};
+
+    /// A deterministic keypair from a fixed seed — no RNG dependency, and
+    /// reproducible across test runs.
+    fn keypair(seed: u8) -> SigningKey {
+        SigningKey::from_bytes(&[seed; 32])
+    }
+
+    fn unsigned_detector() -> Manifest {
+        Manifest {
+            manifest_version: MANIFEST_VERSION,
+            id: "com.example.focus".to_string(),
+            name: "Focus detector".to_string(),
+            version: "1.0.0".to_string(),
+            author: "Jane".to_string(),
+            description: String::new(),
+            kind: PluginKind::Detector,
+            module: Some("module.wasm".to_string()),
+            abi_version: Some(SUPPORTED_ABI_VERSION),
+            imports: vec!["detect:foreground-window".to_string()],
+            content: None,
+            signature: Signature {
+                alg: "ed25519".to_string(),
+                public_key: String::new(),
+                sig: String::new(),
+            },
+        }
+    }
+
+    /// Sign `manifest` in place with `key` over its current payload.
+    fn sign(manifest: &mut Manifest, key: &SigningKey, module_sha256: Option<[u8; 32]>) {
+        manifest.signature.public_key = BASE64_STANDARD.encode(key.verifying_key().to_bytes());
+        let payload = signing_payload(manifest, module_sha256);
+        let sig = key.sign(&payload);
+        manifest.signature.sig = BASE64_STANDARD.encode(sig.to_bytes());
+    }
+
+    #[test]
+    fn sha256_is_stable_and_32_bytes() {
+        let a = sha256(b"hello");
+        let b = sha256(b"hello");
+        assert_eq!(a, b);
+        assert_eq!(a.len(), 32);
+        assert_ne!(sha256(b"hello"), sha256(b"world"));
+    }
+
+    #[test]
+    fn verifies_a_correctly_signed_manifest() {
+        let module = b"\0asm fake module";
+        let hash = sha256(module);
+        let key = keypair(7);
+        let mut m = unsigned_detector();
+        sign(&mut m, &key, Some(hash));
+        assert!(verify_signature(&m, Some(hash)).is_ok());
+    }
+
+    #[test]
+    fn rejects_a_tampered_manifest_field() {
+        let module = b"\0asm fake module";
+        let hash = sha256(module);
+        let key = keypair(7);
+        let mut m = unsigned_detector();
+        sign(&mut m, &key, Some(hash));
+        // Mutate a signed field after signing.
+        m.name = "Evil detector".to_string();
+        assert!(verify_signature(&m, Some(hash))
+            .unwrap_err()
+            .contains("does not match"));
+    }
+
+    #[test]
+    fn rejects_a_swapped_module() {
+        let key = keypair(7);
+        let mut m = unsigned_detector();
+        let original = sha256(b"\0asm original");
+        sign(&mut m, &key, Some(original));
+        // Same manifest, different module bytes ⇒ different hash ⇒ fail.
+        let swapped = sha256(b"\0asm malicious");
+        assert!(verify_signature(&m, Some(swapped))
+            .unwrap_err()
+            .contains("does not match"));
+    }
+
+    #[test]
+    fn rejects_a_wrong_key() {
+        let module = b"\0asm fake module";
+        let hash = sha256(module);
+        let mut m = unsigned_detector();
+        sign(&mut m, &keypair(1), Some(hash));
+        // Re-point the public key at a different keypair without re-signing.
+        m.signature.public_key = BASE64_STANDARD.encode(keypair(2).verifying_key().to_bytes());
+        assert!(verify_signature(&m, Some(hash)).is_err());
+    }
+
+    #[test]
+    fn rejects_non_ed25519_alg() {
+        let mut m = unsigned_detector();
+        m.signature.alg = "rsa".to_string();
+        assert!(verify_signature(&m, None)
+            .unwrap_err()
+            .contains("unsupported signature algorithm"));
+    }
+
+    #[test]
+    fn rejects_malformed_key_and_sig() {
+        let mut m = unsigned_detector();
+        m.signature.public_key = "not base64!!!".to_string();
+        m.signature.sig = "AA==".to_string();
+        assert!(verify_signature(&m, None)
+            .unwrap_err()
+            .contains("public_key is not valid base64"));
+
+        let mut m = unsigned_detector();
+        m.signature.public_key = BASE64_STANDARD.encode([0u8; 32]);
+        m.signature.sig = BASE64_STANDARD.encode([0u8; 10]); // wrong length
+        assert!(verify_signature(&m, None)
+            .unwrap_err()
+            .contains("64-byte ed25519 signature"));
+    }
+
+    #[test]
+    fn content_plugin_signs_without_a_module_hash() {
+        let key = keypair(9);
+        let mut m = unsigned_detector();
+        m.kind = PluginKind::Content;
+        m.module = None;
+        m.abi_version = None;
+        m.imports = vec![];
+        sign(&mut m, &key, None);
+        assert!(verify_signature(&m, None).is_ok());
+        // A content plugin verified as if it had a module must fail.
+        assert!(verify_signature(&m, Some(sha256(b"x"))).is_err());
+    }
+}


### PR DESCRIPTION
## Summary

Slice 1 of the local-only plugin API. The design doc (#166) settles the model — a WASM capability sandbox with signed manifests — and this is the first implementation slice: the **pure parse / validate / signature-verify core**, with no runtime, no bundle I/O, and no IPC. It mirrors how `scheduler::content_pack` landed its pure logic before the commands that drive it.

New module `src-tauri/src/plugins/`:

- **`manifest.rs`** — the manifest envelope, versioned (`MANIFEST_VERSION`), one `kind` per plugin (content / detector / export). Carries the **load-time half of the capability model**: a code-bearing plugin must declare a `module`, a supported `abi_version`, and ≥1 import; a content plugin must declare none and carry a payload. `Capability` is typed and scoped (`detect:*`, `export:file`/`export:http`), round-trips its colon-string manifest form, and is validated against the plugin kind (a detector can't import `export:*`).
- **`signature.rs`** — ed25519 verification over `canonical(manifest-without-signature) ‖ sha256(module)`, so the signature binds the wasm module's bytes, not just metadata. Canonicalisation is key-ordered JSON (deterministic, reproducible by the signing tool). All-error-paths-return-`Err`, never panics.

The runtime half of the capability model (cross-checking the module's actual wasm import section, per-call scope enforcement) lands with the runtime slice.

## Test Plan

- **23 new unit tests**, all green; full Rust lib suite **920 passed**.
- Coverage: manifest serde round-trip; every validation branch (version, id shape, kind/module/abi/imports consistency, capability↔kind mismatch, duplicate/too-many imports); signature happy path; and the **tamper / swapped-module / wrong-key / non-ed25519 / malformed-base64** rejection paths.
- `cargo fmt --check`, `cargo clippy --all-targets`, and `cspell` all clean. No new dependencies (ed25519-dalek / sha2 / base64 already in `Cargo.toml`).

A module-scoped `#![allow(dead_code)]` covers the core until the next slice wires in a caller; the comment ties it to the staging plan and it's removed then.

Refs #156. Builds on the design in #166.

🤖 Generated with [Claude Code](https://claude.com/claude-code)