### PR TITLE
docs(plugins): design doc for local-only plugin API (#156)

### DIFF
--- a/.github/audit/cspell/project-words.txt
+++ b/.github/audit/cspell/project-words.txt
@@ -184,3 +184,9 @@ winddown
 cmdorctrl
 commandorcontrol
 xoxp
+wasmtime
+extism
+WASI
+removability
+ungranted
+unsandboxed

--- a/docs/developer/index.md
+++ b/docs/developer/index.md
@@ -4,4 +4,6 @@ If you've never touched the code, **[Architecture internals](./architecture-inte
 
 The user-facing [Architecture](../architecture/) section covers the high-level "how Entracte works" — useful as a refresher but not where to start when you're editing the code.
 
+**[Plugin API design](./plugin-api-design)** is the review-gate design doc for the longer-term local-only plugin API ([#156](https://github.com/drmowinckels/entracte/issues/156)) — it settles the security boundary, manifest schema, permission model, and threat model before any implementation.
+
 **[Releases](./releases)** describes the tag-triggered pipeline that cuts and signs bundles, and where the in-app updater fits in. The **API references** ([Rust](./rust-api) via `rustdoc` over the Tauri crate with private items, [TypeScript](./ts-api) via `typedoc` over the React frontend) are flat browsers over every symbol in the source tree with the same one-line summaries that appear in IDE hovers — useful when you remember a name but not where it lives.

--- a/docs/developer/plugin-api-design.md
+++ b/docs/developer/plugin-api-design.md
@@ -38,105 +38,117 @@ Entracte already has two precedents at opposite ends of the safety spectrum, and
 
 The plugin API's whole purpose is **distributable third-party extensions**. That rules out the hooks trust model: hooks are safe _because_ they are not meant to be shared, and the moment we encourage installing executables authored by strangers we have reintroduced the hooks risk surface to an audience that did not write the code. A privacy-first app cannot ship "download this binary from a forum and grant it your break history" as a first-class feature.
 
-So the design question is not "how do we sandbox a subprocess" — it is **"what is the least powerful execution model that still satisfies the three extension points?"** The answer differs per extension point, which gives us a tiered design.
+So the design question is: **what execution model lets a stranger's logic extend the app while keeping "no cloud / no account / explicit permission" enforced rather than promised?**
 
 ### Three candidate execution models
 
-- **A — Declarative.** Plugins are manifest + data only. The host implements a fixed vocabulary of behaviours; the plugin selects and configures them. No third-party code runs. Permissions are _enforced_ because the host performs every sensitive action itself.
-- **B — Native subprocess.** Plugin ships an executable invoked over a stdio JSON protocol. Powerful and easy (reuses `proc::reap_or_kill`, detached stdio, timeouts from `hooks.rs`), but **once spawned it has the user's full privileges** — declared "permissions" are honour-system, not enforced. This is hooks with extra ceremony.
-- **C — WASM capability sandbox.** Plugin ships a `.wasm` module; the host exposes only the host-functions a granted permission unlocks. No ambient network or filesystem. Permissions are _enforced by the runtime_. True extensibility **and** true enforcement — at the cost of a wasm runtime dependency (`wasmtime`/`extism`), an ABI, and bridging into the async loop.
+- **A — Declarative.** Plugins are manifest + data only. The host implements a fixed vocabulary of behaviours; the plugin selects and configures them. No third-party code runs, so permissions are trivially enforced — but the host's fixed vocabulary _is_ the ceiling. Anything we didn't anticipate can't be expressed, which doesn't actually deliver "extend without forking" for logic.
+- **B — Native subprocess.** Plugin ships an executable invoked over a stdio protocol. Powerful and easy (reuses `proc::reap_or_kill`, detached stdio, timeouts from `hooks.rs`), but **once spawned it has the user's full privileges** — declared "permissions" are honour-system, not enforced. This is hooks with extra ceremony.
+- **C — WASM capability sandbox.** Plugin ships a `.wasm` module. The sandbox has **no ambient authority** — no syscalls, no filesystem, no clock, no network — so the module can do _nothing_ except call the host functions the host chose to import into it. Each host function corresponds to a granted capability and validates its arguments in Rust on every call. Permissions are _enforced by the runtime and the host-function boundary_, not trusted to the plugin. The cost is a wasm runtime dependency, an ABI, and bridging into the async loop.
 
-### Recommendation
+### Decision: model C from the start
 
-**Ship Tier 1 (declarative, model A) first; design the manifest and permission model so Tier 2 (WASM, model C) can be added later without a schema break; explicitly reject model B.**
+**Build the plugin API on a WASM capability sandbox (model C). Reject model B outright. Keep pure-data payloads (content) declarative — they need no sandbox.**
 
 Rationale:
 
-- Model A covers **all three extension points usefully on day one** (see §4) and is the only model where "no cloud / no account / explicit permission" is _enforced_ rather than promised. It is mostly an extension of the already-merged content-pack machinery.
-- Model B is a privacy regression over the curated content-pack model and is operationally indistinguishable from hooks — we would be re-litigating `HOOKS.md` for an audience that didn't author the code. Reject it outright and say so, so a future contributor doesn't "just shell out" because it's easy.
-- Model C is the right home for genuinely arbitrary logic (a detector that does something we never anticipated), but it is a large investment and a _longer-term_ bet within this longer-term bet. Reserving a manifest slot for it (`runtime: declarative | wasm`) lets us defer it without repainting the contract.
+- Model C is the only model that delivers **real extensibility _and_ enforced permissions** simultaneously. The product's whole pitch is "privacy enforced, not promised"; C is the execution model that honours that pitch for arbitrary third-party logic. A declarative-only API (A) would force us to predict every useful detector and export shape up front and would still leave "extend without forking" unmet for anything novel.
+- The enforcement is structural, not procedural: a sandboxed module **cannot** read a file, open a socket, or read the clock unless the host handed it a function that does — and the host only hands over functions whose capability the user granted. There is no "the plugin promised not to"; there is "the plugin physically cannot."
+- Model B is a privacy regression over the curated content-pack model and is operationally indistinguishable from hooks. Reject it explicitly and say so, so a future contributor doesn't "just shell out" because it's the easy path.
+- **Content providers stay pure data.** You do not run a sandbox to supply a list of hints. Content is a validated data block (the content-pack shape, reused), so the cheapest, highest-value extension point still ships early and carries zero execution risk. "Model C from the start" means _code-bearing_ extension points (detectors, export adapters) are WASM; data-only ones stay data.
 
-The rest of this document specifies **Tier 1** in full and sketches the Tier 2 seam.
+### The cost we are accepting
+
+Going straight to C is the more principled choice, and it is not free. Recorded here so review weighs it with eyes open:
+
+- **A wasm runtime is a non-trivial dependency** — binary-size growth and a new build/CI surface on all three OSes. The codecov multi-OS gate (memory) will see the integration code on macOS + ubuntu + windows; the runtime crate itself is vendored, not our coverage. This is a real weight increase for a break-reminder app and the single biggest argument for having started with A instead.
+- **Longer lead time before any code-bearing extension point ships.** Mitigated by landing content providers (pure data, no runtime) first, so users get value while the runtime work proceeds in parallel.
+- **An ABI we must version and support.** Once third parties compile against the host-function surface, changing it is a compatibility event. The manifest is versioned for exactly this.
 
 ## 3. Security boundary
 
-The boundary is drawn so that **installing a plugin can never, by itself, do anything a plugin's granted permissions don't explicitly allow** — and in Tier 1 every permission maps to an action the _host_ performs, so the boundary is enforced in Rust, not trusted to the plugin.
+The boundary is the **host-function ABI**. A plugin module is loaded into a sandbox with no ambient authority; the _only_ things it can do beyond pure computation are the host functions the host imports into its instance, and the host imports a function **only if the user granted the matching capability**. Every host function validates its arguments against the grant's scope in Rust, on every call.
 
 ```
-                    ┌─────────────────────────────────────────────┐
-   user picks a     │  Host (Rust) — the only code that runs        │
-   .entracte-plugin │                                               │
-   file ───────────▶│  1. read manifest + payload                   │
-                    │  2. verify signature (§5)                     │
-                    │  3. show permission consent dialog (§6)       │
-                    │  4. on grant: register declarative behaviours │
-                    │                                               │
-                    │  ┌─────────────┐  ┌─────────────┐  ┌────────┐ │
-                    │  │ content     │  │ detector    │  │ export │ │
-                    │  │ provider    │  │ (host-run   │  │ adapter│ │
-                    │  │ (data only) │  │  probe)     │  │(host I/O)│
-                    │  └─────────────┘  └─────────────┘  └────────┘ │
-                    └─────────────────────────────────────────────┘
-                          plugin payload is DATA, never an entry point
+                  ┌──────────────────────────────────────────────────────┐
+   user installs  │  Host (Rust)                                           │
+   a signed       │   1. verify signature over manifest + module (§5)     │
+   plugin bundle  │   2. consent dialog: grant per-capability (§6)        │
+   ─────────────▶ │   3. instantiate module with ONLY granted host fns    │
+                  │      (an import with no grant ⇒ refuse to load)        │
+                  │                                                        │
+                  │   ┌────────────────────────────────────────────────┐  │
+                  │   │  WASM sandbox — no syscalls, no fs, no net,      │  │
+                  │   │  no clock, no ambient anything                   │  │
+                  │   │                                                  │  │
+                  │   │   plugin module  ──imports──▶  host functions    │  │
+                  │   │   (detect / on_event)          (Rust, scope-     │  │
+                  │   │                                 checked per call)│  │
+                  │   └────────────────────────────────────────────────┘  │
+                  │                                                        │
+                  │   content payloads: pure data, never instantiated     │
+                  └──────────────────────────────────────────────────────┘
 ```
 
 Boundary invariants:
 
-1. **No ambient authority.** A plugin gets exactly the capabilities its granted permissions name, and nothing transitively. Importing a content provider grants no detector or export reach.
-2. **Host mediates every side effect.** Reading a process list (detector), writing a CSV variant, POSTing to a self-hosted endpoint (export) — all performed by host code with the granted scope, never by plugin-supplied code.
-3. **Failure is contained.** A plugin that errors, times out, or returns garbage is disabled and surfaced; it never blocks the 1Hz loop, corrupts settings, or fires/suppresses a break on its own. Detectors run on the existing snapshot-then-act discipline and a probe budget; a slow probe is treated as "no signal," never as a stall.
-4. **Settings keys are owned by the host.** As with hooks, `update_settings` cannot enable a plugin or grant a permission — only the dedicated, dialog-gated command can (mirrors `set_hooks` stripping hook fields, and the IPC denylist).
-5. **Removal is total.** Uninstalling a plugin removes its registered behaviours, its granted permissions, and any host-managed state it created. No orphaned suppression signals, no dangling export schedule.
+1. **No ambient authority.** WASI is **disabled** — the module gets no default filesystem, clock, randomness, or network. Its entire outside-world surface is the explicit host-function set. A module that imports a host function the grant doesn't cover **fails to instantiate**, with a clear "this plugin needs permission X" message — it never silently runs with the capability stubbed.
+2. **Host validates every call.** `host_write_file(path, …)` rejects any path outside the granted scope; `host_http_post(url, …)` rejects any origin but the granted one. The plugin computes _what_ to send; the host enforces _where_ it may go, in Rust, every time.
+3. **Bounded execution.** Each module call runs with a memory cap and a wall-clock/CPU time-box enforced by the runtime (see §4.4). Overrun ⇒ the call is aborted and the plugin is treated as "no signal" (detector) or "delivery failed" (export) — never a stalled 1Hz loop.
+4. **Failure is contained.** A module that traps, times out, or returns garbage is disabled and surfaced; it cannot corrupt settings, fire/suppress a break on its own, or crash the host. Detectors feed only the suppression path (§4.2).
+5. **Settings keys are owned by the host.** As with hooks, `update_settings` cannot install a plugin or grant a capability — only the dedicated, dialog-gated command can (mirrors `set_hooks` stripping hook fields, and the IPC denylist).
+6. **Removal is total.** Uninstalling drops the module, its grants, its pinned key, and any host-managed state it created. No orphaned suppression signal, no dangling export schedule.
 
-## 4. The three extension points, concretely (Tier 1)
+## 4. The three extension points, concretely
 
-### 4.1 Content providers
+### 4.1 Content providers (pure data — no sandbox)
 
-The smallest step: a content provider **is** a content pack plus a manifest. The merge path already exists (`merge_pack`, additive and non-clobbering, deduped, capped). The plugin wrapper adds provenance (who, signature) and lifecycle (a provider's content can be removed on uninstall, which raw pack import cannot do today).
+A content provider **is** a content pack plus a manifest. No module, no execution. The merge path already exists (`merge_pack`, additive and non-clobbering, deduped, capped); the plugin wrapper adds provenance (signed author) and lifecycle (a provider's content can be removed on uninstall, which raw pack import cannot do today).
 
-- **Capabilities required:** `provide:content` only. No I/O, no system access.
-- **Payload:** the existing `ContentPack` shape (`version`, `name`, `hints`, `routines`), reused unchanged.
-- **Host action on enable:** `merge_pack` into the active profile (or, better for removability, keep provider content in a separate provider-tagged layer the pools read through — decided in implementation; the _manifest_ doesn't change either way).
-- **Risk:** lowest. Validation caps already defend against bloat. This tier alone is shippable and useful.
+- **Capabilities required:** none — it touches no I/O and no system state. Installing is gated by the consent dialog for provenance, but it grants no host functions.
+- **Payload:** the existing `ContentPack` shape (`version`, `name`, `hints`, `routines`), reused unchanged, under the content-pack `MAX_*` caps.
+- **Why it stays data:** running a sandbox to return a fixed list of hints is pure overhead and pure added risk. Keeping content declarative is what lets this ship first.
 
 ### 4.2 Local context detectors (opt-in)
 
-Detectors add a suppression signal to the 1Hz decision tree (`run_loop.rs` step 5, alongside DnD / camera / video / app-pause). Today those are host-coded and feed `GuardReason` (`Dnd`, `Camera`, `Idle`, `AppPause`, `Typing`, `Video`). A detector plugin contributes a new reason.
+A detector is a WASM module exporting a `detect()` function. The host calls it on a throttled interval (not every tick, and never on the async scheduler thread — see §4.4) and feeds the boolean result into the 1Hz suppression tree (`run_loop.rs` step 5, beside DnD / camera / video / app-pause). A match suppresses with a `GuardReason::Plugin { id }` label, logged exactly like the built-ins via `log_suppressions`.
 
-In Tier 1 a detector is a **declarative probe from a fixed, host-implemented vocabulary** — the plugin describes _what to look for_, the host does the looking:
+The module reads context **only** through gated host functions it imports:
 
-- `process_running` — a process whose name matches a given pattern is running (host walks the process list; this is the privacy-sensitive part, gated by `detect:processes`).
-- `window_title_matches` — the foreground window title matches a pattern (gated by `detect:foreground-window`).
-- `file_present` / `file_flag` — a sentinel file exists / contains a truthy value under a user-chosen directory (gated by `detect:file:<scoped-path>`).
+- `host_foreground_window() -> string` — current foreground window title. Importing it requires the `detect:foreground-window` capability.
+- `host_process_running(pattern) -> bool` — whether a process name matches (the host does the matching; the raw list never enters the sandbox). Requires `detect:processes`.
+- `host_read_flag(key) -> string` — read a host-scoped sentinel value under a granted path. Requires `detect:file:<scoped-path>`.
 
-Each declarative probe is something the host can implement safely, throttle, and reason about. The detector manifest names the probe, its parameters, and a debounce. When the probe matches, the loop suppresses with a plugin-supplied `GuardReason::Plugin { id }` label (logged exactly like the built-ins via `log_suppressions`).
+The plugin composes arbitrary logic over these (this is the win over a fixed declarative vocabulary), but its reach is exactly the imports the user authorised.
 
-- **Capabilities required:** one of `detect:processes`, `detect:foreground-window`, `detect:file:<path>` — each named and consented to individually.
-- **Hard limits:** probe evaluation is time-boxed well under the 1Hz budget; a probe that overruns counts as "no match" and is logged. Per-plugin and global caps on number of detectors (mirror `MAX_HOOKS_PER_EVENT`).
-- **Why not arbitrary code here:** "run this stranger's binary every second with access to my window titles" is precisely the privacy hole the product forbids. Anything the fixed vocabulary can't express is a Tier 2 (WASM) candidate, not a reason to shell out.
-- **Anti-goal reminder:** detectors _suppress_ breaks. They can never _force_ a break, lock input, or escalate enforcement.
+- **Capabilities required:** whichever host functions the module imports — each named and consented individually.
+- **Hard limits:** memory cap + per-call time-box (§4.4); a call that overruns counts as "no match" and is logged. Per-plugin and global caps on detector count (the `MAX_HOOKS_PER_EVENT` precedent).
+- **Anti-goal reminder:** detectors _suppress_ breaks. They can never _force_ a break, lengthen one, lock input, or escalate enforcement. `detect()` returns at most "suppress / don't"; the host owns everything else.
 
 ### 4.3 Local export adapters
 
-Export adapters push break stats (the `events.jsonl` / `export_csv` surface) to a user-controlled sink. Today the only export is "Export CSV" on Insights (`export_stats_csv` → renderer Blob download). An adapter generalises the _destination_, while the host keeps ownership of _what data_ and _how it leaves_.
+An export adapter is a WASM module exporting `on_event(event_json) -> bytes` (and/or `on_digest(...)`). The host invokes it on the same scheduler events hooks already expose, hands it the break-stats payload the host assembled (from the `events.jsonl` / `export_csv` surface), and the module returns the bytes to deliver. Delivery is a gated host function:
 
-Tier 1 sinks (host-implemented, plugin-configured):
+- `host_write_file(path, bytes)` — write to a path under the granted scope. Requires `export:file:<scoped-path>`. Host performs the write via `secure_io` and rejects any out-of-scope path.
+- `host_http_post(url, bytes)` — POST to the granted origin. Requires `export:http:<origin>`. Host performs the request and rejects any other origin.
 
-- `file` — write a CSV/JSON variant to a user-chosen path (host does the write via `secure_io`).
-- `http_post` — POST a payload to a user-supplied URL (self-hosted dashboard, local endpoint). The host performs the request; the plugin supplies URL + format template, never raw network code.
+The plugin owns _formatting_ (CSV variant, JSON shape, whatever); the host owns _what data exists_ and _where it may go_.
 
 Critical privacy properties:
 
-- **The user picks the destination at grant time**, and it is shown in full in the consent dialog. An adapter cannot rewrite its own sink after grant without re-consent.
-- **Egress is the host's**, so the redaction posture is the host's: the same redaction that protects the diagnostics report (`diagnostics.rs` strips hook commands and license shapes) applies — break stats carry no hook commands or credentials, but the principle (host decides what is allowed to leave) holds.
-- **`http_post` is the one capability that can leave the machine**, so it is the most prominent line in the consent dialog and the easiest to revoke. It is _user-controlled sink_ only — there is no Entracte-operated endpoint, ever.
+- **The destination is fixed at grant time** and shown in full in the consent dialog. Because the origin/path is enforced at the host-function call, a module cannot exfiltrate to anywhere else even with arbitrary code — the call simply fails.
+- **The host assembles the payload**, so the redaction posture is the host's: the same discipline that strips hook commands and license shapes from the diagnostics report (`diagnostics.rs`) governs what is even available to format. Break stats carry no credentials, but the principle (host decides what may leave) holds at the boundary.
+- **`http_post` is the only machine-crossing capability** — the most prominent line in the consent dialog, one-click revocable. There is no Entracte-operated endpoint, ever; the sink is always user-controlled.
 
-- **Capabilities required:** `export:file:<scoped-path>` or `export:http:<host>` — scoped to the exact path or origin shown at consent.
-- **Cadence:** adapters fire on the same scheduler events hooks already expose, or on a digest schedule; reuse, don't reinvent, the event vocabulary.
+### 4.4 Runtime integration
 
-## 5. Manifest schema
+- **Runtime choice — recommend [extism](https://extism.org/) (embeds wasmtime).** It provides the plugin host-function registration model, the cross-language PDK (authors write Rust / JS / Go / C / AssemblyScript and compile to wasm), and the memory marshalling we'd otherwise hand-roll over a raw `wasmtime` ABI — while inheriting wasmtime's sandbox guarantees, per-call `timeout_ms`, and memory limits. Raw `wasmtime` stays the fallback if we ever need finer fuel-based metering than extism exposes. Either way: **WASI off, host functions only.**
+- **Off the hot path.** Detector modules are evaluated on a blocking worker on a throttled interval; the 1Hz tick reads the last cached result. This preserves the snapshot-then-act locking discipline and the once-per-tick idle read — a plugin call is never awaited inside the scheduler tick.
+- **Metering.** Memory limit + per-call time-box are runtime-enforced (stronger than a cooperative timeout): a runaway module is trapped and unloaded, not merely ignored.
 
-One signed manifest per plugin, versioned like the content-pack format (`CONTENT_PACK_VERSION` is the precedent). A plugin is a single file (`*.entracte-plugin`, a JSON document) or a small bundle whose root is `manifest.json`. Pure-function parse/validate, file I/O and IPC in a commands module — same split as `content_pack.rs` vs `commands::content_pack`.
+## 5. Manifest and bundle
+
+A plugin is a small bundle: `manifest.json` at the root, an optional `module.wasm` (for detectors / export adapters), and optional content data. Single-file distribution wraps the same structure. The manifest is versioned like the content-pack format (`CONTENT_PACK_VERSION` is the precedent). Pure-function parse/validate, file I/O and IPC in a commands module — the `content_pack.rs` vs `commands::content_pack` split.
 
 ```jsonc
 {
@@ -146,80 +158,65 @@ One signed manifest per plugin, versioned like the content-pack format (`CONTENT
   "version": "1.2.0", // plugin's own semver, informational
   "author": "Jane Doe <jane@example.com>",
   "description": "Suppress breaks while a focus app is frontmost.",
-  "runtime": "declarative", // reserved: "declarative" | "wasm" (Tier 2)
+  "kind": "detector", // "content" | "detector" | "export"
 
-  "capabilities": [
-    // every powerful action is named here
-    { "kind": "detect:foreground-window" },
-  ],
+  // Code-bearing kinds reference a module + declare the host functions it
+  // imports. Each import is a capability request, checked at instantiation.
+  "module": "module.wasm",
+  "abi_version": 1, // host-function ABI the module compiled against
+  "imports": ["detect:foreground-window"],
 
-  // Exactly one of the following payload blocks, matching the plugin's role:
-
-  "content": {
-    /* ContentPack shape from §4.1 */
+  // Detector / export metadata the host needs to wire it in:
+  "detect": {
+    "interval_secs": 5, // throttle; host caps the minimum
+    "label": "Focus app frontmost", // shown as the GuardReason label
   },
 
-  "detectors": [
-    {
-      "id": "focus-frontmost",
-      "label": "Focus app frontmost", // shown as the GuardReason label
-      "probe": "window_title_matches",
-      "params": { "pattern": "(?i)\\bfocus\\b" },
-      "debounce_secs": 5,
-    },
-  ],
+  // For "export" kind instead:
+  // "export": { "on": ["break_end", "digest_daily"] },
 
-  "exports": [
-    {
-      "id": "local-dashboard",
-      "sink": "http_post",
-      "url": "http://127.0.0.1:8080/entracte", // shown verbatim at consent
-      "format": "json",
-      "on": ["break_end", "digest_daily"],
-    },
-  ],
+  // For "content" kind instead (no module, no imports):
+  // "content": { /* ContentPack shape from §4.1 */ },
 
   "signature": {
-    // §5.1
     "alg": "ed25519",
     "public_key": "base64…",
-    "sig": "base64…", // over a canonical serialization of all fields above
+    "sig": "base64…", // over canonical(manifest-without-sig) ‖ sha256(module.wasm)
   },
 }
 ```
 
 Validation rules (extending the `validate_pack` pattern — clear, user-facing, first-error-wins):
 
-- `manifest_version` must equal the build's supported version; unknown ⇒ rejected with a "this build reads version N" message.
+- `manifest_version` and `abi_version` must be ones this build supports; unknown ⇒ rejected with a "this build reads version N" message. A module built against a future ABI is refused rather than mis-bound.
 - `id` reverse-DNS, non-empty, length-capped, unique against installed plugins (collision ⇒ "already installed; remove it first").
-- Exactly one payload role per plugin in Tier 1 (a plugin is a content provider _or_ a detector bundle _or_ an export adapter). Multi-role bundles are a later, deliberate extension — keeping it one-role keeps the consent dialog legible.
-- Every payload entry's required capability must appear in `capabilities`; a payload that uses an undeclared capability is rejected (the manifest cannot _under_-declare to dodge consent).
-- All the content-pack caps (`MAX_*`) apply to the `content` block unchanged; analogous caps bound detector/export counts and string lengths.
-- Probe `params.pattern` regexes are size- and complexity-bounded (no catastrophic-backtracking pattern accepted) since the host evaluates them.
+- Exactly one `kind`. `content` carries no `module`/`imports`; `detector`/`export` require both.
+- **Every host function the module imports must be listed in `imports`, and vice versa** — the host cross-checks the module's actual import section against the manifest at load. A module importing anything not declared (an attempt to dodge consent) **fails to instantiate**. This is the load-time half of the capability enforcement; the per-call scope check (§3, §4.3) is the runtime half.
+- Content-pack `MAX_*` caps apply unchanged to a `content` payload; analogous caps bound module size, import count, and detector/export counts.
 
 ### 5.1 Signed manifests
 
-Signing protects **integrity and provenance**, not authorization — a valid signature means "this file is intact and was produced by the holder of this key," _not_ "this plugin is safe." Authorization is the consent dialog (§6).
+Signing protects **integrity and provenance**, not authorization — a valid signature means "this manifest _and module_ are intact and were produced by the holder of this key," _not_ "this plugin is safe." Authorization is the consent dialog (§6). Signing matters more here than for content packs precisely because the bundle now contains executable code.
 
-- **Scheme:** ed25519 over a canonical serialization of every field except `signature`. Small, fast, no dependency drama; verification is pure and unit-testable.
-- **Trust-on-first-use, local-only.** There is no central CA and there will not be one (no remote registry, per non-goals). The first time a given `public_key` is seen, the consent dialog shows its fingerprint; the user may pin it. A later update to the same `id` signed by a _different_ key is surfaced loudly as a key change (the same way SSH does) — this is the main defence against a tampered or substituted plugin.
-- **Unsigned plugins** are not silently accepted. They are installable only via an explicit "I understand this is unsigned" path, styled like the hooks opt-in, and never via any non-interactive route.
-- **What signing deliberately does _not_ do:** it does not gate capabilities, does not imply review, and does not phone home for revocation. Revocation is local — the user removes the plugin.
+- **Scheme:** ed25519 over `canonical(manifest without signature) ‖ sha256(module.wasm)`, so the signature binds the code, not just the metadata. Verification is pure and unit-testable.
+- **Trust-on-first-use, local-only.** No central CA, and there will not be one (no remote registry, per non-goals). First sight of a `public_key` shows its fingerprint in the consent dialog; the user may pin it. A later update to the same `id` signed by a _different_ key is surfaced loudly as a key change (SSH-style) — the main defence against a substituted or tampered bundle.
+- **Unsigned plugins** are not silently accepted: installable only via an explicit "I understand this is unsigned" path, styled like the hooks opt-in, never via any non-interactive route.
+- **What signing deliberately does _not_ do:** it does not gate capabilities, imply review, or phone home for revocation. Revocation is local — the user removes the plugin.
 
 ## 6. Permission model
 
-Permissions are **explicit, per-capability, user-granted, and revocable** — and in Tier 1 each is enforced by the host because the host is what acts.
+Capabilities **are** host-function grants: granting a capability is what makes the host register that host function into the module's instance. Default-deny is therefore structural — an ungranted capability means the function isn't there and the module won't load if it needs it.
 
-- **Default-deny.** A freshly installed plugin runs nothing until permissions are granted. There is no "allow all."
-- **Per-capability consent at install**, shown in a native dialog (the `set_hooks` confirmation dialog is the UX precedent: it renders the proposed effect with control characters sanitised, and only one such dialog can be active at a time via `hook_dialog_busy`). The dialog lists each capability in plain language and, for the I/O-bearing ones, the exact scope:
+- **Default-deny.** A freshly installed plugin's module is not instantiated with any host function until its capabilities are granted. There is no "allow all."
+- **Per-capability consent at install**, in a native dialog (the `set_hooks` confirmation dialog is the UX precedent: renders the proposed effect with control characters sanitised; only one active at a time via `hook_dialog_busy`). Each capability in plain language, with exact scope for the I/O-bearing ones:
   - `detect:foreground-window` → "Read which window is frontmost (window titles)."
-  - `detect:processes` → "Read the list of running process names."
+  - `detect:processes` → "Check whether named programs are running."
   - `export:http:127.0.0.1:8080` → "Send break statistics to `http://127.0.0.1:8080/entracte`." (full URL, highlighted)
   - `export:file:~/Reports/entracte.csv` → "Write break statistics to that file."
-- **Scoped, not blanket.** `export:http` is bound to a specific origin; `export:file` and `detect:file` to a specific path. A plugin cannot widen its own scope post-grant; a wider scope requires a fresh consent.
-- **Revocable any time**, from the same Settings surface that lists installed plugins (no new tab — lives under **system** or **advanced**, beside hooks). Revoking a permission disables the dependent behaviour immediately; revoking all uninstalls.
-- **Master toggle.** A single `plugins_enabled` gate, off by default, mirroring `hooks_enabled` — the coarse kill-switch above the per-plugin grants.
-- **Host-owned keys.** `plugins_enabled`, the installed-plugin list, and grant records are stripped by `update_settings` and denylisted in the local IPC `settings set` path, exactly as hooks are. The only way to install/grant is the dedicated dialog-gated command.
+- **Scoped, not blanket.** `export:http` is bound to one origin; `export:file` / `detect:file` to one path. The host-function call enforces the scope, so a module cannot widen it post-grant; a wider scope requires fresh consent (and, if the manifest's `imports` change, a new install).
+- **Revocable any time** from the Settings surface that lists installed plugins (no new tab — under **system** / **advanced**, beside hooks). Revoking a capability re-instantiates the module without that host function (so it fails closed) or disables it; revoking all uninstalls.
+- **Master toggle.** A single `plugins_enabled` gate, off by default, mirroring `hooks_enabled` — the coarse kill-switch above per-plugin grants.
+- **Host-owned keys.** `plugins_enabled`, the installed-plugin list, and grant records are stripped by `update_settings` and denylisted in the local IPC `settings set` path, exactly as hooks are. Install/grant only via the dedicated dialog-gated command.
 
 ## 7. Threat model
 
@@ -227,51 +224,55 @@ Following the `HOOKS.md` precedent and the global threat-model checklist: inputs
 
 ### Inputs (where untrusted data enters)
 
-- The plugin file the user selects (manifest + payload + signature).
-- Probe parameters (regex patterns, paths, URLs) inside the manifest.
-- Detector outputs _the host computes_ from system state (process list, window title, sentinel file) — untrusted in the sense that a hostile manifest chose what to look at, but the _reading_ is host code.
+- The plugin bundle the user selects (manifest + module + content + signature).
+- The module's import section (cross-checked against `imports`) and its runtime arguments to host functions (paths, URLs, patterns) — all validated host-side.
+- Context the host returns to a detector module via granted host functions (window title, process match).
 - Plugin `id` / `public_key` collisions and key-change events on update.
 
 ### Trust boundaries
 
-- **Install boundary:** signature verification + per-capability consent dialog. Nothing runs before both clear. This is the primary boundary and it is enforced in Rust.
-- **Capability boundary:** a granted capability unlocks exactly one host-performed action class, scoped to a named path/origin. No transitive reach. (In Tier 2 this is the WASM host-function surface; in Tier 1 it is a Rust `match` on capability.)
-- **Loop boundary:** detectors feed the _suppression_ path only — they can delay a break, never trigger, lengthen, or enforce one. The snapshot-then-act locking discipline and the per-tick idle read are unchanged; a plugin probe is just another input to step 5.
-- **Egress boundary:** only `export:http` crosses the machine, only to the user-named origin, only with host-assembled stats, never with secrets (the diagnostics redaction posture governs what may leave).
+- **Install boundary:** signature-over-code verification + per-capability consent. Nothing instantiates before both clear. Enforced in Rust.
+- **Instantiation boundary:** the module is loaded with _only_ the granted host functions and no WASI; an undeclared/ungranted import fails the load. This is where "capabilities = imports" is enforced.
+- **Per-call boundary:** every host function re-checks its argument against the grant scope (path under the granted dir, URL at the granted origin) on every invocation.
+- **Loop boundary:** detectors feed the _suppression_ path only — delay a break, never trigger/lengthen/enforce. Evaluated off the async thread; the tick reads a cached result. Snapshot-then-act and the once-per-tick idle read are unchanged.
+- **Egress boundary:** only `export:http` crosses the machine, only to the granted origin, only with host-assembled stats, governed by the diagnostics redaction posture.
 
 ### Persistence surfaces
 
-- Installed manifests, granted permissions, and pinned keys persist under the app data dir, written via `secure_io::write_user_only` (atomic temp+fsync+rename, `0o600`) like every other user file.
+- Installed manifests, modules, granted capabilities, and pinned keys persist under the app data dir via `secure_io::write_user_only` (atomic temp+fsync+rename, `0o600`) like every other user file.
 - Provider content lives in (or is layered over) the existing profile pools; uninstall must remove it.
-- The diagnostics report must redact plugin-supplied URLs and any user paths the same way it redacts hooks and license shapes — add plugin fields to `redact_sensitive`.
-- The settings-write trust boundary is identical to hooks: anyone who can write the app data dir can pre-install a plugin. The `plugins_enabled` master toggle and the consent records are the gate; document this in the user-facing threat model exactly as `HOOKS.md` documents the crontab-equivalence.
+- The diagnostics report must redact plugin-supplied URLs and user paths the way it redacts hooks and license shapes — add plugin fields to `redact_sensitive`.
+- The settings-write trust boundary matches hooks: anyone who can write the app data dir can pre-stage a plugin. The `plugins_enabled` master toggle and the consent records are the gate; document this in the user-facing threat model exactly as `HOOKS.md` documents the crontab-equivalence.
 
 ### Top risks and mitigations
 
-1. **A distributed plugin runs hostile code as the user** (the hooks risk, now aimed at non-authors). _Mitigation:_ Tier 1 runs **no** third-party code at all — only host-implemented declarative behaviours. Model B (native subprocess) is rejected for exactly this reason. Tier 2 confines code to a WASM sandbox with no ambient authority.
-2. **Data exfiltration via export adapters.** _Mitigation:_ egress is host-performed, origin-scoped, consented with the full URL shown, redaction-governed, and there is no Entracte endpoint to leak to. `export:http` is the loudest line in the consent dialog and one-click revocable.
-3. **Privacy leak via detectors** (window titles / process names are sensitive). _Mitigation:_ each detector capability is named and consented individually; the host reads, throttles, and the plugin never sees the raw system state — only its own boolean suppression result is used.
-4. **Tampered or substituted plugin / key swap on update.** _Mitigation:_ ed25519 signatures over canonical bytes; TOFU key pinning per `id`; a key change on update is surfaced loudly, not auto-accepted.
-5. **Resource exhaustion** (a probe that hangs the 1Hz loop, a fork-bomb of detectors). _Mitigation:_ time-boxed probe evaluation (overrun ⇒ "no signal"), per-plugin and global count caps (the `MAX_HOOKS_PER_EVENT` precedent), bounded regex complexity, all string/collection caps inherited from the content-pack validator.
-6. **Settings injection** (enabling a plugin by writing `settings.json` directly). _Mitigation:_ host-owned keys stripped by `update_settings`, denylisted in IPC `settings set`, install only via the dialog-gated command — identical to the hooks hardening.
+1. **A distributed plugin runs hostile code.** _Mitigation:_ code runs only inside a WASM sandbox with WASI off and **no ambient authority** — it can do nothing but call host functions the user granted, each scope-checked in Rust. Model B (native subprocess) is rejected precisely to avoid an unsandboxed alternative.
+2. **Sandbox escape.** _Mitigation:_ use a mature, widely-deployed runtime (wasmtime, via extism), keep it patched, ship no `unsafe` host glue beyond what the runtime requires, and expose the smallest possible host-function surface. Residual risk is the runtime's own; tracked with dependency updates.
+3. **Data exfiltration via export adapters.** _Mitigation:_ destination enforced at the `host_http_post` / `host_write_file` boundary against the granted scope — arbitrary plugin code still cannot send anywhere but the consented sink. Host assembles the payload; redaction posture applies; `http_post` is the loudest consent line and one-click revocable.
+4. **Privacy leak via detectors** (window titles, process names are sensitive). _Mitigation:_ each context host function is a separately named, separately consented capability; the raw process list never enters the sandbox (host does the match); the module only ever yields a suppress/don't boolean to the loop.
+5. **Tampered / substituted bundle or key swap on update.** _Mitigation:_ ed25519 signature binds manifest **and** module hash; TOFU key pinning per `id`; a key change on update is surfaced loudly, not auto-accepted.
+6. **Resource exhaustion** (a module that spins, allocates, or is registered en masse). _Mitigation:_ runtime-enforced memory cap + per-call time-box (trap & unload on overrun), module-size cap, per-plugin and global detector/export count caps (the `MAX_HOOKS_PER_EVENT` precedent).
+7. **ABI / supply-chain drift.** _Mitigation:_ `abi_version` refuses mis-matched modules at load; the runtime crate is pinned and updated deliberately; the host-function surface is treated as a versioned public contract.
+8. **Settings injection** (enabling a plugin by writing `settings.json`). _Mitigation:_ host-owned keys stripped by `update_settings`, denylisted in IPC `settings set`, install only via the dialog-gated command — identical to the hooks hardening.
 
 ## 8. Staging
 
-This lands **after** the content-pack format (#155) and automation interfaces (#154) are stable — both now merged, so the dependency gate from #157 is satisfied. Suggested slices, each independently reviewable (stacked PRs):
+Lands **after** the content-pack format (#155) and automation interfaces (#154) are stable — both merged, so the #157 dependency gate is satisfied. Suggested slices, each independently reviewable (stacked PRs):
 
-1. **Manifest + signature core** — `plugin.rs` with pure `parse_manifest` / `validate_manifest` / `verify_signature`, versioned, fully unit-tested. No registration, no UI. (Mirrors `content_pack.rs` landing before its commands.)
-2. **Permission model + persistence** — install/grant/revoke commands behind the consent dialog and `plugins_enabled` master toggle; `secure_io` persistence; `update_settings` stripping + IPC denylist; diagnostics redaction. Tested end-to-end at the command layer.
-3. **Content providers (the lowest-risk extension point)** — wire the `content` payload through the existing merge path with removability. Ship this first as the proof of the whole pipeline.
-4. **Export adapters** — `file` then `http_post` sinks, host-performed, on the existing event vocabulary.
-5. **Local context detectors** — the fixed declarative probe vocabulary, wired into `run_loop` step 5 with a `GuardReason::Plugin` label and probe time-boxing.
-6. **(Later, separate bet) Tier 2 WASM runtime** — only if the fixed vocabularies prove too limiting. Reuses the manifest's reserved `runtime: "wasm"` slot and the capability model unchanged.
+1. **Manifest + signature core** — `plugin.rs` with pure `parse_manifest` / `validate_manifest` / `verify_signature` (over manifest ‖ module hash), versioned, fully unit-tested. No runtime, no UI. (Mirrors `content_pack.rs` landing before its commands.)
+2. **Content providers** — wire the `content` payload through the existing merge path with removability. **Ships first and needs no wasm runtime**, so users get value while the runtime work proceeds in parallel; also proves the install / consent / persistence / uninstall pipeline end-to-end.
+3. **Permission model + persistence** — install/grant/revoke behind the consent dialog and `plugins_enabled` master toggle; `secure_io` persistence; `update_settings` stripping + IPC denylist; diagnostics redaction.
+4. **WASM runtime integration** — embed extism (WASI off), the host-call worker, memory + time-box metering, instantiation-time import↔grant cross-check. The load-bearing foundational slice for the two code-bearing kinds; carries the dependency-weight decision (§2).
+5. **Detector host-function surface** — `host_foreground_window` / `host_process_running` / `host_read_flag`, the `detect()` invocation worker, and wiring the cached result into `run_loop` step 5 with a `GuardReason::Plugin` label.
+6. **Export host-function surface** — `host_write_file` then `host_http_post`, scope-checked, on the existing event vocabulary.
 
-Each slice ships with its tests and docs in the same PR (memory: tests-and-docs-with-code), and the user-facing threat model gets a `docs/PLUGINS.md` companion to `HOOKS.md`. Coverage on the OS-probe lines (process/window detectors) follows the established pattern: extract the testable core behind injected deps, leave only the OS-FFI shim uncovered, admin-merge the residual (memory: OS-shim coverage).
+Each slice ships with its tests and docs in the same PR (memory: tests-and-docs-with-code), and the user-facing threat model gets a `docs/PLUGINS.md` companion to `HOOKS.md`. Coverage on OS-probe lines (process/window context functions) follows the established pattern: testable core behind injected deps, only the OS-FFI shim uncovered, admin-merge the residual (memory: OS-shim coverage). The wasm runtime crate is a vendored dependency, not our coverage surface; our integration glue is tested on all three OSes (memory: codecov multi-OS).
 
 ## 9. Open questions for review
 
-1. **Provider content removability** — separate provider-tagged layer vs. merge-and-track. Affects only implementation, not the manifest; flagged for the reviewer's preference.
-2. **One role per plugin** in Tier 1 — proposed for consent legibility. Is a content+detector "theme bundle" worth the more complex dialog now, or deferred?
-3. **`http_post` at all in Tier 1** — it is the only machine-crossing capability. Option: ship Tiers with `file` export only and gate `http_post` behind a later, even louder opt-in. Recommend including it but it is the natural place to be conservative.
-4. **Key pinning UX** — how prominent should a key-change-on-update warning be, and is blocking (vs. warning) the right default?
-5. **Tier 2 trigger** — what concretely would justify the WASM investment? Worth naming a bar now so it isn't built speculatively.
+1. **Runtime: extism vs raw wasmtime.** Recommend extism for the PDK + host-function ergonomics; raw wasmtime if we need fuel-based metering finer than extism's `timeout_ms`. Worth confirming before slice 4, since it shapes the ABI.
+2. **ABI surface scope.** Start with the minimal host-function set in §4.2/§4.3, or define a broader v1 surface up front to reduce early ABI churn for plugin authors? Trade-off: smaller surface = smaller attack surface but more breaking growth.
+3. **Provider content removability** — separate provider-tagged layer vs. merge-and-track. Implementation detail, doesn't touch the manifest; flagged for preference.
+4. **`http_post` in v1** — the only machine-crossing capability. Ship with `file` export only and gate `http_post` behind a later, louder opt-in? Recommend including it (scope-enforced), but it is the natural place to be conservative.
+5. **Key pinning UX** — how prominent is a key-change-on-update warning, and is blocking (vs. warning) the right default?
+6. **Module-size and metering defaults** — concrete caps for module bytes, per-call ms, and memory pages need numbers before slice 4; propose in that PR.

--- a/docs/developer/plugin-api-design.md
+++ b/docs/developer/plugin-api-design.md
@@ -1,0 +1,277 @@
+# Local-only plugin API — design doc
+
+**Status:** Draft for review · **Issue:** [#156](https://github.com/drmowinckels/entracte/issues/156) · **Roadmap:** Phase D of [#157](https://github.com/drmowinckels/entracte/issues/157)
+
+This document is the gate the acceptance criteria require: the security boundary, manifest schema, permission model, and threat model are settled here and reviewed **before any implementation**. It does not ship code. It assumes the two interfaces it builds on are stable: the content-pack format ([#155](https://github.com/drmowinckels/entracte/issues/155), merged) and the safer-automation/hooks surface ([#154](https://github.com/drmowinckels/entracte/issues/154), merged).
+
+## 1. Goal and non-goals
+
+### Goal
+
+Let the community extend Entracte without forking — supply break content, contribute additional break-suppression signals, and push break statistics to user-controlled sinks — **without compromising the local-first, privacy-first, no-account positioning** that defines the product.
+
+The three extension points from the issue:
+
+- **Content providers** — supply ideas / routines / (later) sounds.
+- **Local context detectors** (opt-in) — additional break-suppression signals, no cloud, no account.
+- **Local export adapters** — push break stats to user-controlled sinks (CSV variants, local dashboards, self-hosted endpoints).
+
+### Non-goals (explicitly out of scope)
+
+Carried verbatim from the issue and the roadmap guardrails in [#157](https://github.com/drmowinckels/entracte/issues/157):
+
+- **No cloud, no account, no telemetry, no remote registry.** Plugins are local files the user explicitly installs.
+- **No enterprise / admin / compliance / team-policy management.**
+- **No stronger enforcement** — no keyboard lock, no password-to-skip.
+- **No geolocation-driven behaviour.**
+- **No new Settings tabs** — plugin management slots into the existing tabs (memory: free-tier UI hides cleanly; nav does not wrap).
+- **No marketplace, ratings, auto-update, or "featured plugins."** Discovery and trust are the user's responsibility, exactly as with hooks.
+
+## 2. The core tension, and the decision it forces
+
+Entracte already has two precedents at opposite ends of the safety spectrum, and the plugin API has to choose where it sits between them:
+
+| Precedent                                     | What it is                                                                                                                                     | Trust model                                                                                                                       | Distributable?                                                                  |
+| --------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| **Content packs** (`scheduler::content_pack`) | Versioned JSON bundle of hints + routines. Parsed, validated against hard caps, merged non-destructively. **Pure data — zero code execution.** | Data validation. A hostile pack can at worst bloat settings, which the caps prevent.                                              | Yes — already safe to pass around.                                              |
+| **Hooks** (`hooks.rs`, `docs/HOOKS.md`)       | Arbitrary shell commands fired on scheduler events.                                                                                            | "Same trust as your crontab." One master toggle, no sandbox, no allowlist. Anyone who can write `settings.json` runs code as you. | **Deliberately not.** The threat model assumes you wrote the commands yourself. |
+
+The plugin API's whole purpose is **distributable third-party extensions**. That rules out the hooks trust model: hooks are safe _because_ they are not meant to be shared, and the moment we encourage installing executables authored by strangers we have reintroduced the hooks risk surface to an audience that did not write the code. A privacy-first app cannot ship "download this binary from a forum and grant it your break history" as a first-class feature.
+
+So the design question is not "how do we sandbox a subprocess" — it is **"what is the least powerful execution model that still satisfies the three extension points?"** The answer differs per extension point, which gives us a tiered design.
+
+### Three candidate execution models
+
+- **A — Declarative.** Plugins are manifest + data only. The host implements a fixed vocabulary of behaviours; the plugin selects and configures them. No third-party code runs. Permissions are _enforced_ because the host performs every sensitive action itself.
+- **B — Native subprocess.** Plugin ships an executable invoked over a stdio JSON protocol. Powerful and easy (reuses `proc::reap_or_kill`, detached stdio, timeouts from `hooks.rs`), but **once spawned it has the user's full privileges** — declared "permissions" are honour-system, not enforced. This is hooks with extra ceremony.
+- **C — WASM capability sandbox.** Plugin ships a `.wasm` module; the host exposes only the host-functions a granted permission unlocks. No ambient network or filesystem. Permissions are _enforced by the runtime_. True extensibility **and** true enforcement — at the cost of a wasm runtime dependency (`wasmtime`/`extism`), an ABI, and bridging into the async loop.
+
+### Recommendation
+
+**Ship Tier 1 (declarative, model A) first; design the manifest and permission model so Tier 2 (WASM, model C) can be added later without a schema break; explicitly reject model B.**
+
+Rationale:
+
+- Model A covers **all three extension points usefully on day one** (see §4) and is the only model where "no cloud / no account / explicit permission" is _enforced_ rather than promised. It is mostly an extension of the already-merged content-pack machinery.
+- Model B is a privacy regression over the curated content-pack model and is operationally indistinguishable from hooks — we would be re-litigating `HOOKS.md` for an audience that didn't author the code. Reject it outright and say so, so a future contributor doesn't "just shell out" because it's easy.
+- Model C is the right home for genuinely arbitrary logic (a detector that does something we never anticipated), but it is a large investment and a _longer-term_ bet within this longer-term bet. Reserving a manifest slot for it (`runtime: declarative | wasm`) lets us defer it without repainting the contract.
+
+The rest of this document specifies **Tier 1** in full and sketches the Tier 2 seam.
+
+## 3. Security boundary
+
+The boundary is drawn so that **installing a plugin can never, by itself, do anything a plugin's granted permissions don't explicitly allow** — and in Tier 1 every permission maps to an action the _host_ performs, so the boundary is enforced in Rust, not trusted to the plugin.
+
+```
+                    ┌─────────────────────────────────────────────┐
+   user picks a     │  Host (Rust) — the only code that runs        │
+   .entracte-plugin │                                               │
+   file ───────────▶│  1. read manifest + payload                   │
+                    │  2. verify signature (§5)                     │
+                    │  3. show permission consent dialog (§6)       │
+                    │  4. on grant: register declarative behaviours │
+                    │                                               │
+                    │  ┌─────────────┐  ┌─────────────┐  ┌────────┐ │
+                    │  │ content     │  │ detector    │  │ export │ │
+                    │  │ provider    │  │ (host-run   │  │ adapter│ │
+                    │  │ (data only) │  │  probe)     │  │(host I/O)│
+                    │  └─────────────┘  └─────────────┘  └────────┘ │
+                    └─────────────────────────────────────────────┘
+                          plugin payload is DATA, never an entry point
+```
+
+Boundary invariants:
+
+1. **No ambient authority.** A plugin gets exactly the capabilities its granted permissions name, and nothing transitively. Importing a content provider grants no detector or export reach.
+2. **Host mediates every side effect.** Reading a process list (detector), writing a CSV variant, POSTing to a self-hosted endpoint (export) — all performed by host code with the granted scope, never by plugin-supplied code.
+3. **Failure is contained.** A plugin that errors, times out, or returns garbage is disabled and surfaced; it never blocks the 1Hz loop, corrupts settings, or fires/suppresses a break on its own. Detectors run on the existing snapshot-then-act discipline and a probe budget; a slow probe is treated as "no signal," never as a stall.
+4. **Settings keys are owned by the host.** As with hooks, `update_settings` cannot enable a plugin or grant a permission — only the dedicated, dialog-gated command can (mirrors `set_hooks` stripping hook fields, and the IPC denylist).
+5. **Removal is total.** Uninstalling a plugin removes its registered behaviours, its granted permissions, and any host-managed state it created. No orphaned suppression signals, no dangling export schedule.
+
+## 4. The three extension points, concretely (Tier 1)
+
+### 4.1 Content providers
+
+The smallest step: a content provider **is** a content pack plus a manifest. The merge path already exists (`merge_pack`, additive and non-clobbering, deduped, capped). The plugin wrapper adds provenance (who, signature) and lifecycle (a provider's content can be removed on uninstall, which raw pack import cannot do today).
+
+- **Capabilities required:** `provide:content` only. No I/O, no system access.
+- **Payload:** the existing `ContentPack` shape (`version`, `name`, `hints`, `routines`), reused unchanged.
+- **Host action on enable:** `merge_pack` into the active profile (or, better for removability, keep provider content in a separate provider-tagged layer the pools read through — decided in implementation; the _manifest_ doesn't change either way).
+- **Risk:** lowest. Validation caps already defend against bloat. This tier alone is shippable and useful.
+
+### 4.2 Local context detectors (opt-in)
+
+Detectors add a suppression signal to the 1Hz decision tree (`run_loop.rs` step 5, alongside DnD / camera / video / app-pause). Today those are host-coded and feed `GuardReason` (`Dnd`, `Camera`, `Idle`, `AppPause`, `Typing`, `Video`). A detector plugin contributes a new reason.
+
+In Tier 1 a detector is a **declarative probe from a fixed, host-implemented vocabulary** — the plugin describes _what to look for_, the host does the looking:
+
+- `process_running` — a process whose name matches a given pattern is running (host walks the process list; this is the privacy-sensitive part, gated by `detect:processes`).
+- `window_title_matches` — the foreground window title matches a pattern (gated by `detect:foreground-window`).
+- `file_present` / `file_flag` — a sentinel file exists / contains a truthy value under a user-chosen directory (gated by `detect:file:<scoped-path>`).
+
+Each declarative probe is something the host can implement safely, throttle, and reason about. The detector manifest names the probe, its parameters, and a debounce. When the probe matches, the loop suppresses with a plugin-supplied `GuardReason::Plugin { id }` label (logged exactly like the built-ins via `log_suppressions`).
+
+- **Capabilities required:** one of `detect:processes`, `detect:foreground-window`, `detect:file:<path>` — each named and consented to individually.
+- **Hard limits:** probe evaluation is time-boxed well under the 1Hz budget; a probe that overruns counts as "no match" and is logged. Per-plugin and global caps on number of detectors (mirror `MAX_HOOKS_PER_EVENT`).
+- **Why not arbitrary code here:** "run this stranger's binary every second with access to my window titles" is precisely the privacy hole the product forbids. Anything the fixed vocabulary can't express is a Tier 2 (WASM) candidate, not a reason to shell out.
+- **Anti-goal reminder:** detectors _suppress_ breaks. They can never _force_ a break, lock input, or escalate enforcement.
+
+### 4.3 Local export adapters
+
+Export adapters push break stats (the `events.jsonl` / `export_csv` surface) to a user-controlled sink. Today the only export is "Export CSV" on Insights (`export_stats_csv` → renderer Blob download). An adapter generalises the _destination_, while the host keeps ownership of _what data_ and _how it leaves_.
+
+Tier 1 sinks (host-implemented, plugin-configured):
+
+- `file` — write a CSV/JSON variant to a user-chosen path (host does the write via `secure_io`).
+- `http_post` — POST a payload to a user-supplied URL (self-hosted dashboard, local endpoint). The host performs the request; the plugin supplies URL + format template, never raw network code.
+
+Critical privacy properties:
+
+- **The user picks the destination at grant time**, and it is shown in full in the consent dialog. An adapter cannot rewrite its own sink after grant without re-consent.
+- **Egress is the host's**, so the redaction posture is the host's: the same redaction that protects the diagnostics report (`diagnostics.rs` strips hook commands and license shapes) applies — break stats carry no hook commands or credentials, but the principle (host decides what is allowed to leave) holds.
+- **`http_post` is the one capability that can leave the machine**, so it is the most prominent line in the consent dialog and the easiest to revoke. It is _user-controlled sink_ only — there is no Entracte-operated endpoint, ever.
+
+- **Capabilities required:** `export:file:<scoped-path>` or `export:http:<host>` — scoped to the exact path or origin shown at consent.
+- **Cadence:** adapters fire on the same scheduler events hooks already expose, or on a digest schedule; reuse, don't reinvent, the event vocabulary.
+
+## 5. Manifest schema
+
+One signed manifest per plugin, versioned like the content-pack format (`CONTENT_PACK_VERSION` is the precedent). A plugin is a single file (`*.entracte-plugin`, a JSON document) or a small bundle whose root is `manifest.json`. Pure-function parse/validate, file I/O and IPC in a commands module — same split as `content_pack.rs` vs `commands::content_pack`.
+
+```jsonc
+{
+  "manifest_version": 1,
+  "id": "com.example.focus-detector", // reverse-DNS, stable, unique key
+  "name": "Focus app detector",
+  "version": "1.2.0", // plugin's own semver, informational
+  "author": "Jane Doe <jane@example.com>",
+  "description": "Suppress breaks while a focus app is frontmost.",
+  "runtime": "declarative", // reserved: "declarative" | "wasm" (Tier 2)
+
+  "capabilities": [
+    // every powerful action is named here
+    { "kind": "detect:foreground-window" },
+  ],
+
+  // Exactly one of the following payload blocks, matching the plugin's role:
+
+  "content": {
+    /* ContentPack shape from §4.1 */
+  },
+
+  "detectors": [
+    {
+      "id": "focus-frontmost",
+      "label": "Focus app frontmost", // shown as the GuardReason label
+      "probe": "window_title_matches",
+      "params": { "pattern": "(?i)\\bfocus\\b" },
+      "debounce_secs": 5,
+    },
+  ],
+
+  "exports": [
+    {
+      "id": "local-dashboard",
+      "sink": "http_post",
+      "url": "http://127.0.0.1:8080/entracte", // shown verbatim at consent
+      "format": "json",
+      "on": ["break_end", "digest_daily"],
+    },
+  ],
+
+  "signature": {
+    // §5.1
+    "alg": "ed25519",
+    "public_key": "base64…",
+    "sig": "base64…", // over a canonical serialization of all fields above
+  },
+}
+```
+
+Validation rules (extending the `validate_pack` pattern — clear, user-facing, first-error-wins):
+
+- `manifest_version` must equal the build's supported version; unknown ⇒ rejected with a "this build reads version N" message.
+- `id` reverse-DNS, non-empty, length-capped, unique against installed plugins (collision ⇒ "already installed; remove it first").
+- Exactly one payload role per plugin in Tier 1 (a plugin is a content provider _or_ a detector bundle _or_ an export adapter). Multi-role bundles are a later, deliberate extension — keeping it one-role keeps the consent dialog legible.
+- Every payload entry's required capability must appear in `capabilities`; a payload that uses an undeclared capability is rejected (the manifest cannot _under_-declare to dodge consent).
+- All the content-pack caps (`MAX_*`) apply to the `content` block unchanged; analogous caps bound detector/export counts and string lengths.
+- Probe `params.pattern` regexes are size- and complexity-bounded (no catastrophic-backtracking pattern accepted) since the host evaluates them.
+
+### 5.1 Signed manifests
+
+Signing protects **integrity and provenance**, not authorization — a valid signature means "this file is intact and was produced by the holder of this key," _not_ "this plugin is safe." Authorization is the consent dialog (§6).
+
+- **Scheme:** ed25519 over a canonical serialization of every field except `signature`. Small, fast, no dependency drama; verification is pure and unit-testable.
+- **Trust-on-first-use, local-only.** There is no central CA and there will not be one (no remote registry, per non-goals). The first time a given `public_key` is seen, the consent dialog shows its fingerprint; the user may pin it. A later update to the same `id` signed by a _different_ key is surfaced loudly as a key change (the same way SSH does) — this is the main defence against a tampered or substituted plugin.
+- **Unsigned plugins** are not silently accepted. They are installable only via an explicit "I understand this is unsigned" path, styled like the hooks opt-in, and never via any non-interactive route.
+- **What signing deliberately does _not_ do:** it does not gate capabilities, does not imply review, and does not phone home for revocation. Revocation is local — the user removes the plugin.
+
+## 6. Permission model
+
+Permissions are **explicit, per-capability, user-granted, and revocable** — and in Tier 1 each is enforced by the host because the host is what acts.
+
+- **Default-deny.** A freshly installed plugin runs nothing until permissions are granted. There is no "allow all."
+- **Per-capability consent at install**, shown in a native dialog (the `set_hooks` confirmation dialog is the UX precedent: it renders the proposed effect with control characters sanitised, and only one such dialog can be active at a time via `hook_dialog_busy`). The dialog lists each capability in plain language and, for the I/O-bearing ones, the exact scope:
+  - `detect:foreground-window` → "Read which window is frontmost (window titles)."
+  - `detect:processes` → "Read the list of running process names."
+  - `export:http:127.0.0.1:8080` → "Send break statistics to `http://127.0.0.1:8080/entracte`." (full URL, highlighted)
+  - `export:file:~/Reports/entracte.csv` → "Write break statistics to that file."
+- **Scoped, not blanket.** `export:http` is bound to a specific origin; `export:file` and `detect:file` to a specific path. A plugin cannot widen its own scope post-grant; a wider scope requires a fresh consent.
+- **Revocable any time**, from the same Settings surface that lists installed plugins (no new tab — lives under **system** or **advanced**, beside hooks). Revoking a permission disables the dependent behaviour immediately; revoking all uninstalls.
+- **Master toggle.** A single `plugins_enabled` gate, off by default, mirroring `hooks_enabled` — the coarse kill-switch above the per-plugin grants.
+- **Host-owned keys.** `plugins_enabled`, the installed-plugin list, and grant records are stripped by `update_settings` and denylisted in the local IPC `settings set` path, exactly as hooks are. The only way to install/grant is the dedicated dialog-gated command.
+
+## 7. Threat model
+
+Following the `HOOKS.md` precedent and the global threat-model checklist: inputs, trust boundaries, persistence surfaces, top risks.
+
+### Inputs (where untrusted data enters)
+
+- The plugin file the user selects (manifest + payload + signature).
+- Probe parameters (regex patterns, paths, URLs) inside the manifest.
+- Detector outputs _the host computes_ from system state (process list, window title, sentinel file) — untrusted in the sense that a hostile manifest chose what to look at, but the _reading_ is host code.
+- Plugin `id` / `public_key` collisions and key-change events on update.
+
+### Trust boundaries
+
+- **Install boundary:** signature verification + per-capability consent dialog. Nothing runs before both clear. This is the primary boundary and it is enforced in Rust.
+- **Capability boundary:** a granted capability unlocks exactly one host-performed action class, scoped to a named path/origin. No transitive reach. (In Tier 2 this is the WASM host-function surface; in Tier 1 it is a Rust `match` on capability.)
+- **Loop boundary:** detectors feed the _suppression_ path only — they can delay a break, never trigger, lengthen, or enforce one. The snapshot-then-act locking discipline and the per-tick idle read are unchanged; a plugin probe is just another input to step 5.
+- **Egress boundary:** only `export:http` crosses the machine, only to the user-named origin, only with host-assembled stats, never with secrets (the diagnostics redaction posture governs what may leave).
+
+### Persistence surfaces
+
+- Installed manifests, granted permissions, and pinned keys persist under the app data dir, written via `secure_io::write_user_only` (atomic temp+fsync+rename, `0o600`) like every other user file.
+- Provider content lives in (or is layered over) the existing profile pools; uninstall must remove it.
+- The diagnostics report must redact plugin-supplied URLs and any user paths the same way it redacts hooks and license shapes — add plugin fields to `redact_sensitive`.
+- The settings-write trust boundary is identical to hooks: anyone who can write the app data dir can pre-install a plugin. The `plugins_enabled` master toggle and the consent records are the gate; document this in the user-facing threat model exactly as `HOOKS.md` documents the crontab-equivalence.
+
+### Top risks and mitigations
+
+1. **A distributed plugin runs hostile code as the user** (the hooks risk, now aimed at non-authors). _Mitigation:_ Tier 1 runs **no** third-party code at all — only host-implemented declarative behaviours. Model B (native subprocess) is rejected for exactly this reason. Tier 2 confines code to a WASM sandbox with no ambient authority.
+2. **Data exfiltration via export adapters.** _Mitigation:_ egress is host-performed, origin-scoped, consented with the full URL shown, redaction-governed, and there is no Entracte endpoint to leak to. `export:http` is the loudest line in the consent dialog and one-click revocable.
+3. **Privacy leak via detectors** (window titles / process names are sensitive). _Mitigation:_ each detector capability is named and consented individually; the host reads, throttles, and the plugin never sees the raw system state — only its own boolean suppression result is used.
+4. **Tampered or substituted plugin / key swap on update.** _Mitigation:_ ed25519 signatures over canonical bytes; TOFU key pinning per `id`; a key change on update is surfaced loudly, not auto-accepted.
+5. **Resource exhaustion** (a probe that hangs the 1Hz loop, a fork-bomb of detectors). _Mitigation:_ time-boxed probe evaluation (overrun ⇒ "no signal"), per-plugin and global count caps (the `MAX_HOOKS_PER_EVENT` precedent), bounded regex complexity, all string/collection caps inherited from the content-pack validator.
+6. **Settings injection** (enabling a plugin by writing `settings.json` directly). _Mitigation:_ host-owned keys stripped by `update_settings`, denylisted in IPC `settings set`, install only via the dialog-gated command — identical to the hooks hardening.
+
+## 8. Staging
+
+This lands **after** the content-pack format (#155) and automation interfaces (#154) are stable — both now merged, so the dependency gate from #157 is satisfied. Suggested slices, each independently reviewable (stacked PRs):
+
+1. **Manifest + signature core** — `plugin.rs` with pure `parse_manifest` / `validate_manifest` / `verify_signature`, versioned, fully unit-tested. No registration, no UI. (Mirrors `content_pack.rs` landing before its commands.)
+2. **Permission model + persistence** — install/grant/revoke commands behind the consent dialog and `plugins_enabled` master toggle; `secure_io` persistence; `update_settings` stripping + IPC denylist; diagnostics redaction. Tested end-to-end at the command layer.
+3. **Content providers (the lowest-risk extension point)** — wire the `content` payload through the existing merge path with removability. Ship this first as the proof of the whole pipeline.
+4. **Export adapters** — `file` then `http_post` sinks, host-performed, on the existing event vocabulary.
+5. **Local context detectors** — the fixed declarative probe vocabulary, wired into `run_loop` step 5 with a `GuardReason::Plugin` label and probe time-boxing.
+6. **(Later, separate bet) Tier 2 WASM runtime** — only if the fixed vocabularies prove too limiting. Reuses the manifest's reserved `runtime: "wasm"` slot and the capability model unchanged.
+
+Each slice ships with its tests and docs in the same PR (memory: tests-and-docs-with-code), and the user-facing threat model gets a `docs/PLUGINS.md` companion to `HOOKS.md`. Coverage on the OS-probe lines (process/window detectors) follows the established pattern: extract the testable core behind injected deps, leave only the OS-FFI shim uncovered, admin-merge the residual (memory: OS-shim coverage).
+
+## 9. Open questions for review
+
+1. **Provider content removability** — separate provider-tagged layer vs. merge-and-track. Affects only implementation, not the manifest; flagged for the reviewer's preference.
+2. **One role per plugin** in Tier 1 — proposed for consent legibility. Is a content+detector "theme bundle" worth the more complex dialog now, or deferred?
+3. **`http_post` at all in Tier 1** — it is the only machine-crossing capability. Option: ship Tiers with `file` export only and gate `http_post` behind a later, even louder opt-in. Recommend including it but it is the natural place to be conservative.
+4. **Key pinning UX** — how prominent should a key-change-on-update warning be, and is blocking (vs. warning) the right default?
+5. **Tier 2 trigger** — what concretely would justify the WASM investment? Worth naming a bar now so it isn't built speculatively.


### PR DESCRIPTION
## Summary

Review-gate design doc for the local-only plugin API (#156): security boundary, manifest schema, permission model, and threat model, settled before implementation. Commits to a **WASM capability sandbox** model — capabilities *are* host-function grants, enforced at module instantiation and per-call in Rust; content stays pure data; extism recommended; signature binds the module hash. Links it from the developer guide index.

Slice 1 (the manifest + signature core) is already merged in #167; this is the design that precedes it.

> **Note:** this replaces #166, which was accidentally branched on top of unrelated in-progress Wayland window work (`apply_wayland_fix` / `wayland_fix_strategy`, commits `11cc4c3` / `7d44bb1`) that conflicts with main's `nudge_configure`. This branch is cherry-picked clean off current `main` — docs + cspell only, no `window.rs` changes. #166 is closed in favour of this.

## Test Plan

Docs-only. `cspell` clean; prettier clean. `codecov/patch` has no coverable lines (docs-only) and needs an admin merge per the non-reachable-line policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)