### PR TITLE
docs: fix broken intra-doc links failing the preview cargo-doc step

### DIFF
--- a/src-tauri/src/scheduler/settings.rs
+++ b/src-tauri/src/scheduler/settings.rs
@@ -489,7 +489,7 @@ pub struct Settings {
     pub show_hint: bool,
     pub monitor_placement: MonitorPlacement,
     /// Fraction of the monitor a windowed-mode break overlay fills,
-    /// clamped to `[0.1, 1.0]` by [`centered_windowed_rect`]. Defaults to
+    /// clamped to `[0.1, 1.0]` by [`crate::scheduler::overlay::centered_windowed_rect`]. Defaults to
     /// `0.8` — the historical hardcoded value — so existing users see no
     /// change. Per-kind overrides below take precedence when set; the
     /// effective value is resolved by [`windowed_fraction_for`].
@@ -1063,7 +1063,7 @@ pub fn is_windowed_mode(kind: BreakKind, s: &Settings) -> bool {
 /// Resolve the windowed-overlay size fraction for a break kind: the
 /// per-kind override when set, otherwise the global `windowed_fraction`.
 /// The result is clamped to `[0.1, 1.0]` (matching
-/// [`centered_windowed_rect`]) so a corrupt on-disk value can't size the
+/// [`crate::scheduler::overlay::centered_windowed_rect`]) so a corrupt on-disk value can't size the
 /// overlay off-screen. Sleep has no override and falls back to the global
 /// value (it never renders windowed anyway).
 pub fn windowed_fraction_for(kind: BreakKind, s: &Settings) -> f64 {

--- a/src-tauri/src/window.rs
+++ b/src-tauri/src/window.rs
@@ -11,7 +11,7 @@ use tauri::{Manager, Runtime};
 ///
 /// Pure so the "which size forces a configure" decision is unit-testable
 /// without a windowing system; the actual `set_size` FFI stays in
-/// [`nudge_configure`].
+/// `nudge_configure` (Linux-only, so not linked here).
 #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
 fn nudged_dimension(value: u32) -> u32 {
     value.checked_add(1).unwrap_or_else(|| value - 1)


### PR DESCRIPTION
## Summary

The `preview` job runs `cargo doc -D warnings`, which turns `rustdoc::broken-intra-doc-links` into a hard error. Three links on `main` were unresolved, so **`preview` has been failing on every PR** (e.g. #166, #167) regardless of its contents:

- `[`centered_windowed_rect`]` in `scheduler/settings.rs` (×2) — referenced unqualified, but the symbol lives in `scheduler::overlay`. Unresolved on all OSes. Fixed with the full crate path.
- `[`nudge_configure`]` in `window.rs` — points at a `#[cfg(target_os = "linux")]` fn, so it resolved on the Linux CI runner but broke `cargo doc` for macOS devs locally. Demoted to a plain `` `code span` `` since a cfg-gated item can't be linked cross-platform.

No behaviour change — doc comments only.

## Test Plan

- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --document-private-items` now finishes clean on macOS (previously errored on all three links).
- Unblocks the `preview` check repo-wide; #166 and #167 go green on `preview` once this merges and they pick up `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)