### PR TITLE
feat(plugins): detector context probes + real host-function ABI (#156)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -14,6 +14,7 @@ mod platform;
 mod plugin_store;
 mod plugins;
 mod proc;
+mod proc_match;
 mod renderer_log;
 mod scheduler;
 mod screen_time_store;

--- a/src-tauri/src/plugins/detect.rs
+++ b/src-tauri/src/plugins/detect.rs
@@ -16,15 +16,13 @@ use std::path::Path;
 
 use sysinfo::{ProcessesToUpdate, System};
 
-/// Case-insensitive substring match of `target` within `running`. Empty
-/// `target` never matches. Pure — the testable core of the process probe.
-pub fn name_matches(running_lower: &str, target_lower: &str) -> bool {
-    !target_lower.is_empty() && running_lower.contains(target_lower)
-}
+use crate::proc_match::process_match_lower;
 
-/// Whether any running process's name matches `pattern` (case-insensitive
-/// substring). Refreshes the process list on each call; callers throttle.
-/// Cross-platform via `sysinfo`, so no per-OS shim.
+/// Whether any running process's name matches `pattern`, using the same
+/// token-aware semantics as the app-pause guard ([`process_match_lower`]) —
+/// so `zoom` matches Zoom but not `zoominfo`. Refreshes the process list on
+/// each call; callers throttle. Cross-platform via `sysinfo`, so no per-OS
+/// shim.
 pub fn process_running(pattern: &str) -> bool {
     let target = pattern.trim().to_lowercase();
     if target.is_empty() {
@@ -34,7 +32,7 @@ pub fn process_running(pattern: &str) -> bool {
     sys.refresh_processes(ProcessesToUpdate::All, false);
     sys.processes().values().any(|p| {
         let name = p.name().to_string_lossy().to_lowercase();
-        name_matches(&name, &target)
+        process_match_lower(&name, &target)
     })
 }
 
@@ -53,27 +51,16 @@ pub fn flag_is_truthy(contents: &str) -> bool {
 
 /// Whether the sentinel file at `path` exists and holds a truthy value. A
 /// missing, oversized, or unreadable file reads as `false` (no signal).
+/// Reuses [`crate::secure_io::read_capped`] for the size-bounded read.
 pub fn read_flag(path: &Path) -> bool {
-    match std::fs::metadata(path) {
-        Ok(meta) if meta.is_file() && meta.len() <= MAX_FLAG_BYTES => {}
-        _ => return false,
-    }
-    match std::fs::read_to_string(path) {
-        Ok(contents) => flag_is_truthy(&contents),
-        Err(_) => false,
-    }
+    crate::secure_io::read_capped(path, MAX_FLAG_BYTES)
+        .map(|contents| flag_is_truthy(&contents))
+        .unwrap_or(false)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn name_matches_is_substring_and_rejects_empty() {
-        assert!(name_matches("my-focus-app", "focus"));
-        assert!(!name_matches("anything", ""));
-        assert!(!name_matches("editor", "browser"));
-    }
 
     #[test]
     fn flag_truthy_accepts_known_tokens_only() {
@@ -87,14 +74,11 @@ mod tests {
 
     #[test]
     fn process_running_finds_the_current_process_and_misses_a_bogus_one() {
-        // The test binary is itself a running process, so its own name is a
-        // reliable cross-platform positive. A random name is a reliable
-        // negative.
-        let exe = std::env::current_exe().unwrap();
-        let stem = exe.file_stem().unwrap().to_string_lossy().to_string();
-        // Use a distinctive substring of the test binary's name.
-        let needle = &stem[..stem.len().min(6)];
-        assert!(process_running(needle), "should find self by '{needle}'");
+        // The test binary's name carries "entracte" as a whole token on every
+        // platform (the cargo target is `entracte[_lib]-<hash>`, and it fits
+        // inside Linux's 15-char `comm`), so token-aware matching finds it. A
+        // multi-token bogus target uses substring fallback and matches nothing.
+        assert!(process_running("entracte"), "should find the test binary");
         assert!(!process_running("entracte-no-such-process-zzz"));
         assert!(!process_running("   "));
     }

--- a/src-tauri/src/plugins/detect.rs
+++ b/src-tauri/src/plugins/detect.rs
@@ -1,0 +1,130 @@
+//! Local context probes a detector plugin can ask about, through the gated
+//! host functions in [`super::runtime`] (#156, slice 5).
+//!
+//! These are the host-performed reads: the plugin never touches the OS
+//! itself — it calls a host function, and the host runs the probe here and
+//! returns only a boolean. The matching logic is pure and unit-tested; the
+//! `sysinfo` process read is cross-platform (so it's exercised on every OS,
+//! per the coverage policy) rather than a per-OS FFI shim.
+
+// Consumed by the sandbox host functions in `runtime`, which in turn has no
+// non-test caller until the detector eval worker (slice 5b) wires it into the
+// run loop. Scoped allow until then; the tests exercise these directly.
+#![allow(dead_code)]
+
+use std::path::Path;
+
+use sysinfo::{ProcessesToUpdate, System};
+
+/// Case-insensitive substring match of `target` within `running`. Empty
+/// `target` never matches. Pure — the testable core of the process probe.
+pub fn name_matches(running_lower: &str, target_lower: &str) -> bool {
+    !target_lower.is_empty() && running_lower.contains(target_lower)
+}
+
+/// Whether any running process's name matches `pattern` (case-insensitive
+/// substring). Refreshes the process list on each call; callers throttle.
+/// Cross-platform via `sysinfo`, so no per-OS shim.
+pub fn process_running(pattern: &str) -> bool {
+    let target = pattern.trim().to_lowercase();
+    if target.is_empty() {
+        return false;
+    }
+    let mut sys = System::new();
+    sys.refresh_processes(ProcessesToUpdate::All, false);
+    sys.processes().values().any(|p| {
+        let name = p.name().to_string_lossy().to_lowercase();
+        name_matches(&name, &target)
+    })
+}
+
+/// Maximum sentinel-flag file we'll read. A flag is a tiny truthy marker, so
+/// anything larger is treated as not-a-flag rather than read into memory.
+const MAX_FLAG_BYTES: u64 = 64 * 1024;
+
+/// Whether the trimmed, lowercased contents are a recognised truthy token.
+/// Pure — the testable core of the file probe.
+pub fn flag_is_truthy(contents: &str) -> bool {
+    matches!(
+        contents.trim().to_lowercase().as_str(),
+        "1" | "true" | "yes" | "on"
+    )
+}
+
+/// Whether the sentinel file at `path` exists and holds a truthy value. A
+/// missing, oversized, or unreadable file reads as `false` (no signal).
+pub fn read_flag(path: &Path) -> bool {
+    match std::fs::metadata(path) {
+        Ok(meta) if meta.is_file() && meta.len() <= MAX_FLAG_BYTES => {}
+        _ => return false,
+    }
+    match std::fs::read_to_string(path) {
+        Ok(contents) => flag_is_truthy(&contents),
+        Err(_) => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn name_matches_is_substring_and_rejects_empty() {
+        assert!(name_matches("my-focus-app", "focus"));
+        assert!(!name_matches("anything", ""));
+        assert!(!name_matches("editor", "browser"));
+    }
+
+    #[test]
+    fn flag_truthy_accepts_known_tokens_only() {
+        for t in ["1", "true", "TRUE", " yes ", "On\n"] {
+            assert!(flag_is_truthy(t), "{t:?} should be truthy");
+        }
+        for f in ["0", "false", "", "maybe", "2"] {
+            assert!(!flag_is_truthy(f), "{f:?} should be falsey");
+        }
+    }
+
+    #[test]
+    fn process_running_finds_the_current_process_and_misses_a_bogus_one() {
+        // The test binary is itself a running process, so its own name is a
+        // reliable cross-platform positive. A random name is a reliable
+        // negative.
+        let exe = std::env::current_exe().unwrap();
+        let stem = exe.file_stem().unwrap().to_string_lossy().to_string();
+        // Use a distinctive substring of the test binary's name.
+        let needle = &stem[..stem.len().min(6)];
+        assert!(process_running(needle), "should find self by '{needle}'");
+        assert!(!process_running("entracte-no-such-process-zzz"));
+        assert!(!process_running("   "));
+    }
+
+    #[test]
+    fn read_flag_reads_truthy_files_and_ignores_the_rest() {
+        let dir = crate::test_support::temp_dir();
+        let yes = dir.path().join("on.flag");
+        std::fs::write(&yes, "true").unwrap();
+        assert!(read_flag(&yes));
+
+        let no = dir.path().join("off.flag");
+        std::fs::write(&no, "0").unwrap();
+        assert!(!read_flag(&no));
+
+        assert!(!read_flag(&dir.path().join("missing.flag")));
+        // A directory is not a flag file.
+        assert!(!read_flag(dir.path()));
+
+        // A non-UTF-8 file reads as no-signal rather than erroring out.
+        let binary = dir.path().join("binary.flag");
+        std::fs::write(&binary, [0xff, 0xfe, 0x00, 0x01]).unwrap();
+        assert!(!read_flag(&binary));
+    }
+
+    #[test]
+    fn read_flag_ignores_an_oversized_file() {
+        let dir = crate::test_support::temp_dir();
+        let big = dir.path().join("big.flag");
+        std::fs::write(&big, vec![b'1'; (MAX_FLAG_BYTES + 1) as usize]).unwrap();
+        assert!(!read_flag(&big));
+    }
+}

--- a/src-tauri/src/plugins/install.rs
+++ b/src-tauri/src/plugins/install.rs
@@ -76,6 +76,7 @@ mod tests {
             module: None,
             abi_version: None,
             imports: vec![],
+            detect: None,
             content: Some(pack()),
             signature: super::super::manifest::Signature {
                 alg: "ed25519".to_string(),
@@ -141,6 +142,7 @@ mod tests {
             module: Some("module.wasm".to_string()),
             abi_version: Some(crate::plugins::manifest::SUPPORTED_ABI_VERSION),
             imports: vec!["detect:foreground-window".to_string()],
+            detect: None,
             content: None,
             signature: super::super::manifest::Signature {
                 alg: "ed25519".to_string(),

--- a/src-tauri/src/plugins/manifest.rs
+++ b/src-tauri/src/plugins/manifest.rs
@@ -121,6 +121,19 @@ impl Capability {
     }
 }
 
+/// Detector configuration: the parameters the host matches against when it
+/// computes a detector's gated booleans. Only meaningful for a detector
+/// plugin. The `detect:file:<path>` scope lives in the capability itself, so
+/// only the process pattern needs declaring here.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DetectConfig {
+    /// Substring (case-insensitive) matched against running process names by
+    /// the `host_process_running` host function. Requires a `detect:processes`
+    /// import.
+    #[serde(default)]
+    pub process_name: Option<String>,
+}
+
 /// The detached signature over `canonical(manifest-without-signature)` plus
 /// the module hash. ed25519; keys and signature are base64.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -150,6 +163,8 @@ pub struct Manifest {
     pub abi_version: Option<u32>,
     #[serde(default)]
     pub imports: Vec<String>,
+    #[serde(default)]
+    pub detect: Option<DetectConfig>,
     #[serde(default)]
     pub content: Option<ContentPack>,
     pub signature: Signature,
@@ -273,6 +288,18 @@ pub fn validate_manifest(m: &Manifest) -> Result<(), String> {
         }
     }
 
+    if let Some(detect) = &m.detect {
+        if m.kind != PluginKind::Detector {
+            return Err("only a detector plugin may carry a detect config".to_string());
+        }
+        if let Some(pattern) = &detect.process_name {
+            check_string(pattern, "detect process_name")?;
+            if !m.imports.iter().any(|i| i == "detect:processes") {
+                return Err("detect.process_name requires a 'detect:processes' import".to_string());
+            }
+        }
+    }
+
     Ok(())
 }
 
@@ -300,6 +327,7 @@ mod tests {
             module: Some("module.wasm".to_string()),
             abi_version: Some(SUPPORTED_ABI_VERSION),
             imports: vec!["detect:foreground-window".to_string()],
+            detect: None,
             content: None,
             signature: sig(),
         }
@@ -317,6 +345,7 @@ mod tests {
             module: None,
             abi_version: None,
             imports: vec![],
+            detect: None,
             content: Some(sample_pack()),
             signature: sig(),
         }
@@ -534,6 +563,53 @@ mod tests {
         assert!(validate_manifest(&m)
             .unwrap_err()
             .contains("missing a version"));
+    }
+
+    #[test]
+    fn validate_accepts_a_detector_with_a_process_detect_config() {
+        let mut m = detector_manifest();
+        m.imports = vec!["detect:processes".to_string()];
+        m.detect = Some(DetectConfig {
+            process_name: Some("zoom".to_string()),
+        });
+        assert!(validate_manifest(&m).is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_detect_config_on_non_detector() {
+        let mut m = content_manifest();
+        m.detect = Some(DetectConfig::default());
+        assert!(validate_manifest(&m)
+            .unwrap_err()
+            .contains("only a detector plugin may carry a detect config"));
+    }
+
+    #[test]
+    fn validate_accepts_a_detector_with_an_empty_detect_config() {
+        let mut m = detector_manifest();
+        m.detect = Some(DetectConfig::default()); // no process_name → no extra requirement
+        assert!(validate_manifest(&m).is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_an_overlong_process_name() {
+        let mut m = detector_manifest();
+        m.imports = vec!["detect:processes".to_string()];
+        m.detect = Some(DetectConfig {
+            process_name: Some("a".repeat(MAX_STRING_LEN + 1)),
+        });
+        assert!(validate_manifest(&m).unwrap_err().contains("exceeds"));
+    }
+
+    #[test]
+    fn validate_rejects_process_name_without_the_processes_import() {
+        let mut m = detector_manifest(); // imports detect:foreground-window only
+        m.detect = Some(DetectConfig {
+            process_name: Some("zoom".to_string()),
+        });
+        assert!(validate_manifest(&m)
+            .unwrap_err()
+            .contains("requires a 'detect:processes' import"));
     }
 
     #[test]

--- a/src-tauri/src/plugins/mod.rs
+++ b/src-tauri/src/plugins/mod.rs
@@ -43,6 +43,6 @@ pub use signature::{sha256, signing_payload, verify_signature};
 // tested ahead of its consumers (the wat-driven tests exercise it directly).
 #[allow(unused_imports)]
 pub use runtime::{
-    build_sandboxed_plugin, host_function_name, host_function_names_for, SandboxContext,
-    DEFAULT_FUEL, DEFAULT_MEMORY_MAX_PAGES, DEFAULT_TIMEOUT,
+    build_sandboxed_plugin, host_function_name, SandboxContext, DEFAULT_FUEL,
+    DEFAULT_MEMORY_MAX_PAGES, DEFAULT_TIMEOUT,
 };

--- a/src-tauri/src/plugins/mod.rs
+++ b/src-tauri/src/plugins/mod.rs
@@ -15,6 +15,7 @@
 //! plugins parse and validate here but cannot yet be installed — they need
 //! the wasm runtime (a later slice).
 
+mod detect;
 mod install;
 mod manifest;
 pub(crate) mod registry;
@@ -42,6 +43,6 @@ pub use signature::{sha256, signing_payload, verify_signature};
 // tested ahead of its consumers (the wat-driven tests exercise it directly).
 #[allow(unused_imports)]
 pub use runtime::{
-    build_sandboxed_plugin, host_function_name, host_function_names_for, DEFAULT_FUEL,
-    DEFAULT_MEMORY_MAX_PAGES, DEFAULT_TIMEOUT,
+    build_sandboxed_plugin, host_function_name, host_function_names_for, SandboxContext,
+    DEFAULT_FUEL, DEFAULT_MEMORY_MAX_PAGES, DEFAULT_TIMEOUT,
 };

--- a/src-tauri/src/plugins/runtime.rs
+++ b/src-tauri/src/plugins/runtime.rs
@@ -25,13 +25,24 @@
 // when the first consumer lands.
 #![allow(dead_code)]
 
+use std::path::PathBuf;
 use std::time::Duration;
 
 use extism::{
     CurrentPlugin, Error as ExtismError, Manifest, PluginBuilder, UserData, Val, ValType, Wasm,
 };
 
+use super::detect;
 use super::manifest::Capability;
+
+/// Per-install context the host functions need beyond the capability scopes
+/// themselves. The `detect:file:<path>` scope lives in the capability; the
+/// process pattern a `detect:processes` grant matches against comes from the
+/// manifest's detect config and is threaded in here.
+#[derive(Debug, Clone, Default)]
+pub struct SandboxContext {
+    pub process_pattern: Option<String>,
+}
 
 /// Memory ceiling for a plugin instance, in 64 KiB wasm pages. 64 pages =
 /// 4 MiB — generous for a detector/export module, tight enough that a
@@ -76,19 +87,77 @@ pub fn host_function_names_for(grants: &[Capability]) -> Vec<&'static str> {
     names
 }
 
-/// Stub host-function body for this slice: takes one i64, returns 0. Slices 5
-/// and 6 replace these with real, scope-checked implementations. Registered
-/// only for granted capabilities, so its mere presence is gated.
+/// Set the single i64 output of a host function to a boolean (1/0).
+fn set_bool(outputs: &mut [Val], value: bool) {
+    if let Some(out) = outputs.first_mut() {
+        *out = Val::I64(value as i64);
+    }
+}
+
+/// Placeholder body for host functions whose real implementation lands in a
+/// later slice (foreground-window and the export sinks). Returns 0. Its mere
+/// presence is still gated by the capability, so registering it doesn't widen
+/// the module's reach.
 fn host_stub(
     _plugin: &mut CurrentPlugin,
     _inputs: &[Val],
     outputs: &mut [Val],
     _user_data: UserData<()>,
 ) -> Result<(), ExtismError> {
-    if let Some(out) = outputs.first_mut() {
-        *out = Val::I64(0);
-    }
+    set_bool(outputs, false);
     Ok(())
+}
+
+/// Register the host function a single capability unlocks, with a body that's
+/// scope-checked by construction: the data each closure needs (the process
+/// pattern, the granted file path) is captured here from the grant + context,
+/// never supplied by the module. All host functions are `() -> i64` booleans
+/// in this ABI.
+fn register_capability<'a>(
+    builder: PluginBuilder<'a>,
+    cap: &Capability,
+    ctx: &SandboxContext,
+) -> PluginBuilder<'a> {
+    let name = host_function_name(cap);
+    match cap {
+        Capability::DetectProcesses => {
+            let pattern = ctx.process_pattern.clone().unwrap_or_default();
+            builder.with_function(
+                name,
+                [],
+                [ValType::I64],
+                UserData::new(pattern),
+                |_p, _in, out, ud| {
+                    let data = ud.get()?;
+                    let pattern = data.lock().unwrap();
+                    set_bool(out, detect::process_running(&pattern));
+                    Ok(())
+                },
+            )
+        }
+        Capability::DetectFile(path) => {
+            let path = PathBuf::from(path);
+            builder.with_function(
+                name,
+                [],
+                [ValType::I64],
+                UserData::new(path),
+                |_p, _in, out, ud| {
+                    let data = ud.get()?;
+                    let path = data.lock().unwrap();
+                    set_bool(out, detect::read_flag(&path));
+                    Ok(())
+                },
+            )
+        }
+        // Foreground-window and the export sinks are stubbed until their
+        // slices; registered (gated) but inert.
+        Capability::DetectForegroundWindow
+        | Capability::ExportFile(_)
+        | Capability::ExportHttp(_) => {
+            builder.with_function(name, [], [ValType::I64], UserData::default(), host_stub)
+        }
+    }
 }
 
 /// Build a sandboxed plugin from `module` bytes, registering host functions
@@ -96,9 +165,13 @@ fn host_stub(
 /// timeout are bounded (see the `DEFAULT_*` consts). Returns a user-facing
 /// error if the module fails to compile, link, or instantiate — including the
 /// case where it imports a host function whose capability wasn't granted.
+///
+/// Duplicate host-function names are registered once (the first grant wins),
+/// so a plugin with two `detect:file:<path>` grants links cleanly.
 pub fn build_sandboxed_plugin(
     module: &[u8],
     capabilities: &[Capability],
+    ctx: &SandboxContext,
 ) -> Result<extism::Plugin, String> {
     let manifest = Manifest::new([Wasm::data(module.to_vec())])
         .with_memory_max(DEFAULT_MEMORY_MAX_PAGES)
@@ -108,14 +181,14 @@ pub fn build_sandboxed_plugin(
         .with_wasi(false)
         .with_fuel_limit(DEFAULT_FUEL);
 
-    for name in host_function_names_for(capabilities) {
-        builder = builder.with_function(
-            name,
-            [ValType::I64],
-            [ValType::I64],
-            UserData::default(),
-            host_stub,
-        );
+    let mut registered: Vec<&str> = Vec::new();
+    for cap in capabilities {
+        let name = host_function_name(cap);
+        if registered.contains(&name) {
+            continue;
+        }
+        registered.push(name);
+        builder = register_capability(builder, cap, ctx);
     }
 
     builder
@@ -157,6 +230,21 @@ mod tests {
         }
     }
 
+    /// A module that calls the named `() -> i64` host function and **traps**
+    /// when it returns non-zero, so a test can read the host's boolean answer
+    /// through call success (false) vs. error (true) — no extism output
+    /// marshalling needed.
+    fn trap_if_true_module(host_fn: &str) -> Vec<u8> {
+        wasm(&format!(
+            r#"(module
+                 (import "extism:host/user" "{host_fn}" (func $f (result i64)))
+                 (memory (export "memory") 1)
+                 (func (export "run") (result i32)
+                   (if (i64.ne (call $f) (i64.const 0)) (then unreachable))
+                   (i32.const 0)))"#
+        ))
+    }
+
     #[test]
     fn loads_a_clean_module_with_no_imports() {
         let module = wasm(
@@ -164,20 +252,14 @@ mod tests {
                  (memory (export "memory") 1)
                  (func (export "run") (result i32) i32.const 0))"#,
         );
-        assert!(build_sandboxed_plugin(&module, &[]).is_ok());
+        assert!(build_sandboxed_plugin(&module, &[], &SandboxContext::default()).is_ok());
     }
 
     #[test]
     fn rejects_a_module_importing_an_ungranted_host_function() {
-        // Imports host_foreground_window but no detect:foreground-window grant.
-        let module = wasm(
-            r#"(module
-                 (import "extism:host/user" "host_foreground_window"
-                   (func $f (param i64) (result i64)))
-                 (memory (export "memory") 1)
-                 (func (export "run") (result i64) (call $f (i64.const 0))))"#,
-        );
-        let err = build_sandboxed_plugin(&module, &[]).unwrap_err();
+        // Imports host_process_running but no detect:processes grant.
+        let module = trap_if_true_module("host_process_running");
+        let err = build_sandboxed_plugin(&module, &[], &SandboxContext::default()).unwrap_err();
         assert!(
             err.contains("failed to load"),
             "ungranted import should fail the load, got: {err}"
@@ -185,24 +267,97 @@ mod tests {
     }
 
     #[test]
-    fn accepts_and_invokes_a_granted_host_function() {
-        // `run` calls the granted host function, so building succeeds and
-        // calling it actually dispatches into the registered host stub.
-        let module = wasm(
-            r#"(module
-                 (import "extism:host/user" "host_foreground_window"
-                   (func $f (param i64) (result i64)))
-                 (memory (export "memory") 1)
-                 (func (export "run") (result i32)
-                   (drop (call $f (i64.const 0)))
-                   (i32.const 0)))"#,
+    fn host_process_running_reports_a_live_process_to_the_module() {
+        let exe = std::env::current_exe().unwrap();
+        let stem = exe.file_stem().unwrap().to_string_lossy().to_string();
+        let needle = stem[..stem.len().min(6)].to_string();
+
+        // Pattern matches a live process (this test binary) → host returns
+        // true → the module traps → the call errors.
+        let module = trap_if_true_module("host_process_running");
+        let mut plugin = build_sandboxed_plugin(
+            &module,
+            &[Capability::DetectProcesses],
+            &SandboxContext {
+                process_pattern: Some(needle),
+            },
+        )
+        .expect("granted detect:processes builds");
+        assert!(
+            plugin.call::<&str, &str>("run", "").is_err(),
+            "a matching process should be reported true (module traps)"
         );
-        let mut plugin = build_sandboxed_plugin(&module, &[Capability::DetectForegroundWindow])
-            .expect("granting the capability registers the host function");
+
+        // A pattern that matches nothing → host returns false → call succeeds.
+        let module = trap_if_true_module("host_process_running");
+        let mut plugin = build_sandboxed_plugin(
+            &module,
+            &[Capability::DetectProcesses],
+            &SandboxContext {
+                process_pattern: Some("entracte-no-such-process-zzz".to_string()),
+            },
+        )
+        .unwrap();
+        assert!(plugin.call::<&str, &str>("run", "").is_ok());
+    }
+
+    #[test]
+    fn host_read_flag_reports_the_granted_files_truthiness() {
+        let dir = crate::test_support::temp_dir();
+        let flag = dir.path().join("focus.flag");
+        std::fs::write(&flag, "true").unwrap();
+        let cap = Capability::DetectFile(flag.display().to_string());
+
+        // Truthy flag → host returns true → module traps → call errors.
+        let module = trap_if_true_module("host_read_flag");
+        let mut plugin = build_sandboxed_plugin(
+            &module,
+            std::slice::from_ref(&cap),
+            &SandboxContext::default(),
+        )
+        .expect("granted detect:file builds");
+        assert!(plugin.call::<&str, &str>("run", "").is_err());
+
+        // Flip the flag to falsey → host returns false → call succeeds.
+        std::fs::write(&flag, "0").unwrap();
+        let module = trap_if_true_module("host_read_flag");
+        let mut plugin = build_sandboxed_plugin(
+            &module,
+            std::slice::from_ref(&cap),
+            &SandboxContext::default(),
+        )
+        .unwrap();
+        assert!(plugin.call::<&str, &str>("run", "").is_ok());
+    }
+
+    #[test]
+    fn a_stubbed_capability_registers_an_inert_host_function() {
+        // Foreground-window is still a stub: a granted module that calls it
+        // links and the stub returns false, so the trap-if-true module's call
+        // succeeds.
+        let module = trap_if_true_module("host_foreground_window");
+        let mut plugin = build_sandboxed_plugin(
+            &module,
+            &[Capability::DetectForegroundWindow],
+            &SandboxContext::default(),
+        )
+        .expect("granted detect:foreground-window builds");
         assert!(
             plugin.call::<&str, &str>("run", "").is_ok(),
-            "calling the export should dispatch into the host stub and return"
+            "the stub should return false (no suppression)"
         );
+    }
+
+    #[test]
+    fn duplicate_capabilities_register_their_host_function_once() {
+        // Two detect:file grants map to one host_read_flag; the second is
+        // skipped so the module links cleanly against a single registration.
+        let module = trap_if_true_module("host_read_flag");
+        let grants = vec![
+            Capability::DetectFile("/tmp/a.flag".to_string()),
+            Capability::DetectFile("/tmp/b.flag".to_string()),
+        ];
+        assert!(build_sandboxed_plugin(&module, &grants, &SandboxContext::default()).is_ok());
     }
 
     #[test]
@@ -216,7 +371,8 @@ mod tests {
                    (loop $l (br $l))
                    (i32.const 0)))"#,
         );
-        let mut plugin = build_sandboxed_plugin(&module, &[]).expect("module loads");
+        let mut plugin =
+            build_sandboxed_plugin(&module, &[], &SandboxContext::default()).expect("module loads");
         let started = std::time::Instant::now();
         let result = plugin.call::<&str, &str>("run", "");
         let elapsed = started.elapsed();

--- a/src-tauri/src/plugins/runtime.rs
+++ b/src-tauri/src/plugins/runtime.rs
@@ -72,21 +72,6 @@ pub fn host_function_name(cap: &Capability) -> &'static str {
     }
 }
 
-/// The distinct host-function names the granted capabilities unlock, in a
-/// stable order with duplicates removed (two `detect:file:<path>` grants map
-/// to one `host_read_flag`). Pure — the registration list without a wasm
-/// engine.
-pub fn host_function_names_for(grants: &[Capability]) -> Vec<&'static str> {
-    let mut names = Vec::new();
-    for cap in grants {
-        let name = host_function_name(cap);
-        if !names.contains(&name) {
-            names.push(name);
-        }
-    }
-    names
-}
-
 /// Set the single i64 output of a host function to a boolean (1/0).
 fn set_bool(outputs: &mut [Val], value: bool) {
     if let Some(out) = outputs.first_mut() {
@@ -108,11 +93,36 @@ fn host_stub(
     Ok(())
 }
 
-/// Register the host function a single capability unlocks, with a body that's
-/// scope-checked by construction: the data each closure needs (the process
-/// pattern, the granted file path) is captured here from the grant + context,
-/// never supplied by the module. All host functions are `() -> i64` booleans
-/// in this ABI.
+/// Register a `() -> i64` boolean host function whose answer is `probe(data)`.
+/// `data` is captured host-side from the grant/context — never supplied by
+/// the module — so the probe is scope-checked by construction.
+fn register_probe<'a, T, F>(
+    builder: PluginBuilder<'a>,
+    name: &str,
+    data: T,
+    probe: F,
+) -> PluginBuilder<'a>
+where
+    T: Send + Sync + 'static,
+    F: Fn(&T) -> bool + Send + Sync + 'static,
+{
+    builder.with_function(
+        name,
+        [],
+        [ValType::I64],
+        UserData::new(data),
+        move |_p, _in, out, ud| {
+            let guard = ud.get()?;
+            set_bool(out, probe(&guard.lock().unwrap()));
+            Ok(())
+        },
+    )
+}
+
+/// Register the host function a single capability unlocks. All host functions
+/// are `() -> i64` booleans in this ABI; the data each one reads (the process
+/// pattern, the granted file path) is captured from the grant + context, so a
+/// module cannot influence what's probed.
 fn register_capability<'a>(
     builder: PluginBuilder<'a>,
     cap: &Capability,
@@ -122,33 +132,14 @@ fn register_capability<'a>(
     match cap {
         Capability::DetectProcesses => {
             let pattern = ctx.process_pattern.clone().unwrap_or_default();
-            builder.with_function(
-                name,
-                [],
-                [ValType::I64],
-                UserData::new(pattern),
-                |_p, _in, out, ud| {
-                    let data = ud.get()?;
-                    let pattern = data.lock().unwrap();
-                    set_bool(out, detect::process_running(&pattern));
-                    Ok(())
-                },
-            )
+            register_probe(builder, name, pattern, |p: &String| {
+                detect::process_running(p)
+            })
         }
         Capability::DetectFile(path) => {
-            let path = PathBuf::from(path);
-            builder.with_function(
-                name,
-                [],
-                [ValType::I64],
-                UserData::new(path),
-                |_p, _in, out, ud| {
-                    let data = ud.get()?;
-                    let path = data.lock().unwrap();
-                    set_bool(out, detect::read_flag(&path));
-                    Ok(())
-                },
-            )
+            register_probe(builder, name, PathBuf::from(path), |p: &PathBuf| {
+                detect::read_flag(p)
+            })
         }
         // Foreground-window and the export sinks are stubbed until their
         // slices; registered (gated) but inert.
@@ -205,19 +196,6 @@ mod tests {
     }
 
     #[test]
-    fn host_function_names_dedupe_and_map_per_capability() {
-        let grants = vec![
-            Capability::DetectForegroundWindow,
-            Capability::DetectFile("/a".to_string()),
-            Capability::DetectFile("/b".to_string()), // same host fn → one entry
-        ];
-        assert_eq!(
-            host_function_names_for(&grants),
-            vec!["host_foreground_window", "host_read_flag"]
-        );
-    }
-
-    #[test]
     fn host_function_name_covers_every_capability() {
         for cap in [
             Capability::DetectForegroundWindow,
@@ -268,18 +246,16 @@ mod tests {
 
     #[test]
     fn host_process_running_reports_a_live_process_to_the_module() {
-        let exe = std::env::current_exe().unwrap();
-        let stem = exe.file_stem().unwrap().to_string_lossy().to_string();
-        let needle = stem[..stem.len().min(6)].to_string();
-
-        // Pattern matches a live process (this test binary) → host returns
-        // true → the module traps → the call errors.
+        // "entracte" is a whole token of the test binary's process name on
+        // every platform (see the detect.rs test for the rationale).
+        // Pattern matches a live process → host returns true → the module
+        // traps → the call errors.
         let module = trap_if_true_module("host_process_running");
         let mut plugin = build_sandboxed_plugin(
             &module,
             &[Capability::DetectProcesses],
             &SandboxContext {
-                process_pattern: Some(needle),
+                process_pattern: Some("entracte".to_string()),
             },
         )
         .expect("granted detect:processes builds");

--- a/src-tauri/src/plugins/signature.rs
+++ b/src-tauri/src/plugins/signature.rs
@@ -108,6 +108,7 @@ mod tests {
             module: Some("module.wasm".to_string()),
             abi_version: Some(SUPPORTED_ABI_VERSION),
             imports: vec!["detect:foreground-window".to_string()],
+            detect: None,
             content: None,
             signature: Signature {
                 alg: "ed25519".to_string(),

--- a/src-tauri/src/proc_match.rs
+++ b/src-tauri/src/proc_match.rs
@@ -1,0 +1,89 @@
+//! Shared process-name matching. Used by the run loop's app-pause guard and
+//! by the local-context detector probes, so both agree on what "process X is
+//! running" means — in particular both reject substring collisions
+//! (`zoom` must not match `zoominfo`) while allowing digit-versioned
+//! binaries (`obs` matches `obs64`).
+
+/// Case-insensitive token match assuming **both** arguments are already
+/// lowercased. A single-token target (all alphanumeric, e.g. `zoom`) matches
+/// a whole token of the process name, or a token that differs only by a
+/// trailing digit run (`obs64`); a multi-token target (e.g. `osascript -e`)
+/// falls back to substring so power-users can match a distinctive snippet.
+///
+/// The run loop pre-lowercases its target list once at settings load
+/// (`derived.app_pause_targets_lower`) and only lowercases the live process
+/// name per scan, so the hot path never re-lowercases every configured
+/// target for every running process.
+pub fn process_match_lower(running_lower: &str, target_lower: &str) -> bool {
+    if target_lower.is_empty() {
+        return false;
+    }
+    let target_is_single_token = target_lower.chars().all(|c| c.is_alphanumeric());
+    if !target_is_single_token {
+        return running_lower.contains(target_lower);
+    }
+    running_lower
+        .split(|c: char| !c.is_alphanumeric())
+        .any(|tok| {
+            if tok == target_lower {
+                return true;
+            }
+            if let Some(suffix) = tok.strip_prefix(target_lower) {
+                !suffix.is_empty() && suffix.chars().all(|c| c.is_ascii_digit())
+            } else {
+                false
+            }
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::process_match_lower;
+
+    /// Convenience wrapper that lowercases both sides, so the cases below read
+    /// naturally regardless of the production hot path's pre-lowercasing.
+    fn process_match(running: &str, target: &str) -> bool {
+        process_match_lower(&running.to_lowercase(), &target.to_lowercase())
+    }
+
+    #[test]
+    fn matches_whole_token() {
+        assert!(process_match("zoom.us", "zoom"));
+        assert!(process_match("OBS Studio", "obs"));
+        assert!(process_match("zoom", "zoom"));
+        assert!(process_match("Zoom Meeting Helper", "zoom"));
+    }
+
+    #[test]
+    fn rejects_substring_collisions() {
+        assert!(!process_match("zoominfo.exe", "zoom"));
+        assert!(!process_match("azoomatic", "zoom"));
+        assert!(!process_match("doomsday", "doom"));
+    }
+
+    #[test]
+    fn allows_digit_versioned_binaries() {
+        assert!(process_match("obs64.exe", "obs"));
+        assert!(process_match("OBS32.exe", "obs"));
+        assert!(process_match("firefox64.exe", "firefox"));
+        assert!(!process_match("firefoxnightly.exe", "firefox"));
+    }
+
+    #[test]
+    fn rejects_unrelated_apps() {
+        assert!(!process_match("safari", "zoom"));
+        assert!(!process_match("", "zoom"));
+    }
+
+    #[test]
+    fn falls_back_to_substring_for_multi_token_targets() {
+        assert!(process_match("/usr/bin/osascript -e foo", "osascript -e"));
+        assert!(!process_match("osascript", "osascript -e"));
+    }
+
+    #[test]
+    fn empty_target_never_matches() {
+        assert!(!process_match("zoom.us", ""));
+        assert!(!process_match("", ""));
+    }
+}

--- a/src-tauri/src/scheduler/commands/plugins.rs
+++ b/src-tauri/src/scheduler/commands/plugins.rs
@@ -338,6 +338,7 @@ mod tests {
             module: None,
             abi_version: None,
             imports: vec![],
+            detect: None,
             content: Some(ContentPack {
                 version: CONTENT_PACK_VERSION,
                 name: "Stretch pack".to_string(),
@@ -670,6 +671,7 @@ mod mock_app_tests {
             module: None,
             abi_version: None,
             imports: vec![],
+            detect: None,
             content: Some(ContentPack {
                 version: CONTENT_PACK_VERSION,
                 name: "Signed pack".to_string(),

--- a/src-tauri/src/scheduler/run_loop.rs
+++ b/src-tauri/src/scheduler/run_loop.rs
@@ -8,6 +8,7 @@ use user_idle::UserIdle;
 
 use crate::dnd;
 use crate::hooks::{self, HookContext, HookEvent};
+use crate::proc_match::process_match_lower;
 use crate::stats::{EventPayload, GuardReason, Logger};
 
 use super::overlay::deliver_break;
@@ -1030,42 +1031,6 @@ fn fixed_break_due(kind: BreakKind, s: &Settings, now_min: u32) -> bool {
     b.enabled && s.fixed_active(kind) && b.fixed_minutes.contains(&now_min)
 }
 
-// Case-insensitive token match for the app-pause list. We tokenise the
-// running process name on non-alphanumeric boundaries (`.`, `-`, `_`,
-// whitespace, path separators) and accept a target that EITHER equals a
-// token OR is the prefix of a token whose remainder is digits — the
-// `obs64.exe`/`chrome32` Windows versioning convention. That keeps
-// `zoom` matching Zoom (`zoom.us`, `Zoom Meeting Helper`) while
-// rejecting `zoominfo` and `azoomatic`. Multi-token targets (e.g.
-// `osascript -e`) fall back to substring so power-users can still
-// match a distinctive snippet.
-/// Case-insensitive token match assuming both arguments are already
-/// lowercased. The run loop pre-lowercases the target list once at
-/// settings load/update (`derived.app_pause_targets_lower`) and only
-/// lowercases the live process name per scan, so the hot path avoids
-/// re-lowercasing every configured target for every running process.
-fn process_match_lower(running_lower: &str, target_lower: &str) -> bool {
-    if target_lower.is_empty() {
-        return false;
-    }
-    let target_is_single_token = target_lower.chars().all(|c| c.is_alphanumeric());
-    if !target_is_single_token {
-        return running_lower.contains(target_lower);
-    }
-    running_lower
-        .split(|c: char| !c.is_alphanumeric())
-        .any(|tok| {
-            if tok == target_lower {
-                return true;
-            }
-            if let Some(suffix) = tok.strip_prefix(target_lower) {
-                !suffix.is_empty() && suffix.chars().all(|c| c.is_ascii_digit())
-            } else {
-                false
-            }
-        })
-}
-
 #[cfg(test)]
 mod tests {
     use super::super::settings::ScheduleMode;
@@ -1075,14 +1040,6 @@ mod tests {
     // so a Windows build doesn't trip `-D unused-imports`.
     #[cfg(not(target_os = "windows"))]
     use super::super::settings::BreakMode;
-
-    /// Test-only convenience wrapper: lowercases both sides then defers to
-    /// the production `process_match_lower`. Lets the existing match tests
-    /// keep their raw (mixed-case) inputs while production stays on the
-    /// pre-lowercased hot path.
-    fn process_match(running: &str, target: &str) -> bool {
-        process_match_lower(&running.to_lowercase(), &target.to_lowercase())
-    }
 
     // Drives `deliver_scheduled_break` end to end through the
     // Notification delivery path — the one branch that doesn't enumerate
@@ -1417,89 +1374,6 @@ mod tests {
         s.rebuild_derived();
         assert!(!fixed_break_due(BreakKind::Micro, &s, 480));
         assert!(fixed_break_due(BreakKind::Micro, &s, 945));
-    }
-
-    #[test]
-    fn process_match_lower_equals_process_match_for_prelowercased_input() {
-        // The hot path calls `process_match_lower` with both sides already
-        // lowercased; it must return the same answer as the public wrapper
-        // for every case the wrapper covers.
-        let cases = [
-            ("zoom.us", "zoom", true),
-            ("OBS Studio", "obs", true),
-            ("zoominfo.exe", "zoom", false),
-            ("obs64.exe", "obs", true),
-            ("firefoxnightly.exe", "firefox", false),
-            ("/usr/bin/osascript -e foo", "osascript -e", true),
-            ("safari", "zoom", false),
-            ("zoom.us", "", false),
-        ];
-        for (running, target, expected) in cases {
-            assert_eq!(
-                process_match_lower(&running.to_lowercase(), &target.to_lowercase()),
-                expected,
-                "process_match_lower({running:?}, {target:?})"
-            );
-            // And the wrapper agrees, since the run loop relies on parity.
-            assert_eq!(process_match(running, target), expected);
-        }
-    }
-
-    #[test]
-    fn process_match_matches_whole_token() {
-        // Pre-fix this matched anything containing the substring.
-        assert!(process_match("zoom.us", "zoom"));
-        assert!(process_match("OBS Studio", "obs"));
-        assert!(process_match("zoom", "zoom"));
-        assert!(process_match(
-            "/Applications/zoom.us.app/Contents/MacOS/zoom.us",
-            "zoom"
-        ));
-        assert!(process_match("Zoom Meeting Helper", "zoom"));
-    }
-
-    #[test]
-    fn process_match_rejects_substring_collisions() {
-        // The motivating regression: a Zoom-pause rule should not silently
-        // also pause for ZoomInfo or unrelated tools that contain "zoom".
-        assert!(!process_match("zoominfo.exe", "zoom"));
-        assert!(!process_match("azoomatic", "zoom"));
-        assert!(!process_match("doomsday", "doom"));
-    }
-
-    #[test]
-    fn process_match_allows_digit_versioned_binaries() {
-        // Windows often versions binaries with a digit suffix — the OBS
-        // Studio binary is `obs64.exe`, Firefox ships `firefox64.exe`,
-        // etc. Users entering `obs` expect those to match.
-        assert!(process_match("obs64.exe", "obs"));
-        assert!(process_match("OBS32.exe", "obs"));
-        assert!(process_match("firefox64.exe", "firefox"));
-        // But `firefoxnightly.exe` should not — letters after the prefix.
-        assert!(!process_match("firefoxnightly.exe", "firefox"));
-    }
-
-    #[test]
-    fn process_match_rejects_unrelated_apps() {
-        assert!(!process_match("safari", "zoom"));
-        assert!(!process_match("", "zoom"));
-    }
-
-    #[test]
-    fn process_match_falls_back_to_substring_for_multi_token_targets() {
-        // Power-users who type a distinctive multi-token snippet expect
-        // substring semantics — splitting `osascript -e` into tokens would
-        // make it match anything with osascript or -e separately.
-        assert!(process_match("/usr/bin/osascript -e foo", "osascript -e"));
-        assert!(!process_match("osascript", "osascript -e"));
-    }
-
-    #[test]
-    fn process_match_empty_target_never_matches() {
-        // Defensive: a blank line in the pause list shouldn't pause for
-        // every process on the system.
-        assert!(!process_match("zoom.us", ""));
-        assert!(!process_match("", ""));
     }
 
     // Fix #1: anchoring `last_app_refresh` 60s before boot used to be


### PR DESCRIPTION
## Summary

Slice 5a of the local-only plugin API — the **detector context layer** and the **real host functions** that replace slice 4's stubs. (The detector eval worker, `run_loop` `GuardReason::Plugin` wiring, install-gate lift, and module-bytes persistence are slice 5b.)

- **`plugins::detect`** — host-performed context probes: `process_running` (via `sysinfo`, cross-platform — so it's exercised on every OS, not a per-OS shim) and `read_flag` (sentinel-file truthiness). The matching/parsing logic is pure and unit-tested. The plugin never touches the OS itself; it calls a gated host function and the host runs the probe here, returning only a boolean.
- **`runtime`** — host functions are `() -> i64` booleans **computed host-side** from the granted scope + a `SandboxContext`, never from module-supplied data — scope-checked by construction. `host_process_running` and `host_read_flag` are real; foreground-window and the export sinks stay inert stubs until their slices. Duplicate host-function names register once (two `detect:file` grants → one `host_read_flag`).
- **`manifest`** — a `detect` config (`process_name` pattern), validated detector-only and requiring a matching `detect:processes` import.

### ABI note
Per the design doc's §4.2 sketch I refined the detector ABI to **scalar-boolean host functions over manifest-declared params**, rather than host functions that marshal strings into wasm memory. It's simpler, safer (the module only ever receives a yes/no, never raw window titles / process lists), and — importantly — testable without a PDK toolchain. Capability-as-import enforcement (slice 4) is unchanged.

## Test Plan
WAT modules that **trap when a host function returns true**, so a test reads the host's boolean answer through call success vs. error — no extism output marshalling, no committed wasm fixtures. Covers: a live process is reported to the module; a granted file's truthiness is reported; an ungranted import is rejected; a stubbed capability is inert; duplicate grants link once; runaways are trapped.

`detect.rs` and `runtime.rs` at **100% line coverage**; new manifest validation fully covered; full Rust lib suite **985 green**; `clippy` / `fmt` / `cargo doc -D warnings` clean. No user-facing change yet (detectors aren't installable/wired until 5b), so no doc update.

Refs #156. Builds on #171.

🤖 Generated with [Claude Code](https://claude.com/claude-code)