### PR TITLE
feat(plugins): content-provider install/uninstall pipeline (#156)

### DIFF
--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -1,0 +1,40 @@
+# Plugins
+
+Entracte can be extended with **local-only plugins** — files you choose from disk that add capability without forking the app. There is no plugin store, no account, and no network: a plugin is a file you already have, and installing it never contacts a server. The design and roadmap live in [the plugin API design doc](developer/plugin-api-design.md) ([#156](https://github.com/drmowinckels/entracte/issues/156)).
+
+This release ships the first plugin kind: **content providers**.
+
+## Content providers
+
+A content provider supplies break **ideas** and guided **routines**. Installing one merges its content into your active profile, exactly like importing a [content pack](#) — but with provenance (a signed author) and clean removal: uninstalling takes out precisely what the plugin added, and nothing you created yourself.
+
+- **Install:** Settings → System → Plugins → **Install plugin…**, then pick the plugin file. A confirmation dialog shows the plugin's name, author, signing-key fingerprint, and how many ideas and routines it will add. Nothing is installed until you click **Install**.
+- **Uninstall:** the same panel lists each installed plugin with an **Uninstall** button. Uninstalling removes exactly the ideas and routines that plugin added. If you'd already deleted some of them by hand, that's fine — uninstall skips what's gone.
+- **Merge is additive:** installing never overwrites or removes anything you already have; exact-duplicate ideas and id-colliding routines are skipped.
+
+Installed plugins are recorded in `plugins.json` in your app config directory, written with the same owner-only (`0o600`) atomic write as the rest of your Entracte data. The record is small provenance plus the list of what each plugin added — the merged content itself lives in your profile, as if you'd typed it.
+
+## Signing
+
+Every plugin is **signed** (ed25519). The signature covers the whole manifest, so a file that's been tampered with after signing fails to install. The install dialog shows a short fingerprint of the signing key so a returning user can recognise a familiar author — and notice if a plugin claiming to be from them is signed by a different key.
+
+Signing proves **integrity and origin**, not safety. A valid signature means "this file is intact and was produced by the holder of this key" — it does **not** mean Entracte reviewed or endorses the plugin. The decision to trust a plugin is yours, made at the confirmation dialog.
+
+## What plugins can and cannot do
+
+Content providers are **pure data** — a list of ideas and routines. They run no code, touch no files, and reach no network. Installing one can, at most, add break suggestions to your profile.
+
+Two further plugin kinds are designed but **not yet installable** — they need a sandboxed runtime that a later release adds:
+
+- **Local context detectors** — extra break-suppression signals (e.g. "don't interrupt while a focus app is frontmost").
+- **Local export adapters** — push your break statistics to a destination you control (a local file, a self-hosted endpoint).
+
+When those land they will run inside a capability sandbox with no ambient access: a plugin will be able to do **only** what a permission you explicitly grant allows, enforced by Entracte, and never anything involving a cloud service or account. Until then, Entracte will refuse to install a detector or export plugin.
+
+## Threat model
+
+A content plugin is data the merge code validates against the same hard caps as a content pack (size, count, and string-length limits), so a malformed or hostile file can't bloat your settings or stall the app. It executes no code.
+
+The trust boundary is the **install confirmation dialog**, exactly as with [hooks](HOOKS.md): installing is the moment you vouch for a file. Treat plugin files like any other file you'd run — only install ones from sources you trust, and read the dialog before clicking Install. The signing-key fingerprint is there to help you spot a substituted plugin.
+
+As with hooks, anyone who can write your Entracte config directory can place a `plugins.json` entry directly; the registry is only mutated through the install/uninstall flow, which always shows the confirmation dialog. The content a plugin adds lands in your normal idea/routine pools and is editable and removable like anything else there.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -11,6 +11,7 @@ mod media;
 mod notifications;
 mod pause_store;
 mod platform;
+mod plugin_store;
 mod plugins;
 mod proc;
 mod renderer_log;
@@ -148,6 +149,9 @@ pub fn run() {
             scheduler::import_backup_from_path,
             scheduler::import_content_pack,
             scheduler::export_content_pack,
+            scheduler::install_content_plugin,
+            scheduler::uninstall_plugin,
+            scheduler::list_plugins,
             scheduler::get_pause_info,
             scheduler::end_break,
             scheduler::trigger_test_break,

--- a/src-tauri/src/plugin_store.rs
+++ b/src-tauri/src/plugin_store.rs
@@ -1,0 +1,95 @@
+//! Load/save the installed-plugin registry (`plugins.json`), mirroring
+//! `pause_store` / `screen_time_store`: a capped read and an atomic,
+//! `0o600` write via `secure_io`. A missing or unparseable file yields an
+//! empty registry rather than failing startup.
+
+use std::io;
+use std::path::Path;
+
+use log::error;
+
+use crate::plugins::PluginRegistry;
+use crate::secure_io::{read_capped, write_user_only};
+
+/// Defensive cap on the registry file. Generous: each record is small
+/// provenance + a list of the strings the plugin added.
+const MAX_REGISTRY_BYTES: u64 = 4 * 1024 * 1024;
+
+/// Load the registry, defaulting to empty on a missing or malformed file.
+pub fn load(path: &Path) -> PluginRegistry {
+    match read_capped(path, MAX_REGISTRY_BYTES) {
+        Ok(text) => serde_json::from_str(&text).unwrap_or_else(|e| {
+            error!("plugin_store: failed to parse {}: {e}", path.display());
+            PluginRegistry::default()
+        }),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => PluginRegistry::default(),
+        Err(e) => {
+            error!("plugin_store: failed to read {}: {e}", path.display());
+            PluginRegistry::default()
+        }
+    }
+}
+
+/// Atomically persist the registry with owner-only permissions.
+pub fn save(path: &Path, registry: &PluginRegistry) -> io::Result<()> {
+    let body = serde_json::to_string_pretty(registry).map_err(io::Error::other)?;
+    write_user_only(path, body.as_bytes())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::plugins::registry::InstalledPlugin;
+    use crate::plugins::PluginKind;
+
+    fn temp_path() -> (tempfile::TempDir, std::path::PathBuf) {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("plugins.json");
+        (dir, path)
+    }
+
+    fn sample() -> PluginRegistry {
+        let mut reg = PluginRegistry::default();
+        reg.insert(InstalledPlugin {
+            id: "com.x.pack".to_string(),
+            name: "Pack".to_string(),
+            author: "Me".to_string(),
+            version: "1.0.0".to_string(),
+            kind: PluginKind::Content,
+            public_key: "AA==".to_string(),
+            added: Default::default(),
+        });
+        reg
+    }
+
+    #[test]
+    fn missing_file_loads_empty() {
+        let (_d, path) = temp_path();
+        assert_eq!(load(&path), PluginRegistry::default());
+    }
+
+    #[test]
+    fn save_then_load_round_trips() {
+        let (_d, path) = temp_path();
+        let reg = sample();
+        save(&path, &reg).unwrap();
+        assert_eq!(load(&path), reg);
+    }
+
+    #[test]
+    fn malformed_file_loads_empty() {
+        let (_d, path) = temp_path();
+        std::fs::write(&path, b"{ not json").unwrap();
+        assert_eq!(load(&path), PluginRegistry::default());
+    }
+
+    #[test]
+    fn unreadable_path_loads_empty() {
+        // A path that exists but isn't a readable file (a directory) hits the
+        // generic read-error arm, which still degrades to an empty registry.
+        let dir = tempfile::tempdir().unwrap();
+        let as_dir = dir.path().join("subdir");
+        std::fs::create_dir(&as_dir).unwrap();
+        assert_eq!(load(&as_dir), PluginRegistry::default());
+    }
+}

--- a/src-tauri/src/plugins/install.rs
+++ b/src-tauri/src/plugins/install.rs
@@ -1,0 +1,166 @@
+//! Pure install-time validation. No I/O, no settings mutation — the command
+//! layer (`scheduler::commands::plugins`) handles the file read, the consent
+//! dialog, the content merge under lock, and persistence. Keeping the gate
+//! pure makes every rejection path unit-testable.
+
+use super::manifest::{parse_manifest, validate_manifest, Manifest, PluginKind};
+use super::registry::PluginRegistry;
+use super::signature::verify_signature;
+
+/// Validate an incoming content-plugin manifest end to end and return it
+/// ready to merge. Runs, in order: JSON parse, schema validation, the
+/// content-only gate, signature verification, and the not-already-installed
+/// check. Detector/export plugins validate but are rejected here — they need
+/// the wasm runtime that a later slice adds.
+///
+/// Signature note: a content plugin ships no wasm module, so the signature
+/// is verified over the manifest alone (no module hash).
+pub fn prepare_content_install(
+    manifest_json: &str,
+    registry: &PluginRegistry,
+) -> Result<Manifest, String> {
+    let manifest = parse_manifest(manifest_json)?;
+    validate_manifest(&manifest)?;
+
+    if manifest.kind != PluginKind::Content {
+        return Err(
+            "only content plugins can be installed in this version; detector and export \
+             plugins need the plugin runtime (a later release)"
+                .to_string(),
+        );
+    }
+
+    verify_signature(&manifest, None)?;
+
+    if registry.contains(&manifest.id) {
+        return Err(format!(
+            "plugin '{}' is already installed; remove it first",
+            manifest.id
+        ));
+    }
+
+    Ok(manifest)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::plugins::registry::InstalledPlugin;
+    use crate::plugins::signature::{sha256, signing_payload};
+    use crate::scheduler::content_pack::{ContentPack, PackHints, CONTENT_PACK_VERSION};
+    use base64::prelude::{Engine, BASE64_STANDARD};
+    use ed25519_dalek::{Signer, SigningKey};
+
+    fn pack() -> ContentPack {
+        ContentPack {
+            version: CONTENT_PACK_VERSION,
+            name: "Pack".to_string(),
+            hints: PackHints {
+                micro_physical: vec!["Stretch".to_string()],
+                ..PackHints::default()
+            },
+            routines: vec![],
+        }
+    }
+
+    /// Build a signed content-plugin manifest JSON with a deterministic key.
+    fn signed_content_manifest_json(id: &str) -> String {
+        let mut m = Manifest {
+            manifest_version: crate::plugins::manifest::MANIFEST_VERSION,
+            id: id.to_string(),
+            name: "Idea pack".to_string(),
+            version: "1.0.0".to_string(),
+            author: "Jane".to_string(),
+            description: String::new(),
+            kind: PluginKind::Content,
+            module: None,
+            abi_version: None,
+            imports: vec![],
+            content: Some(pack()),
+            signature: super::super::manifest::Signature {
+                alg: "ed25519".to_string(),
+                public_key: String::new(),
+                sig: String::new(),
+            },
+        };
+        let key = SigningKey::from_bytes(&[5u8; 32]);
+        m.signature.public_key = BASE64_STANDARD.encode(key.verifying_key().to_bytes());
+        let sig = key.sign(&signing_payload(&m, None));
+        m.signature.sig = BASE64_STANDARD.encode(sig.to_bytes());
+        serde_json::to_string(&m).unwrap()
+    }
+
+    #[test]
+    fn accepts_a_signed_content_plugin() {
+        let json = signed_content_manifest_json("com.example.pack");
+        let m = prepare_content_install(&json, &PluginRegistry::default()).unwrap();
+        assert_eq!(m.id, "com.example.pack");
+        assert!(m.content.is_some());
+    }
+
+    #[test]
+    fn rejects_a_bad_signature() {
+        let mut json_manifest: Manifest =
+            serde_json::from_str(&signed_content_manifest_json("com.example.pack")).unwrap();
+        json_manifest.name = "Tampered".to_string();
+        let json = serde_json::to_string(&json_manifest).unwrap();
+        assert!(prepare_content_install(&json, &PluginRegistry::default())
+            .unwrap_err()
+            .contains("does not match"));
+    }
+
+    #[test]
+    fn rejects_an_already_installed_id() {
+        let json = signed_content_manifest_json("com.example.pack");
+        let mut reg = PluginRegistry::default();
+        reg.insert(InstalledPlugin {
+            id: "com.example.pack".to_string(),
+            name: "Pack".to_string(),
+            author: String::new(),
+            version: "1.0.0".to_string(),
+            kind: PluginKind::Content,
+            public_key: "AA==".to_string(),
+            added: Default::default(),
+        });
+        assert!(prepare_content_install(&json, &reg)
+            .unwrap_err()
+            .contains("already installed"));
+    }
+
+    #[test]
+    fn rejects_a_detector_plugin_until_the_runtime_exists() {
+        // A validly-signed detector manifest still can't be installed yet.
+        let mut m = Manifest {
+            manifest_version: crate::plugins::manifest::MANIFEST_VERSION,
+            id: "com.example.detector".to_string(),
+            name: "Detector".to_string(),
+            version: "1.0.0".to_string(),
+            author: String::new(),
+            description: String::new(),
+            kind: PluginKind::Detector,
+            module: Some("module.wasm".to_string()),
+            abi_version: Some(crate::plugins::manifest::SUPPORTED_ABI_VERSION),
+            imports: vec!["detect:foreground-window".to_string()],
+            content: None,
+            signature: super::super::manifest::Signature {
+                alg: "ed25519".to_string(),
+                public_key: String::new(),
+                sig: String::new(),
+            },
+        };
+        let key = SigningKey::from_bytes(&[6u8; 32]);
+        let hash = sha256(b"\0asm module");
+        m.signature.public_key = BASE64_STANDARD.encode(key.verifying_key().to_bytes());
+        m.signature.sig =
+            BASE64_STANDARD.encode(key.sign(&signing_payload(&m, Some(hash))).to_bytes());
+        let json = serde_json::to_string(&m).unwrap();
+        assert!(prepare_content_install(&json, &PluginRegistry::default())
+            .unwrap_err()
+            .contains("need the plugin runtime"));
+    }
+
+    #[test]
+    fn rejects_malformed_json() {
+        assert!(prepare_content_install("{ not json", &PluginRegistry::default()).is_err());
+    }
+}

--- a/src-tauri/src/plugins/manifest.rs
+++ b/src-tauri/src/plugins/manifest.rs
@@ -11,6 +11,8 @@
 
 use serde::{Deserialize, Serialize};
 
+use crate::scheduler::content_pack::{validate_pack, ContentPack};
+
 /// Manifest schema version this build reads and writes. Bumped only on a
 /// breaking change to the manifest shape.
 pub const MANIFEST_VERSION: u32 = 1;
@@ -128,9 +130,9 @@ pub struct Signature {
     pub sig: String,
 }
 
-/// A parsed plugin manifest. The `content` payload is left as a raw JSON
-/// value at this slice; the content-provider slice swaps in the typed
-/// `content_pack::ContentPack` when it wires the merge path.
+/// A parsed plugin manifest. A content plugin carries a typed
+/// [`ContentPack`] payload (validated via `content_pack::validate_pack`);
+/// code-bearing kinds carry a wasm `module` and declared `imports` instead.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Manifest {
     pub manifest_version: u32,
@@ -149,7 +151,7 @@ pub struct Manifest {
     #[serde(default)]
     pub imports: Vec<String>,
     #[serde(default)]
-    pub content: Option<serde_json::Value>,
+    pub content: Option<ContentPack>,
     pub signature: Signature,
 }
 
@@ -233,6 +235,9 @@ pub fn validate_manifest(m: &Manifest) -> Result<(), String> {
         if m.imports.is_empty() {
             return Err("a code-bearing plugin must import at least one capability".to_string());
         }
+        if m.content.is_some() {
+            return Err("a code-bearing plugin must not carry a content payload".to_string());
+        }
     } else {
         // Content plugins are pure data: no module, no ABI, no capabilities.
         if m.module.is_some() {
@@ -244,8 +249,9 @@ pub fn validate_manifest(m: &Manifest) -> Result<(), String> {
         if !m.imports.is_empty() {
             return Err("a content plugin must not import capabilities".to_string());
         }
-        if m.content.is_none() {
-            return Err("a content plugin must carry a content payload".to_string());
+        match &m.content {
+            Some(pack) => validate_pack(pack)?,
+            None => return Err("a content plugin must carry a content payload".to_string()),
         }
     }
 
@@ -311,8 +317,21 @@ mod tests {
             module: None,
             abi_version: None,
             imports: vec![],
-            content: Some(serde_json::json!({ "version": 1, "name": "p" })),
+            content: Some(sample_pack()),
             signature: sig(),
+        }
+    }
+
+    fn sample_pack() -> ContentPack {
+        use crate::scheduler::content_pack::PackHints;
+        ContentPack {
+            version: crate::scheduler::content_pack::CONTENT_PACK_VERSION,
+            name: "Idea pack".to_string(),
+            hints: PackHints {
+                micro_physical: vec!["Roll your shoulders".to_string()],
+                ..PackHints::default()
+            },
+            routines: vec![],
         }
     }
 
@@ -515,6 +534,15 @@ mod tests {
         assert!(validate_manifest(&m)
             .unwrap_err()
             .contains("missing a version"));
+    }
+
+    #[test]
+    fn validate_forbids_content_payload_on_code_bearing() {
+        let mut m = detector_manifest();
+        m.content = Some(sample_pack());
+        assert!(validate_manifest(&m)
+            .unwrap_err()
+            .contains("must not carry a content payload"));
     }
 
     #[test]

--- a/src-tauri/src/plugins/mod.rs
+++ b/src-tauri/src/plugins/mod.rs
@@ -1,28 +1,33 @@
-//! Local-only plugin API (#156): the parse / validate / signature-verify
-//! core for plugin manifests. This is slice 1 of the staged plan in
-//! `docs/developer/plugin-api-design.md` — pure functions only, no runtime,
-//! no bundle I/O, no IPC. Those land in later slices; keeping this layer
-//! pure mirrors how `scheduler::content_pack` landed before its commands.
+//! Local-only plugin API (#156): manifests, signatures, the installed-plugin
+//! registry, and the install/uninstall orchestration. See the staged plan in
+//! `docs/developer/plugin-api-design.md`.
 //!
 //! A plugin is a signed bundle whose root is a `manifest.json`. The manifest
 //! declares one `kind` (content / detector / export). Code-bearing kinds
-//! reference a wasm `module` and list the host-function capabilities it
-//! `imports`; each import is a permission request the user must grant. The
+//! reference a wasm `module` and list the host-function capabilities they
+//! `import`; each import is a permission request the user must grant. The
 //! signature binds the manifest **and** the module's hash, so a tampered
 //! module fails verification even if the manifest is untouched.
+//!
+//! This slice ships **content providers** end to end: a content plugin
+//! carries a typed content pack, merged into the active profile on install
+//! and removed exactly on uninstall (merge-and-track). Detector and export
+//! plugins parse and validate here but cannot yet be installed — they need
+//! the wasm runtime (a later slice).
 
-// This is the foundational slice: the parse/validate/verify core has no
-// in-crate callers yet (the install/consent commands and the wasm runtime
-// that consume it land in later slices per the design doc's staging plan),
-// so its items read as dead in the non-test build. The allow is scoped to
-// this module and removed as soon as the next slice wires in a caller.
-#![allow(dead_code)]
-
+mod install;
 mod manifest;
+pub(crate) mod registry;
 mod signature;
 
-// The module's public surface, re-exported so this slice defines the API in
-// one place even before anything consumes it.
+pub use install::prepare_content_install;
+pub use registry::{InstalledPlugin, PluginRegistry, PluginSummary};
+
+// The full manifest/signature API surface. Some items are consumed by the
+// command layer and tests now; others (the ABI version, module hashing, the
+// raw parse/validate/verify entry points) by the wasm-runtime slice. Marked
+// allow(unused_imports) so the public API can live in one place ahead of all
+// its consumers.
 #[allow(unused_imports)]
 pub use manifest::{
     parse_manifest, validate_manifest, Capability, Manifest, PluginKind, Signature,

--- a/src-tauri/src/plugins/mod.rs
+++ b/src-tauri/src/plugins/mod.rs
@@ -34,4 +34,4 @@ pub use manifest::{
     MANIFEST_VERSION, SUPPORTED_ABI_VERSION,
 };
 #[allow(unused_imports)]
-pub use signature::{sha256, verify_signature};
+pub use signature::{sha256, signing_payload, verify_signature};

--- a/src-tauri/src/plugins/registry.rs
+++ b/src-tauri/src/plugins/registry.rs
@@ -1,0 +1,166 @@
+//! The installed-plugin registry: provenance for each installed plugin plus
+//! the merge-and-track record of exactly what content it added, so an
+//! uninstall can remove precisely those entries. Pure data + pure methods;
+//! the on-disk persistence is in `crate::plugin_store`.
+//!
+//! We deliberately store a lightweight provenance record rather than the
+//! whole manifest: a content plugin's pack already lives in `settings.json`
+//! after merge, so re-storing it here would duplicate it. What we keep is
+//! what an uninstall and the Settings UI need — identity, author/version,
+//! the signing key (for future key-pinning), and the [`AddedContent`].
+
+use serde::{Deserialize, Serialize};
+
+use super::manifest::{Manifest, PluginKind};
+use crate::scheduler::content_pack::AddedContent;
+
+/// One installed plugin: provenance + what it added to settings.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct InstalledPlugin {
+    pub id: String,
+    pub name: String,
+    #[serde(default)]
+    pub author: String,
+    pub version: String,
+    pub kind: PluginKind,
+    /// The base64 ed25519 public key the manifest was signed with. Recorded
+    /// so a future update flow can detect a key change (TOFU pinning).
+    pub public_key: String,
+    /// The concrete content this plugin added, for a clean uninstall.
+    #[serde(default)]
+    pub added: AddedContent,
+}
+
+impl InstalledPlugin {
+    /// Build a registry record from a validated manifest and the content its
+    /// install actually merged.
+    pub fn from_manifest(manifest: &Manifest, added: AddedContent) -> Self {
+        Self {
+            id: manifest.id.clone(),
+            name: manifest.name.clone(),
+            author: manifest.author.clone(),
+            version: manifest.version.clone(),
+            kind: manifest.kind,
+            public_key: manifest.signature.public_key.clone(),
+            added,
+        }
+    }
+}
+
+/// The set of installed plugins. Keyed by `id` (unique).
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PluginRegistry {
+    #[serde(default)]
+    pub plugins: Vec<InstalledPlugin>,
+}
+
+impl PluginRegistry {
+    /// Whether a plugin with this id is already installed.
+    pub fn contains(&self, id: &str) -> bool {
+        self.plugins.iter().any(|p| p.id == id)
+    }
+
+    /// Add a record. Caller must have checked [`Self::contains`] first; this
+    /// does not dedupe.
+    pub fn insert(&mut self, plugin: InstalledPlugin) {
+        self.plugins.push(plugin);
+    }
+
+    /// Remove and return the record for `id`, if present.
+    pub fn remove(&mut self, id: &str) -> Option<InstalledPlugin> {
+        let idx = self.plugins.iter().position(|p| p.id == id)?;
+        Some(self.plugins.remove(idx))
+    }
+
+    /// A renderer-facing summary of each installed plugin, in install order.
+    pub fn summaries(&self) -> Vec<PluginSummary> {
+        self.plugins.iter().map(PluginSummary::from).collect()
+    }
+}
+
+/// What the Settings UI shows per installed plugin. Counts come from the
+/// merge-and-track record so the user sees the effect of each plugin.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct PluginSummary {
+    pub id: String,
+    pub name: String,
+    pub author: String,
+    pub version: String,
+    pub kind: PluginKind,
+    pub hints_added: usize,
+    pub routines_added: usize,
+}
+
+impl From<&InstalledPlugin> for PluginSummary {
+    fn from(p: &InstalledPlugin) -> Self {
+        let a = &p.added;
+        let hints_added = a.micro_physical.len()
+            + a.micro_psychological.len()
+            + a.long_solo.len()
+            + a.long_social.len()
+            + a.sleep.len();
+        Self {
+            id: p.id.clone(),
+            name: p.name.clone(),
+            author: p.author.clone(),
+            version: p.version.clone(),
+            kind: p.kind,
+            hints_added,
+            routines_added: a.routine_ids.len(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn record(id: &str) -> InstalledPlugin {
+        InstalledPlugin {
+            id: id.to_string(),
+            name: "Pack".to_string(),
+            author: "Me".to_string(),
+            version: "1.0.0".to_string(),
+            kind: PluginKind::Content,
+            public_key: "AA==".to_string(),
+            added: AddedContent {
+                micro_physical: vec!["a".to_string(), "b".to_string()],
+                routine_ids: vec!["r1".to_string()],
+                ..AddedContent::default()
+            },
+        }
+    }
+
+    #[test]
+    fn insert_contains_remove() {
+        let mut reg = PluginRegistry::default();
+        assert!(!reg.contains("com.x.pack"));
+        reg.insert(record("com.x.pack"));
+        assert!(reg.contains("com.x.pack"));
+
+        let removed = reg.remove("com.x.pack").unwrap();
+        assert_eq!(removed.id, "com.x.pack");
+        assert!(!reg.contains("com.x.pack"));
+        assert!(reg.remove("com.x.pack").is_none());
+    }
+
+    #[test]
+    fn summaries_count_hints_and_routines() {
+        let mut reg = PluginRegistry::default();
+        reg.insert(record("com.x.pack"));
+        let s = reg.summaries();
+        assert_eq!(s.len(), 1);
+        assert_eq!(s[0].hints_added, 2);
+        assert_eq!(s[0].routines_added, 1);
+        assert_eq!(s[0].kind, PluginKind::Content);
+    }
+
+    #[test]
+    fn registry_serde_round_trips() {
+        let mut reg = PluginRegistry::default();
+        reg.insert(record("com.x.pack"));
+        let json = serde_json::to_string(&reg).unwrap();
+        let back: PluginRegistry = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, reg);
+    }
+}

--- a/src-tauri/src/plugins/signature.rs
+++ b/src-tauri/src/plugins/signature.rs
@@ -19,7 +19,10 @@ use sha2::{Digest, Sha256};
 use super::manifest::Manifest;
 
 /// SHA-256 of `bytes`, as a fixed 32-byte array. Used to hash a plugin's
-/// wasm module for inclusion in the signed payload.
+/// wasm module for inclusion in the signed payload. Only code-bearing
+/// plugins ship a module, so this has no non-test caller until the runtime
+/// slice; content plugins sign over the manifest alone.
+#[allow(dead_code)]
 pub fn sha256(bytes: &[u8]) -> [u8; 32] {
     let mut hasher = Sha256::new();
     hasher.update(bytes);

--- a/src-tauri/src/scheduler/commands/mod.rs
+++ b/src-tauri/src/scheduler/commands/mod.rs
@@ -2,6 +2,7 @@ pub mod backup;
 pub mod breaks;
 pub mod content_pack;
 pub mod hooks;
+pub mod plugins;
 pub mod profiles;
 pub mod settings;
 pub mod stats;

--- a/src-tauri/src/scheduler/commands/plugins.rs
+++ b/src-tauri/src/scheduler/commands/plugins.rs
@@ -1,0 +1,491 @@
+//! Content-plugin install / uninstall / list commands.
+//!
+//! Install is gated by a native confirmation dialog (mirroring `set_hooks`):
+//! the user must explicitly approve installing a plugin, with its provenance
+//! shown. A content plugin's pack is merged into the active profile and the
+//! exact additions are recorded in the registry (merge-and-track), so
+//! uninstall removes precisely what was added. The registry persists to
+//! `plugins.json`; the merged content persists in the profile as usual.
+
+use std::path::Path;
+use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
+
+use serde::Serialize;
+use tauri::{AppHandle, Runtime, WebviewWindow};
+
+use crate::plugins::{prepare_content_install, InstalledPlugin, Manifest, PluginSummary};
+use crate::scheduler::content_pack::{
+    merge_pack_tracked, remove_content, AddedContent, MergeSummary,
+};
+use crate::secure_io::read_capped;
+
+use super::super::{persist_plugins, persist_profiles, Scheduler};
+
+/// Plugin IPC is restricted to the main settings window, like content packs.
+const MAIN_WINDOW_LABEL: &str = "main";
+/// Hard cap on a plugin manifest we'll read+parse. A content plugin embeds
+/// its pack, so this matches the content-pack cap.
+const MAX_MANIFEST_BYTES: u64 = 8 * 1024 * 1024;
+
+const PLUGIN_DIALOG_ALLOW: &str = "Install";
+const PLUGIN_DIALOG_CANCEL: &str = "Cancel";
+
+fn ensure_main_window<R: Runtime>(webview: &WebviewWindow<R>) -> Result<(), String> {
+    if webview.label() != MAIN_WINDOW_LABEL {
+        return Err("plugin commands are restricted to the main window".to_string());
+    }
+    Ok(())
+}
+
+/// Read a plugin manifest file with the size cap, mapping I/O errors to
+/// user-facing strings. Pure (filesystem only), so the read + error-mapping
+/// is testable without a Tauri window.
+fn read_manifest_text(path: &str) -> Result<String, String> {
+    read_capped(Path::new(path), MAX_MANIFEST_BYTES).map_err(|e| match e.kind() {
+        std::io::ErrorKind::InvalidData => format!(
+            "plugin file is too large (over {} MiB)",
+            MAX_MANIFEST_BYTES / (1024 * 1024)
+        ),
+        _ => format!("failed to read plugin file: {e}"),
+    })
+}
+
+struct DialogBusyGuard(Arc<AtomicBool>);
+
+impl Drop for DialogBusyGuard {
+    fn drop(&mut self) {
+        self.0.store(false, std::sync::atomic::Ordering::Release);
+    }
+}
+
+/// Result of an install, surfaced to the renderer.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct InstallOutcome {
+    pub id: String,
+    pub name: String,
+    pub hints_added: usize,
+    pub routines_added: usize,
+}
+
+/// Install a content plugin from `path`: read (size-capped), parse, validate,
+/// verify the signature, confirm via a native dialog, then merge its pack
+/// into the active profile and record what was added. Returns a summary of
+/// the effect. Errors are user-facing strings.
+#[tauri::command]
+pub async fn install_content_plugin<R: Runtime>(
+    app: AppHandle<R>,
+    webview: WebviewWindow<R>,
+    scheduler: tauri::State<'_, Scheduler>,
+    path: String,
+) -> Result<InstallOutcome, String> {
+    ensure_main_window(&webview)?;
+    let text = read_manifest_text(&path)?;
+
+    // Validate against the current registry (parse, schema, signature,
+    // content-only, not-already-installed) before prompting.
+    let manifest = {
+        let registry = scheduler.plugins.lock().await;
+        prepare_content_install(&text, &registry)?
+    };
+
+    if scheduler
+        .plugin_dialog_busy
+        .compare_exchange(
+            false,
+            true,
+            std::sync::atomic::Ordering::Acquire,
+            std::sync::atomic::Ordering::Relaxed,
+        )
+        .is_err()
+    {
+        return Err("another plugin install is already pending".to_string());
+    }
+    let _guard = DialogBusyGuard(scheduler.plugin_dialog_busy.clone());
+    if !confirm_install(&app, &manifest).await {
+        return Err("user declined plugin install".to_string());
+    }
+
+    Ok(apply_install(scheduler.inner(), &manifest).await)
+}
+
+/// Merge a validated content plugin into the active profile, record the
+/// additions in the registry, and persist both. Split out so it's
+/// unit-testable without a `WebviewWindow`/dialog. Mirrors the content-pack
+/// `apply_pack` write sequence (merge into a clone, rebuild the derived
+/// caches, store, upsert the active profile, persist).
+async fn apply_install(scheduler: &Scheduler, manifest: &Manifest) -> InstallOutcome {
+    let pack = manifest
+        .content
+        .as_ref()
+        .expect("content plugin always carries a pack (validated)");
+    let (merged, summary, added) = {
+        let mut next = scheduler.settings.lock().await.clone();
+        let (summary, added) = merge_pack_tracked(pack, &mut next);
+        next.rebuild_derived();
+        (next, summary, added)
+    };
+    *scheduler.settings.lock().await = merged.clone();
+    {
+        let active = scheduler.active_profile_name.lock().await.clone();
+        let mut profiles = scheduler.profiles.lock().await;
+        if let Some(p) = profiles.iter_mut().find(|p| p.name == active) {
+            p.settings = merged;
+        } else {
+            profiles.push(crate::config::Profile {
+                name: active,
+                settings: merged,
+            });
+        }
+    }
+    persist_profiles(scheduler).await;
+
+    {
+        let mut registry = scheduler.plugins.lock().await;
+        registry.insert(InstalledPlugin::from_manifest(manifest, added));
+    }
+    persist_plugins(scheduler).await;
+
+    InstallOutcome {
+        id: manifest.id.clone(),
+        name: manifest.name.clone(),
+        hints_added: summary.hints_added,
+        routines_added: summary.routines_added,
+    }
+}
+
+/// Uninstall the plugin `id`: remove exactly the content it added from the
+/// active profile and drop its registry record. No-op-safe if the user
+/// already deleted some of that content by hand. Returns what was removed.
+#[tauri::command]
+pub async fn uninstall_plugin(
+    scheduler: tauri::State<'_, Scheduler>,
+    id: String,
+) -> Result<MergeSummary, String> {
+    uninstall_by_id(scheduler.inner(), &id).await
+}
+
+/// Drop the registry record for `id` and remove its tracked content from the
+/// active profile, persisting both. Errors if `id` isn't installed. Split
+/// from the command wrapper so it's testable against a real `Scheduler`.
+async fn uninstall_by_id(scheduler: &Scheduler, id: &str) -> Result<MergeSummary, String> {
+    let removed = {
+        let mut registry = scheduler.plugins.lock().await;
+        registry.remove(id)
+    };
+    let Some(record) = removed else {
+        return Err(format!("plugin '{id}' is not installed"));
+    };
+    let outcome = apply_uninstall(scheduler, &record.added).await;
+    persist_plugins(scheduler).await;
+    Ok(outcome)
+}
+
+/// Remove `added` content from the active profile and persist. The registry
+/// entry is dropped by the caller; this only touches settings. Split out for
+/// unit testing. Returns `MergeSummary` repurposed as removal counts.
+async fn apply_uninstall(scheduler: &Scheduler, added: &AddedContent) -> MergeSummary {
+    let (merged, hints_removed, routines_removed) = {
+        let mut next = scheduler.settings.lock().await.clone();
+        let (h, r) = remove_content(&mut next, added);
+        next.rebuild_derived();
+        (next, h, r)
+    };
+    *scheduler.settings.lock().await = merged.clone();
+    {
+        let active = scheduler.active_profile_name.lock().await.clone();
+        let mut profiles = scheduler.profiles.lock().await;
+        if let Some(p) = profiles.iter_mut().find(|p| p.name == active) {
+            p.settings = merged;
+        }
+    }
+    persist_profiles(scheduler).await;
+    MergeSummary {
+        hints_added: hints_removed,
+        routines_added: routines_removed,
+    }
+}
+
+/// List installed plugins for the Settings UI.
+#[tauri::command]
+pub async fn list_plugins(
+    scheduler: tauri::State<'_, Scheduler>,
+) -> Result<Vec<PluginSummary>, String> {
+    Ok(scheduler.plugins.lock().await.summaries())
+}
+
+async fn confirm_install<R: Runtime>(app: &AppHandle<R>, manifest: &Manifest) -> bool {
+    use tauri_plugin_dialog::{
+        DialogExt, MessageDialogButtons, MessageDialogKind, MessageDialogResult,
+    };
+    let summary = format_install_summary(manifest);
+    let app = app.clone();
+    let (tx, rx) = tokio::sync::oneshot::channel::<MessageDialogResult>();
+    std::thread::spawn(move || {
+        let result = app
+            .dialog()
+            .message(summary)
+            .title("Entracte: install plugin")
+            .kind(MessageDialogKind::Warning)
+            .buttons(MessageDialogButtons::OkCancelCustom(
+                PLUGIN_DIALOG_CANCEL.to_string(),
+                PLUGIN_DIALOG_ALLOW.to_string(),
+            ))
+            .blocking_show_with_result();
+        let _ = tx.send(result);
+    });
+    match rx.await {
+        Ok(MessageDialogResult::Custom(label)) => label == PLUGIN_DIALOG_ALLOW,
+        _ => false,
+    }
+}
+
+/// Number of leading characters of the base64 signing key shown as a short
+/// visual fingerprint in the dialog, so a returning user can recognise a
+/// familiar author and spot a substituted one.
+const KEY_FINGERPRINT_CHARS: usize = 16;
+
+fn format_install_summary(manifest: &Manifest) -> String {
+    let pack_hints = manifest
+        .content
+        .as_ref()
+        .map(|p| {
+            p.hints.micro_physical.len()
+                + p.hints.micro_psychological.len()
+                + p.hints.long_solo.len()
+                + p.hints.long_social.len()
+                + p.hints.sleep.len()
+        })
+        .unwrap_or(0);
+    let pack_routines = manifest
+        .content
+        .as_ref()
+        .map(|p| p.routines.len())
+        .unwrap_or(0);
+
+    let author = if manifest.author.trim().is_empty() {
+        "(unknown author)".to_string()
+    } else {
+        sanitize_for_dialog(&manifest.author, 80)
+    };
+    let key: String = manifest
+        .signature
+        .public_key
+        .chars()
+        .take(KEY_FINGERPRINT_CHARS)
+        .collect();
+
+    let mut s = String::new();
+    s.push_str("⚠ Only click Install if you chose this plugin file yourself.\n");
+    s.push_str("Installing adds its break ideas and routines to your active profile.\n\n");
+    s.push_str(&format!(
+        "Plugin: {}\n",
+        sanitize_for_dialog(&manifest.name, 120)
+    ));
+    s.push_str(&format!("Author: {author}\n"));
+    s.push_str(&format!(
+        "Version: {}\n",
+        sanitize_for_dialog(&manifest.version, 40)
+    ));
+    s.push_str(&format!("Signing key: {key}…\n\n"));
+    s.push_str(&format!(
+        "Adds up to {pack_hints} idea(s) and {pack_routines} routine(s) (duplicates are skipped).\n"
+    ));
+    s
+}
+
+/// Same control-character / bidi sanitisation as the hooks dialog, so a
+/// hostile manifest can't spoof or scramble the consent prompt.
+fn sanitize_for_dialog(s: &str, max_chars: usize) -> String {
+    let mut out = String::with_capacity(s.len().min(max_chars * 4));
+    for (count, c) in s.chars().enumerate() {
+        if count >= max_chars {
+            out.push('…');
+            break;
+        }
+        let replacement = match c {
+            '\n' | '\r' | '\t' => Some('␣'),
+            c if (c as u32) < 0x20 || c as u32 == 0x7F => Some('·'),
+            '\u{202A}'..='\u{202E}' | '\u{2066}'..='\u{2069}' | '\u{200E}' | '\u{200F}' => {
+                Some('·')
+            }
+            _ => None,
+        };
+        out.push(replacement.unwrap_or(c));
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::plugins::{PluginKind, Signature};
+    use crate::scheduler::content_pack::{ContentPack, PackHints, CONTENT_PACK_VERSION};
+    use crate::scheduler::routines::{Routine, RoutineCategory, RoutineDifficulty, RoutineKind};
+    use crate::scheduler::types::RoutineStep;
+    use crate::scheduler::BreakKind;
+    use crate::test_support::test_scheduler;
+
+    fn content_manifest(id: &str) -> Manifest {
+        Manifest {
+            manifest_version: crate::plugins::MANIFEST_VERSION,
+            id: id.to_string(),
+            name: "Stretch pack".to_string(),
+            version: "1.0.0".to_string(),
+            author: "Jane".to_string(),
+            description: String::new(),
+            kind: PluginKind::Content,
+            module: None,
+            abi_version: None,
+            imports: vec![],
+            content: Some(ContentPack {
+                version: CONTENT_PACK_VERSION,
+                name: "Stretch pack".to_string(),
+                hints: PackHints {
+                    micro_physical: vec!["Roll your shoulders".to_string()],
+                    ..PackHints::default()
+                },
+                routines: vec![Routine {
+                    id: "plugin-rt".to_string(),
+                    label: "Plugin routine".to_string(),
+                    kind: RoutineKind::Micro,
+                    category: RoutineCategory::Eyes,
+                    difficulty: RoutineDifficulty::Gentle,
+                    steps: vec![RoutineStep {
+                        text: "Look away".to_string(),
+                        seconds: 5,
+                    }],
+                }],
+            }),
+            signature: Signature {
+                alg: "ed25519".to_string(),
+                public_key: "QUJDREVGR0hJSktMTU5PUA==".to_string(),
+                sig: String::new(),
+            },
+        }
+    }
+
+    #[tokio::test]
+    async fn install_then_uninstall_round_trips_settings_and_registry() {
+        let (_dir, sched) = test_scheduler(crate::scheduler::Settings::default());
+        let before = sched.settings.lock().await.micro_physical_hints.clone();
+
+        let manifest = content_manifest("com.example.stretch");
+        let outcome = apply_install(&sched, &manifest).await;
+        assert_eq!(outcome.hints_added, 1);
+        assert_eq!(outcome.routines_added, 1);
+
+        // Registry recorded it, and the derived cache the fire path reads was
+        // rebuilt so the idea is actually live.
+        assert!(sched.plugins.lock().await.contains("com.example.stretch"));
+        {
+            let s = sched.settings.lock().await;
+            assert!(s
+                .effective_hints(BreakKind::Micro)
+                .contains(&"Roll your shoulders".to_string()));
+            assert!(s.custom_routines.iter().any(|r| r.id == "plugin-rt"));
+        }
+
+        // Uninstall removes exactly what was added.
+        let record = sched
+            .plugins
+            .lock()
+            .await
+            .remove("com.example.stretch")
+            .unwrap();
+        let removed = apply_uninstall(&sched, &record.added).await;
+        assert_eq!(removed.hints_added, 1);
+        assert_eq!(removed.routines_added, 1);
+        let s = sched.settings.lock().await;
+        assert_eq!(s.micro_physical_hints, before);
+        assert!(!s.custom_routines.iter().any(|r| r.id == "plugin-rt"));
+    }
+
+    #[tokio::test]
+    async fn uninstall_by_id_errors_when_not_installed() {
+        let (_dir, sched) = test_scheduler(crate::scheduler::Settings::default());
+        let err = uninstall_by_id(&sched, "com.nope.absent")
+            .await
+            .unwrap_err();
+        assert!(err.contains("not installed"));
+    }
+
+    #[tokio::test]
+    async fn uninstall_by_id_removes_tracked_content_and_record() {
+        let (_dir, sched) = test_scheduler(crate::scheduler::Settings::default());
+        apply_install(&sched, &content_manifest("com.example.stretch")).await;
+        let removed = uninstall_by_id(&sched, "com.example.stretch")
+            .await
+            .unwrap();
+        assert_eq!(removed.hints_added, 1);
+        assert_eq!(removed.routines_added, 1);
+        assert!(!sched.plugins.lock().await.contains("com.example.stretch"));
+    }
+
+    #[test]
+    fn read_manifest_text_reads_a_file_and_reports_a_missing_one() {
+        let dir = crate::test_support::temp_dir();
+        let path = dir.path().join("plugin.json");
+        std::fs::write(&path, b"{\"hello\":true}").unwrap();
+        assert_eq!(
+            read_manifest_text(&path.display().to_string()).unwrap(),
+            "{\"hello\":true}"
+        );
+
+        let missing = dir.path().join("nope.json");
+        assert!(read_manifest_text(&missing.display().to_string())
+            .unwrap_err()
+            .contains("failed to read plugin file"));
+    }
+
+    #[tokio::test]
+    async fn apply_install_writes_into_the_active_profile() {
+        let (_dir, sched) = test_scheduler(crate::scheduler::Settings::default());
+        apply_install(&sched, &content_manifest("com.example.stretch")).await;
+        let active = sched.active_profile_name.lock().await.clone();
+        let profiles = sched.profiles.lock().await;
+        let p = profiles.iter().find(|p| p.name == active).unwrap();
+        assert!(p
+            .settings
+            .custom_routines
+            .iter()
+            .any(|r| r.id == "plugin-rt"));
+    }
+
+    #[test]
+    fn format_install_summary_shows_provenance_and_counts() {
+        let m = content_manifest("com.example.stretch");
+        let s = format_install_summary(&m);
+        assert!(s.contains("Stretch pack"));
+        assert!(s.contains("Jane"));
+        assert!(s.contains("1.0.0"));
+        assert!(s.contains("Signing key:"));
+        assert!(s.contains("1 idea(s) and 1 routine(s)"));
+        let warn = s.find("Only click Install").unwrap();
+        let body = s.find("Adds up to").unwrap();
+        assert!(warn < body, "safety warning must come first");
+    }
+
+    #[test]
+    fn format_install_summary_handles_missing_author() {
+        let mut m = content_manifest("com.example.stretch");
+        m.author = "   ".to_string();
+        assert!(format_install_summary(&m).contains("(unknown author)"));
+    }
+
+    #[test]
+    fn sanitize_for_dialog_strips_control_and_bidi() {
+        let out = sanitize_for_dialog("a\nb\u{202E}c", 100);
+        assert!(!out.contains('\n'));
+        assert!(!out.contains('\u{202E}'));
+    }
+
+    #[test]
+    fn dialog_busy_guard_resets_flag_on_drop() {
+        let flag = Arc::new(AtomicBool::new(true));
+        {
+            let _g = DialogBusyGuard(flag.clone());
+        }
+        assert!(!flag.load(std::sync::atomic::Ordering::Acquire));
+    }
+}

--- a/src-tauri/src/scheduler/commands/plugins.rs
+++ b/src-tauri/src/scheduler/commands/plugins.rs
@@ -438,6 +438,33 @@ mod tests {
             .contains("failed to read plugin file"));
     }
 
+    #[test]
+    fn read_manifest_text_rejects_an_oversized_file() {
+        let dir = crate::test_support::temp_dir();
+        let path = dir.path().join("huge.json");
+        std::fs::write(&path, vec![b'x'; (MAX_MANIFEST_BYTES + 1) as usize]).unwrap();
+        assert!(read_manifest_text(&path.display().to_string())
+            .unwrap_err()
+            .contains("too large"));
+    }
+
+    #[tokio::test]
+    async fn apply_install_pushes_active_profile_when_absent() {
+        let (_dir, sched) = test_scheduler(crate::scheduler::Settings::default());
+        *sched.active_profile_name.lock().await = "Ghost".to_string();
+        apply_install(&sched, &content_manifest("com.example.stretch")).await;
+        let profiles = sched.profiles.lock().await;
+        let ghost = profiles
+            .iter()
+            .find(|p| p.name == "Ghost")
+            .expect("absent active profile was pushed");
+        assert!(ghost
+            .settings
+            .custom_routines
+            .iter()
+            .any(|r| r.id == "plugin-rt"));
+    }
+
     #[tokio::test]
     async fn apply_install_writes_into_the_active_profile() {
         let (_dir, sched) = test_scheduler(crate::scheduler::Settings::default());
@@ -481,11 +508,211 @@ mod tests {
     }
 
     #[test]
+    fn sanitize_for_dialog_clips_at_max_chars() {
+        let out = sanitize_for_dialog(&"x".repeat(50), 8);
+        assert_eq!(out.chars().count(), 9); // 8 + the ellipsis
+        assert!(out.ends_with('…'));
+    }
+
+    #[test]
     fn dialog_busy_guard_resets_flag_on_drop() {
         let flag = Arc::new(AtomicBool::new(true));
         {
             let _g = DialogBusyGuard(flag.clone());
         }
         assert!(!flag.load(std::sync::atomic::Ordering::Acquire));
+    }
+}
+
+// Integration tests that need a Tauri `AppHandle` / `WebviewWindow` /
+// `State`, driven through `tauri::test`'s MockRuntime. Gated off Windows
+// like the rest of the mock-app rig (see Cargo.toml). These cover the
+// command wrappers around the unit-tested cores: the main-window gate,
+// `list_plugins`, `uninstall_plugin`, and `install_content_plugin`'s
+// pre-dialog error paths. The native confirmation dialog itself can't be
+// driven headless, so the post-consent install path is covered via
+// `apply_install` in the unit tests above.
+#[cfg(all(test, not(target_os = "windows")))]
+mod mock_app_tests {
+    use super::*;
+    use crate::plugins::{InstalledPlugin, PluginKind};
+    use crate::scheduler::content_pack::AddedContent;
+    use crate::test_support::{temp_dir, test_scheduler, wrap_in_mock_app};
+    use tauri::test::MockRuntime;
+    use tauri::{App, Manager, WebviewWindowBuilder};
+
+    fn webview(app: &App<MockRuntime>, label: &str) -> tauri::WebviewWindow<MockRuntime> {
+        WebviewWindowBuilder::new(app, label, Default::default())
+            .build()
+            .expect("mock webview builds")
+    }
+
+    fn installed(id: &str) -> InstalledPlugin {
+        InstalledPlugin {
+            id: id.to_string(),
+            name: "Pack".to_string(),
+            author: "Me".to_string(),
+            version: "1.0.0".to_string(),
+            kind: PluginKind::Content,
+            public_key: "AA==".to_string(),
+            added: AddedContent {
+                micro_physical: vec!["Stretch".to_string()],
+                ..AddedContent::default()
+            },
+        }
+    }
+
+    #[tokio::test]
+    async fn ensure_main_window_accepts_main_rejects_others() {
+        let (_dir, sched) = test_scheduler(crate::scheduler::Settings::default());
+        let app = wrap_in_mock_app(sched);
+        assert!(ensure_main_window(&webview(&app, MAIN_WINDOW_LABEL)).is_ok());
+        assert!(ensure_main_window(&webview(&app, "overlay"))
+            .unwrap_err()
+            .contains("restricted to the main window"));
+    }
+
+    #[tokio::test]
+    async fn list_plugins_command_returns_summaries() {
+        let (_dir, sched) = test_scheduler(crate::scheduler::Settings::default());
+        sched.plugins.lock().await.insert(installed("com.x.pack"));
+        let app = wrap_in_mock_app(sched);
+        let out = list_plugins(app.state::<Scheduler>()).await.unwrap();
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].id, "com.x.pack");
+        assert_eq!(out[0].hints_added, 1);
+    }
+
+    #[tokio::test]
+    async fn uninstall_plugin_command_removes_record() {
+        let (_dir, sched) = test_scheduler(crate::scheduler::Settings::default());
+        sched.plugins.lock().await.insert(installed("com.x.pack"));
+        let app = wrap_in_mock_app(sched.clone());
+        uninstall_plugin(app.state::<Scheduler>(), "com.x.pack".to_string())
+            .await
+            .unwrap();
+        assert!(!sched.plugins.lock().await.contains("com.x.pack"));
+
+        // The not-installed path through the wrapper.
+        assert!(
+            uninstall_plugin(app.state::<Scheduler>(), "com.nope".to_string())
+                .await
+                .unwrap_err()
+                .contains("not installed")
+        );
+    }
+
+    #[tokio::test]
+    async fn install_rejects_a_non_main_window_before_any_dialog() {
+        let (_dir, sched) = test_scheduler(crate::scheduler::Settings::default());
+        let app = wrap_in_mock_app(sched);
+        let err = install_content_plugin(
+            app.handle().clone(),
+            webview(&app, "overlay"),
+            app.state::<Scheduler>(),
+            "/whatever.json".to_string(),
+        )
+        .await
+        .unwrap_err();
+        assert!(err.contains("restricted to the main window"));
+    }
+
+    #[tokio::test]
+    async fn install_reports_an_unreadable_file_before_any_dialog() {
+        let (_dir, sched) = test_scheduler(crate::scheduler::Settings::default());
+        let app = wrap_in_mock_app(sched);
+        let err = install_content_plugin(
+            app.handle().clone(),
+            webview(&app, MAIN_WINDOW_LABEL),
+            app.state::<Scheduler>(),
+            "/no/such/plugin.json".to_string(),
+        )
+        .await
+        .unwrap_err();
+        assert!(err.contains("failed to read plugin file"));
+    }
+
+    #[tokio::test]
+    async fn install_rejects_a_malformed_manifest_before_any_dialog() {
+        let (_dir, sched) = test_scheduler(crate::scheduler::Settings::default());
+        let app = wrap_in_mock_app(sched);
+        let dir = temp_dir();
+        let path = dir.path().join("bad.json");
+        std::fs::write(&path, b"{ not a manifest").unwrap();
+        let err = install_content_plugin(
+            app.handle().clone(),
+            webview(&app, MAIN_WINDOW_LABEL),
+            app.state::<Scheduler>(),
+            path.display().to_string(),
+        )
+        .await
+        .unwrap_err();
+        assert!(err.contains("not a valid plugin manifest"));
+    }
+
+    /// Write a validly-signed content-plugin manifest to a temp file and
+    /// return its path. Lets the install command get past `prepare_content_
+    /// install` to the dialog-guard logic.
+    fn write_signed_content_plugin(dir: &std::path::Path) -> String {
+        use crate::plugins::{signing_payload, Signature};
+        use crate::scheduler::content_pack::{ContentPack, PackHints, CONTENT_PACK_VERSION};
+        use base64::prelude::{Engine, BASE64_STANDARD};
+        use ed25519_dalek::{Signer, SigningKey};
+
+        let mut m = Manifest {
+            manifest_version: crate::plugins::MANIFEST_VERSION,
+            id: "com.example.signed".to_string(),
+            name: "Signed pack".to_string(),
+            version: "1.0.0".to_string(),
+            author: "Jane".to_string(),
+            description: String::new(),
+            kind: crate::plugins::PluginKind::Content,
+            module: None,
+            abi_version: None,
+            imports: vec![],
+            content: Some(ContentPack {
+                version: CONTENT_PACK_VERSION,
+                name: "Signed pack".to_string(),
+                hints: PackHints {
+                    micro_physical: vec!["Breathe".to_string()],
+                    ..PackHints::default()
+                },
+                routines: vec![],
+            }),
+            signature: Signature {
+                alg: "ed25519".to_string(),
+                public_key: String::new(),
+                sig: String::new(),
+            },
+        };
+        let key = SigningKey::from_bytes(&[11u8; 32]);
+        m.signature.public_key = BASE64_STANDARD.encode(key.verifying_key().to_bytes());
+        m.signature.sig = BASE64_STANDARD.encode(key.sign(&signing_payload(&m, None)).to_bytes());
+        let path = dir.join("signed.json");
+        std::fs::write(&path, serde_json::to_string(&m).unwrap()).unwrap();
+        path.display().to_string()
+    }
+
+    #[tokio::test]
+    async fn install_rejects_when_a_dialog_is_already_pending() {
+        // A valid signed plugin gets past prepare; with the dialog flag
+        // already set, the single-flight guard rejects before any dialog —
+        // exercising the guard branch without a blocking native prompt.
+        let (_dir, sched) = test_scheduler(crate::scheduler::Settings::default());
+        sched
+            .plugin_dialog_busy
+            .store(true, std::sync::atomic::Ordering::Release);
+        let app = wrap_in_mock_app(sched);
+        let dir = temp_dir();
+        let path = write_signed_content_plugin(dir.path());
+        let err = install_content_plugin(
+            app.handle().clone(),
+            webview(&app, MAIN_WINDOW_LABEL),
+            app.state::<Scheduler>(),
+            path,
+        )
+        .await
+        .unwrap_err();
+        assert!(err.contains("another plugin install is already pending"));
     }
 }

--- a/src-tauri/src/scheduler/content_pack.rs
+++ b/src-tauri/src/scheduler/content_pack.rs
@@ -159,10 +159,11 @@ pub fn validate_pack(pack: &ContentPack) -> Result<(), String> {
 }
 
 /// Append `additions` to `pool`, skipping blanks and exact duplicates
-/// (against both the existing pool and earlier additions). Returns the count
-/// actually added. Order-preserving and non-clobbering.
-fn merge_pool(pool: &mut Vec<String>, additions: &[String]) -> usize {
-    let mut added = 0;
+/// (against both the existing pool and earlier additions). Returns the
+/// strings actually added (so an uninstall can remove exactly those).
+/// Order-preserving and non-clobbering.
+fn merge_pool(pool: &mut Vec<String>, additions: &[String]) -> Vec<String> {
+    let mut added = Vec::new();
     for hint in additions {
         let trimmed = hint.trim();
         if trimmed.is_empty() {
@@ -172,43 +173,112 @@ fn merge_pool(pool: &mut Vec<String>, additions: &[String]) -> usize {
             continue;
         }
         pool.push(hint.clone());
-        added += 1;
+        added.push(hint.clone());
     }
     added
 }
 
-/// Merge a validated pack into `settings`: append hints to each pool and add
-/// routines to `custom_routines`, skipping ids that collide with a bundled
-/// starter or an already-present custom routine. Non-destructive — nothing is
-/// removed or overwritten. Returns what was added.
-pub fn merge_pack(pack: &ContentPack, settings: &mut Settings) -> MergeSummary {
-    let mut summary = MergeSummary::default();
-    summary.hints_added += merge_pool(
-        &mut settings.micro_physical_hints,
-        &pack.hints.micro_physical,
-    );
-    summary.hints_added += merge_pool(
-        &mut settings.micro_psychological_hints,
-        &pack.hints.micro_psychological,
-    );
-    summary.hints_added += merge_pool(&mut settings.long_hints, &pack.hints.long_solo);
-    summary.hints_added += merge_pool(&mut settings.long_social_hints, &pack.hints.long_social);
-    summary.hints_added += merge_pool(&mut settings.sleep_hints, &pack.hints.sleep);
+/// The concrete content a merge added, so an uninstall can remove exactly
+/// those entries (the merge-and-track model). Mirrors [`PackHints`] plus the
+/// ids of routines that were appended to `custom_routines`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AddedContent {
+    #[serde(default)]
+    pub micro_physical: Vec<String>,
+    #[serde(default)]
+    pub micro_psychological: Vec<String>,
+    #[serde(default)]
+    pub long_solo: Vec<String>,
+    #[serde(default)]
+    pub long_social: Vec<String>,
+    #[serde(default)]
+    pub sleep: Vec<String>,
+    #[serde(default)]
+    pub routine_ids: Vec<String>,
+}
 
-    let mut taken: std::collections::HashSet<String> = starter_routines()
-        .into_iter()
-        .map(|r| r.id)
-        .chain(settings.custom_routines.iter().map(|r| r.id.clone()))
-        .collect();
-    for r in &pack.routines {
-        if taken.contains(&r.id) {
-            continue;
-        }
-        taken.insert(r.id.clone());
-        settings.custom_routines.push(r.clone());
-        summary.routines_added += 1;
+/// Merge a validated pack into `settings`, recording exactly what was added.
+/// Append hints to each pool and routines to `custom_routines`, skipping ids
+/// that collide with a bundled starter or an already-present custom routine.
+/// Non-destructive — nothing is removed or overwritten. Returns the summary
+/// counts plus the concrete [`AddedContent`] for a later [`remove_content`].
+pub fn merge_pack_tracked(
+    pack: &ContentPack,
+    settings: &mut Settings,
+) -> (MergeSummary, AddedContent) {
+    let added = AddedContent {
+        micro_physical: merge_pool(
+            &mut settings.micro_physical_hints,
+            &pack.hints.micro_physical,
+        ),
+        micro_psychological: merge_pool(
+            &mut settings.micro_psychological_hints,
+            &pack.hints.micro_psychological,
+        ),
+        long_solo: merge_pool(&mut settings.long_hints, &pack.hints.long_solo),
+        long_social: merge_pool(&mut settings.long_social_hints, &pack.hints.long_social),
+        sleep: merge_pool(&mut settings.sleep_hints, &pack.hints.sleep),
+        routine_ids: {
+            let mut taken: std::collections::HashSet<String> = starter_routines()
+                .into_iter()
+                .map(|r| r.id)
+                .chain(settings.custom_routines.iter().map(|r| r.id.clone()))
+                .collect();
+            let mut ids = Vec::new();
+            for r in &pack.routines {
+                if taken.contains(&r.id) {
+                    continue;
+                }
+                taken.insert(r.id.clone());
+                settings.custom_routines.push(r.clone());
+                ids.push(r.id.clone());
+            }
+            ids
+        },
+    };
+    let summary = MergeSummary {
+        hints_added: added.micro_physical.len()
+            + added.micro_psychological.len()
+            + added.long_solo.len()
+            + added.long_social.len()
+            + added.sleep.len(),
+        routines_added: added.routine_ids.len(),
+    };
+    (summary, added)
+}
+
+/// Merge a validated pack into `settings`, returning only the summary counts.
+/// Thin wrapper over [`merge_pack_tracked`] for the content-pack import path,
+/// which has no uninstall and so doesn't need the [`AddedContent`] record.
+pub fn merge_pack(pack: &ContentPack, settings: &mut Settings) -> MergeSummary {
+    merge_pack_tracked(pack, settings).0
+}
+
+/// Remove exactly the content recorded in `added` from `settings` (the
+/// uninstall half of merge-and-track): drop the recorded hint strings from
+/// each pool and the recorded routine ids from `custom_routines`. Tolerant
+/// of intervening user edits — anything already gone is simply skipped.
+/// Returns `(hints_removed, routines_removed)`.
+pub fn remove_content(settings: &mut Settings, added: &AddedContent) -> (usize, usize) {
+    fn drop_all(pool: &mut Vec<String>, remove: &[String]) -> usize {
+        let before = pool.len();
+        pool.retain(|h| !remove.contains(h));
+        before - pool.len()
     }
-    summary
+    let hints_removed = drop_all(&mut settings.micro_physical_hints, &added.micro_physical)
+        + drop_all(
+            &mut settings.micro_psychological_hints,
+            &added.micro_psychological,
+        )
+        + drop_all(&mut settings.long_hints, &added.long_solo)
+        + drop_all(&mut settings.long_social_hints, &added.long_social)
+        + drop_all(&mut settings.sleep_hints, &added.sleep);
+    let before = settings.custom_routines.len();
+    settings
+        .custom_routines
+        .retain(|r| !added.routine_ids.contains(&r.id));
+    let routines_removed = before - settings.custom_routines.len();
+    (hints_removed, routines_removed)
 }
 
 /// Build a content pack capturing the user's current pools + custom routines,
@@ -383,6 +453,68 @@ mod tests {
         assert_eq!(dst.long_social_hints, src.long_social_hints);
         assert_eq!(dst.sleep_hints, src.sleep_hints);
         assert_eq!(dst.custom_routines, src.custom_routines);
+    }
+
+    #[test]
+    fn merge_pack_tracked_records_exact_additions() {
+        let mut s = Settings {
+            micro_physical_hints: Vec::new(),
+            sleep_hints: Vec::new(),
+            custom_routines: Vec::new(),
+            ..Settings::default()
+        };
+        let pack = pack_with(
+            vec![sample_routine("rt-a")],
+            PackHints {
+                micro_physical: vec!["Stand up".to_string()],
+                sleep: vec!["Dim the lights".to_string()],
+                ..PackHints::default()
+            },
+        );
+        let (summary, added) = merge_pack_tracked(&pack, &mut s);
+        assert_eq!(summary.hints_added, 2);
+        assert_eq!(summary.routines_added, 1);
+        assert_eq!(added.micro_physical, vec!["Stand up".to_string()]);
+        assert_eq!(added.sleep, vec!["Dim the lights".to_string()]);
+        assert_eq!(added.routine_ids, vec!["rt-a".to_string()]);
+    }
+
+    #[test]
+    fn remove_content_undoes_a_tracked_merge() {
+        let mut s = Settings::default();
+        let before_physical = s.micro_physical_hints.clone();
+        let before_routines = s.custom_routines.len();
+        let pack = pack_with(
+            vec![sample_routine("rt-x")],
+            PackHints {
+                micro_physical: vec!["A brand-new idea".to_string()],
+                ..PackHints::default()
+            },
+        );
+        let (_, added) = merge_pack_tracked(&pack, &mut s);
+        assert!(s
+            .micro_physical_hints
+            .contains(&"A brand-new idea".to_string()));
+
+        let (hints_removed, routines_removed) = remove_content(&mut s, &added);
+        assert_eq!(hints_removed, 1);
+        assert_eq!(routines_removed, 1);
+        // Back to exactly the pre-merge state — no collateral removal.
+        assert_eq!(s.micro_physical_hints, before_physical);
+        assert_eq!(s.custom_routines.len(), before_routines);
+    }
+
+    #[test]
+    fn remove_content_tolerates_entries_the_user_already_deleted() {
+        let mut s = Settings::default();
+        let added = AddedContent {
+            micro_physical: vec!["never present".to_string()],
+            routine_ids: vec!["ghost".to_string()],
+            ..AddedContent::default()
+        };
+        let (hints_removed, routines_removed) = remove_content(&mut s, &added);
+        assert_eq!(hints_removed, 0);
+        assert_eq!(routines_removed, 0);
     }
 
     #[test]

--- a/src-tauri/src/scheduler/mod.rs
+++ b/src-tauri/src/scheduler/mod.rs
@@ -327,3 +327,22 @@ pub async fn persist_plugins(sched: &Scheduler) {
         );
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::plugins_path_for;
+    use std::path::PathBuf;
+
+    #[test]
+    fn plugins_path_is_beside_settings() {
+        let p = plugins_path_for(&PathBuf::from("/cfg/dir/settings.json"));
+        assert_eq!(p, PathBuf::from("/cfg/dir/plugins.json"));
+    }
+
+    #[test]
+    fn plugins_path_falls_back_when_config_has_no_parent() {
+        let p = plugins_path_for(&PathBuf::from("settings.json"));
+        // A bare filename has a parent of "" — joining still yields the file.
+        assert_eq!(p.file_name().unwrap(), "plugins.json");
+    }
+}

--- a/src-tauri/src/scheduler/mod.rs
+++ b/src-tauri/src/scheduler/mod.rs
@@ -1,6 +1,6 @@
 mod break_stats;
 mod commands;
-mod content_pack;
+pub(crate) mod content_pack;
 mod hotkeys;
 mod overlay;
 mod pause;
@@ -35,6 +35,7 @@ pub use commands::backup::*;
 pub use commands::breaks::*;
 pub use commands::content_pack::*;
 pub use commands::hooks::*;
+pub use commands::plugins::*;
 pub use commands::profiles::*;
 pub use commands::settings::*;
 pub use commands::stats::*;
@@ -143,6 +144,14 @@ pub struct Scheduler {
     pub pause_path: PathBuf,
     pub events_path: PathBuf,
     pub screen_time_path: PathBuf,
+    /// Installed content plugins + the merge-and-track record of what each
+    /// added, persisted to `plugins.json` beside `settings.json`. See
+    /// `docs/developer/plugin-api-design.md`.
+    pub plugins_path: PathBuf,
+    pub plugins: Arc<Mutex<crate::plugins::PluginRegistry>>,
+    /// Single-flight guard for the plugin-install confirmation dialog,
+    /// mirroring [`Scheduler::hook_dialog_busy`].
+    pub plugin_dialog_busy: Arc<AtomicBool>,
     pub timers: Arc<Mutex<BreakTimers>>,
     pub stats: Arc<Mutex<BreakStats>>,
     pub screen_time: Arc<Mutex<InternalScreenTimeState>>,
@@ -188,6 +197,8 @@ impl Scheduler {
             crate::screen_time_store::load(&screen_time_path),
             &today,
         );
+        let plugins_path = plugins_path_for(&config_path);
+        let plugins = crate::plugin_store::load(&plugins_path);
         Self {
             settings: Arc::new(Mutex::new(initial)),
             pause_state: Arc::new(Mutex::new(pause_state)),
@@ -198,6 +209,9 @@ impl Scheduler {
             pause_path,
             events_path,
             screen_time_path,
+            plugins_path,
+            plugins: Arc::new(Mutex::new(plugins)),
+            plugin_dialog_busy: Arc::new(AtomicBool::new(false)),
             timers: Arc::new(Mutex::new(BreakTimers::new())),
             stats: Arc::new(Mutex::new(BreakStats::default())),
             screen_time: Arc::new(Mutex::new(screen_time)),
@@ -249,6 +263,9 @@ impl Scheduler {
             pause_path: dir.join("pause.json"),
             events_path: events_path.clone(),
             screen_time_path: dir.join("screen_time.json"),
+            plugins_path: dir.join("plugins.json"),
+            plugins: Arc::new(Mutex::new(crate::plugins::PluginRegistry::default())),
+            plugin_dialog_busy: Arc::new(AtomicBool::new(false)),
             timers: Arc::new(Mutex::new(BreakTimers::new())),
             stats: Arc::new(Mutex::new(BreakStats::default())),
             screen_time: Arc::new(Mutex::new(InternalScreenTimeState::from_snapshot(
@@ -285,6 +302,28 @@ pub async fn persist_profiles(sched: &Scheduler) {
         warn!(
             "config: failed to save {}: {e}",
             sched.config_path.display()
+        );
+    }
+}
+
+/// The plugin registry lives beside `settings.json` in the same config dir.
+/// Derived rather than threaded through `Scheduler::new` so adding it didn't
+/// change the constructor signature.
+pub(crate) fn plugins_path_for(config_path: &std::path::Path) -> PathBuf {
+    match config_path.parent() {
+        Some(dir) => dir.join("plugins.json"),
+        None => PathBuf::from("plugins.json"),
+    }
+}
+
+/// Atomically persist the installed-plugin registry. Called after every
+/// install / uninstall so a crash never loses the merge-and-track record.
+pub async fn persist_plugins(sched: &Scheduler) {
+    let registry = sched.plugins.lock().await.clone();
+    if let Err(e) = crate::plugin_store::save(&sched.plugins_path, &registry) {
+        warn!(
+            "plugin_store: failed to save {}: {e}",
+            sched.plugins_path.display()
         );
     }
 }

--- a/src-tauri/src/scheduler/tray_countdown.rs
+++ b/src-tauri/src/scheduler/tray_countdown.rs
@@ -321,6 +321,9 @@ mod tests {
             pause_path,
             events_path,
             screen_time_path,
+            plugins_path: dir.path().join("plugins.json"),
+            plugins: Arc::new(TokioMutex::new(crate::plugins::PluginRegistry::default())),
+            plugin_dialog_busy: Arc::new(AtomicBool::new(false)),
             timers: Arc::new(TokioMutex::new(BreakTimers::new())),
             stats: Arc::new(TokioMutex::new(BreakStats::default())),
             screen_time: Arc::new(TokioMutex::new(ScreenTimeState::from_snapshot(

--- a/src/views/settings/components/plugins.test.tsx
+++ b/src/views/settings/components/plugins.test.tsx
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+
+const invoke = vi.fn();
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (...a: unknown[]) => invoke(...a),
+}));
+
+const openDialog = vi.fn();
+vi.mock("@tauri-apps/plugin-dialog", () => ({
+  open: (...a: unknown[]) => openDialog(...a),
+}));
+
+const { Plugins } = await import("./plugins");
+
+function summary(over: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: "com.example.stretch",
+    name: "Stretch pack",
+    author: "Jane",
+    version: "1.0.0",
+    kind: "content",
+    hints_added: 2,
+    routines_added: 1,
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  invoke.mockReset();
+  openDialog.mockReset();
+});
+
+describe("Plugins", () => {
+  it("lists installed plugins on mount", async () => {
+    invoke.mockImplementation((cmd: string) =>
+      cmd === "list_plugins" ? Promise.resolve([summary()]) : Promise.resolve(),
+    );
+    render(<Plugins reload={async () => {}} />);
+    expect(await screen.findByText("Stretch pack")).toBeTruthy();
+    expect(screen.getByText(/Jane · v1.0.0 · 2 ideas, 1 routine/)).toBeTruthy();
+  });
+
+  it("shows an empty state when nothing is installed", async () => {
+    invoke.mockResolvedValue([]);
+    render(<Plugins reload={async () => {}} />);
+    expect(await screen.findByText("No plugins installed.")).toBeTruthy();
+  });
+
+  it("guards against a non-array list result", async () => {
+    // The shared test harness mocks invoke to resolve a string; the
+    // component must not crash trying to map over it.
+    invoke.mockResolvedValue("linux");
+    render(<Plugins reload={async () => {}} />);
+    expect(await screen.findByText("No plugins installed.")).toBeTruthy();
+  });
+
+  it("installs the chosen file and reloads", async () => {
+    openDialog.mockResolvedValue("/tmp/pack.json");
+    const reload = vi.fn(async () => {});
+    let installed = false;
+    invoke.mockImplementation((cmd: string) => {
+      if (cmd === "list_plugins") {
+        return Promise.resolve(installed ? [summary()] : []);
+      }
+      if (cmd === "install_content_plugin") {
+        installed = true;
+        return Promise.resolve({
+          id: "com.example.stretch",
+          name: "Stretch pack",
+          hints_added: 2,
+          routines_added: 1,
+        });
+      }
+      return Promise.resolve();
+    });
+
+    render(<Plugins reload={reload} />);
+    await screen.findByText("No plugins installed.");
+    fireEvent.click(screen.getByRole("button", { name: /install plugin/i }));
+
+    await waitFor(() =>
+      expect(invoke).toHaveBeenCalledWith("install_content_plugin", {
+        path: "/tmp/pack.json",
+      }),
+    );
+    expect(reload).toHaveBeenCalled();
+    expect(await screen.findByText(/Installed "Stretch pack"/)).toBeTruthy();
+  });
+
+  it("does nothing when the file dialog is cancelled", async () => {
+    openDialog.mockResolvedValue(null);
+    invoke.mockResolvedValue([]);
+    render(<Plugins reload={async () => {}} />);
+    await screen.findByText("No plugins installed.");
+    fireEvent.click(screen.getByRole("button", { name: /install plugin/i }));
+    await waitFor(() => expect(openDialog).toHaveBeenCalled());
+    expect(invoke).not.toHaveBeenCalledWith(
+      "install_content_plugin",
+      expect.anything(),
+    );
+  });
+
+  it("uninstalls a plugin and reloads", async () => {
+    const reload = vi.fn(async () => {});
+    let present = true;
+    invoke.mockImplementation((cmd: string) => {
+      if (cmd === "list_plugins") {
+        return Promise.resolve(present ? [summary()] : []);
+      }
+      if (cmd === "uninstall_plugin") {
+        present = false;
+        return Promise.resolve({ hints_added: 2, routines_added: 1 });
+      }
+      return Promise.resolve();
+    });
+
+    render(<Plugins reload={reload} />);
+    await screen.findByText("Stretch pack");
+    fireEvent.click(
+      screen.getByRole("button", { name: /uninstall stretch pack/i }),
+    );
+
+    await waitFor(() =>
+      expect(invoke).toHaveBeenCalledWith("uninstall_plugin", {
+        id: "com.example.stretch",
+      }),
+    );
+    expect(reload).toHaveBeenCalled();
+    expect(await screen.findByText(/Removed "Stretch pack"/)).toBeTruthy();
+  });
+
+  it("surfaces an install error", async () => {
+    openDialog.mockResolvedValue("/tmp/bad.json");
+    invoke.mockImplementation((cmd: string) => {
+      if (cmd === "list_plugins") return Promise.resolve([]);
+      if (cmd === "install_content_plugin") {
+        return Promise.reject("signature does not match the manifest");
+      }
+      return Promise.resolve();
+    });
+    render(<Plugins reload={async () => {}} />);
+    await screen.findByText("No plugins installed.");
+    fireEvent.click(screen.getByRole("button", { name: /install plugin/i }));
+    expect(await screen.findByText(/Install failed/)).toBeTruthy();
+  });
+});

--- a/src/views/settings/components/plugins.test.tsx
+++ b/src/views/settings/components/plugins.test.tsx
@@ -148,6 +148,20 @@ describe("Plugins", () => {
     expect(await screen.findByText(/Removed "Stretch pack"/)).toBeTruthy();
   });
 
+  it("surfaces an uninstall error", async () => {
+    invoke.mockImplementation((cmd: string) => {
+      if (cmd === "list_plugins") return Promise.resolve([summary()]);
+      if (cmd === "uninstall_plugin") return Promise.reject("not installed");
+      return Promise.resolve();
+    });
+    render(<Plugins reload={async () => {}} />);
+    await screen.findByText("Stretch pack");
+    fireEvent.click(
+      screen.getByRole("button", { name: /uninstall stretch pack/i }),
+    );
+    expect(await screen.findByText(/Uninstall failed/)).toBeTruthy();
+  });
+
   it("surfaces an install error", async () => {
     openDialog.mockResolvedValue("/tmp/bad.json");
     invoke.mockImplementation((cmd: string) => {

--- a/src/views/settings/components/plugins.test.tsx
+++ b/src/views/settings/components/plugins.test.tsx
@@ -47,6 +47,24 @@ describe("Plugins", () => {
     expect(await screen.findByText("No plugins installed.")).toBeTruthy();
   });
 
+  it("surfaces a listing error", async () => {
+    invoke.mockRejectedValue("backend exploded");
+    render(<Plugins reload={async () => {}} />);
+    expect(await screen.findByText(/Could not list plugins/)).toBeTruthy();
+  });
+
+  it("omits the author prefix when there is no author", async () => {
+    invoke.mockImplementation((cmd: string) =>
+      cmd === "list_plugins"
+        ? Promise.resolve([summary({ author: "" })])
+        : Promise.resolve(),
+    );
+    render(<Plugins reload={async () => {}} />);
+    expect(
+      await screen.findByText(/^v1.0.0 · 2 ideas, 1 routine/),
+    ).toBeTruthy();
+  });
+
   it("guards against a non-array list result", async () => {
     // The shared test harness mocks invoke to resolve a string; the
     // component must not crash trying to map over it.

--- a/src/views/settings/components/plugins.tsx
+++ b/src/views/settings/components/plugins.tsx
@@ -1,0 +1,140 @@
+import { useCallback, useEffect, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { open as openDialog } from "@tauri-apps/plugin-dialog";
+import { InfoTip } from "./info-tip";
+import type { InstallOutcome, PluginSummary } from "../types";
+
+type Status = { kind: "ok" | "err"; message: string } | null;
+
+const FILTER = [{ name: "Entracte plugin", extensions: ["json"] }];
+
+// Local-only plugin install/uninstall (#156). This slice ships content
+// providers: a signed plugin file whose ideas/routines merge into the active
+// profile on install (after a native confirmation dialog) and are removed
+// exactly on uninstall. Detector/export plugins need the wasm runtime and are
+// rejected by the backend for now.
+export function Plugins({
+  // Reload settings after install/uninstall so merged ideas/routines show
+  // (or disappear) immediately elsewhere in Settings.
+  reload,
+}: {
+  reload: () => Promise<unknown>;
+}) {
+  const [plugins, setPlugins] = useState<PluginSummary[]>([]);
+  const [status, setStatus] = useState<Status>(null);
+  const [busy, setBusy] = useState(false);
+
+  const refresh = useCallback(async () => {
+    try {
+      const list = await invoke<PluginSummary[]>("list_plugins");
+      setPlugins(Array.isArray(list) ? list : []);
+    } catch (e) {
+      setStatus({ kind: "err", message: `Could not list plugins: ${e}` });
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const onInstall = async () => {
+    setStatus(null);
+    try {
+      const path = await openDialog({
+        multiple: false,
+        directory: false,
+        filters: FILTER,
+      });
+      if (typeof path !== "string" || !path) return;
+      setBusy(true);
+      const outcome = await invoke<InstallOutcome>("install_content_plugin", {
+        path,
+      });
+      await Promise.all([refresh(), reload()]);
+      const ideas = `${outcome.hints_added} idea${outcome.hints_added === 1 ? "" : "s"}`;
+      const routines = `${outcome.routines_added} routine${outcome.routines_added === 1 ? "" : "s"}`;
+      setStatus({
+        kind: "ok",
+        message: `Installed "${outcome.name}" — added ${ideas} and ${routines}.`,
+      });
+    } catch (e) {
+      setStatus({ kind: "err", message: `Install failed: ${e}` });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const onUninstall = async (plugin: PluginSummary) => {
+    setStatus(null);
+    try {
+      setBusy(true);
+      await invoke("uninstall_plugin", { id: plugin.id });
+      await Promise.all([refresh(), reload()]);
+      setStatus({ kind: "ok", message: `Removed "${plugin.name}".` });
+    } catch (e) {
+      setStatus({ kind: "err", message: `Uninstall failed: ${e}` });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <>
+      <p className="placeholder">
+        Install a local plugin file to add break ideas and routines from the
+        community.
+        <InfoTip text="Plugins are local files you choose yourself — no store, no account, no network. Installing shows a confirmation dialog with the plugin's name, author, and signing key. Uninstalling removes exactly what it added." />
+      </p>
+      <p className="placeholder plugin-warning">
+        ⚠ Only install plugin files from sources you trust.
+      </p>
+      <div className="actions inline">
+        <button
+          type="button"
+          className="secondary"
+          onClick={onInstall}
+          disabled={busy}
+        >
+          {busy ? "Working…" : "Install plugin…"}
+        </button>
+      </div>
+      {plugins.length > 0 ? (
+        <ul className="plugin-list">
+          {plugins.map((p) => (
+            <li key={p.id} className="plugin-row">
+              <div className="plugin-meta">
+                <span className="plugin-name">{p.name}</span>
+                <span className="plugin-sub">
+                  {p.author ? `${p.author} · ` : ""}v{p.version} ·{" "}
+                  {p.hints_added} idea{p.hints_added === 1 ? "" : "s"},{" "}
+                  {p.routines_added} routine
+                  {p.routines_added === 1 ? "" : "s"}
+                </span>
+              </div>
+              <button
+                type="button"
+                className="secondary"
+                onClick={() => onUninstall(p)}
+                disabled={busy}
+                aria-label={`Uninstall ${p.name}`}
+              >
+                Uninstall
+              </button>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p className="placeholder">No plugins installed.</p>
+      )}
+      {status && (
+        <p
+          className={status.kind === "err" ? "content-pack-err" : "placeholder"}
+          role="status"
+          aria-live="polite"
+        >
+          {status.message}
+        </p>
+      )}
+    </>
+  );
+}

--- a/src/views/settings/index.tsx
+++ b/src/views/settings/index.tsx
@@ -140,6 +140,7 @@ export default function Settings() {
                 update={update}
                 setAutostart={setAutostart}
                 hooks={hooks}
+                reload={reloadFromActive}
               />
             </div>
             <div

--- a/src/views/settings/settings.css
+++ b/src/views/settings/settings.css
@@ -934,11 +934,6 @@ body,
   font-size: 0.9rem;
 }
 
-.settings .plugin-warning {
-  color: var(--danger, #d9534f);
-  font-size: 0.9rem;
-}
-
 .settings .plugin-list {
   list-style: none;
   margin: 0.5rem 0 0;

--- a/src/views/settings/settings.css
+++ b/src/views/settings/settings.css
@@ -934,6 +934,42 @@ body,
   font-size: 0.9rem;
 }
 
+.settings .plugin-warning {
+  color: var(--danger, #d9534f);
+  font-size: 0.9rem;
+}
+
+.settings .plugin-list {
+  list-style: none;
+  margin: 0.5rem 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.settings .plugin-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.settings .plugin-meta {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.settings .plugin-name {
+  font-weight: 600;
+}
+
+.settings .plugin-sub {
+  font-size: 0.85rem;
+  opacity: 0.75;
+}
+
 .settings .routine-categories {
   display: flex;
   flex-wrap: wrap;

--- a/src/views/settings/tabs/system-tab.test.tsx
+++ b/src/views/settings/tabs/system-tab.test.tsx
@@ -56,6 +56,7 @@ function Harness({ initial }: { initial: HookConfig[] }) {
       update={() => {}}
       setAutostart={async () => {}}
       hooks={hooks}
+      reload={async () => {}}
     />
   );
 }
@@ -184,6 +185,7 @@ function renderTab(
       update={update as unknown as Parameters<typeof SystemTab>[0]["update"]}
       setAutostart={setAutostart}
       hooks={hooks}
+      reload={async () => {}}
     />,
   );
   return { ...utils, update, setAutostart, hooks, settings };
@@ -347,6 +349,7 @@ describe("SystemTab — Hooks editor", () => {
           isDirty: () => true,
           saving: true,
         })}
+        reload={async () => {}}
       />,
     );
     const waiting = screen.getByRole("button", {
@@ -366,6 +369,7 @@ describe("SystemTab — Hooks editor", () => {
           save,
           isDirty: () => false,
         })}
+        reload={async () => {}}
       />,
     );
     const idle = screen.getByRole("button", {

--- a/src/views/settings/tabs/system-tab.tsx
+++ b/src/views/settings/tabs/system-tab.tsx
@@ -7,6 +7,7 @@ import { Advanced } from "../components/advanced";
 import { CheckboxRow, NumberRow } from "../components/rows";
 import { HotkeysSection } from "../components/hotkeys-section";
 import { HookRow } from "../components/hook-row";
+import { Plugins } from "../components/plugins";
 import type { UseHooks } from "../hooks/use-hooks";
 import type { UseSettings } from "../hooks/use-settings";
 import type { ClockFormat, HookConfig, SchedulerSettings } from "../types";
@@ -26,11 +27,13 @@ export function SystemTab({
   update,
   setAutostart,
   hooks,
+  reload,
 }: {
   settings: SchedulerSettings;
   update: UseSettings["update"];
   setAutostart: UseSettings["setAutostart"];
   hooks: UseHooks;
+  reload: () => Promise<unknown>;
 }) {
   // Stable IDs for hook rows so React keys survive reordering / mid-list edits.
   // The IDs are local UI state only; they never leave the component.
@@ -154,6 +157,11 @@ export function SystemTab({
             ))}
           </select>
         </label>
+      </section>
+
+      <h2>Plugins</h2>
+      <section>
+        <Plugins reload={reload} />
       </section>
 
       <Advanced label="Show advanced (hooks)">

--- a/src/views/settings/types.ts
+++ b/src/views/settings/types.ts
@@ -85,6 +85,25 @@ export type ContentPackSummary = {
   routines_added: number;
 };
 
+export type PluginKind = "content" | "detector" | "export";
+
+export type PluginSummary = {
+  id: string;
+  name: string;
+  author: string;
+  version: string;
+  kind: PluginKind;
+  hints_added: number;
+  routines_added: number;
+};
+
+export type InstallOutcome = {
+  id: string;
+  name: string;
+  hints_added: number;
+  routines_added: number;
+};
+
 export type SchedulerSettings = {
   micro_interval_secs: number;
   micro_duration_secs: number;


### PR DESCRIPTION
## Summary

Slice 2 of the local-only plugin API (design in #169, manifest/signature core in #167): **content providers, end to end**. A signed content plugin's ideas and routines merge into the active profile on install — behind a native confirmation dialog — and are removed *exactly* on uninstall (merge-and-track). No store, no account, no network; a plugin is a local file you pick.

You chose **full end-to-end pipeline** + **merge-and-track**; this delivers both.

### Backend
- **Typed payload:** the manifest's `content` is now a `ContentPack`, validated via `content_pack::validate_pack`. Code-bearing kinds may not carry one.
- **Merge-and-track:** `content_pack` gains `merge_pack_tracked` + `AddedContent` + `remove_content`, recording the precise hint strings / routine ids added so uninstall removes exactly those and tolerates intervening user edits.
- **Registry + persistence:** `plugins::registry` (`InstalledPlugin`/`PluginRegistry`/`PluginSummary`) and `plugin_store` (`plugins.json`, atomic `0o600` via `secure_io`). The registry lives beside `settings.json`, derived from the config dir so `Scheduler::new`'s signature is unchanged.
- **Pure install gate:** `plugins::install::prepare_content_install` runs parse → schema → signature → content-only → not-already-installed (fully unit-tested). Detector/export plugins validate but are rejected until the wasm runtime slice.
- **Commands:** `install_content_plugin` (dialog-gated, mirroring `set_hooks`: single-flight `plugin_dialog_busy` guard, control-char/bidi-sanitised summary, blocking dialog on a thread), `uninstall_plugin`, `list_plugins`.

### Hardening
The registry is **not** part of `Settings`, so it's inherently outside `update_settings` and the IPC `settings set` path — no new denylist entries needed. Install/uninstall are the only mutators and both pass through the confirmation dialog.

### Frontend
A **Plugins** section in Settings → System: install picker + per-plugin uninstall, showing name/author/version/counts. Reloads settings after changes so merged content appears (or disappears) immediately. Guards against a non-array list result.

### Docs
User-facing [`docs/PLUGINS.md`](docs/PLUGINS.md), companion to `HOOKS.md`.

## Test Plan
- **+25 Rust unit tests** (manifest, signature, registry, install gate, store, command cores) — full Rust lib suite **954 green**.
- **+7 TS component tests** for the Plugins UI — frontend **666 green**.
- `cargo fmt`, `cargo clippy --all-targets`, `cspell` (md/ts/tsx), and `cargo doc -D warnings` all clean. No new dependencies.

### Coverage note (codecov/patch)
Every testable core is extracted and covered (`apply_install`, `apply_uninstall`, `uninstall_by_id`, `read_manifest_text`, `format_install_summary`, `prepare_content_install`, merge/remove, registry, store). The residual uncovered lines are the **Tauri command shims** in `commands/plugins.rs` — `ensure_main_window`, the `State`/`AppHandle`/`WebviewWindow` command wrappers, and the native `confirm_install` dialog thread — which have no mockable surface, exactly as `commands/content_pack.rs` ships on `main`. These are the documented admin-merge case (reachable by the app, not by unit tests).

Refs #156. Builds on #167 (#169 design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)