### PR TITLE
ci: segment rust cache per runner image to stop cross-glibc poisoning

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -78,6 +78,10 @@ jobs:
       - uses: swatinem/rust-cache@v2
         with:
           workspaces: src-tauri
+          # Key the cache per runner image: ubuntu-22.04 and ubuntu-24.04
+          # both report runner.os=Linux, so a cross-image restore can run a
+          # build-script binary against the wrong glibc (GLIBC_2.39 not found).
+          prefix-key: "rust-ubuntu-22.04"
       - run: mkdir -p audit-reports
 
       - name: Install cargo-deny

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,10 @@ jobs:
       - uses: swatinem/rust-cache@v2
         with:
           workspaces: src-tauri
+          # Key the cache per runner image: ubuntu-22.04 and ubuntu-24.04
+          # both report runner.os=Linux, so a cross-image restore can run a
+          # build-script binary against the wrong glibc (GLIBC_2.39 not found).
+          prefix-key: "rust-${{ matrix.platform }}"
       - name: cargo fmt
         run: cargo fmt --manifest-path src-tauri/Cargo.toml --check
       - name: cargo clippy

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -57,6 +57,10 @@ jobs:
       - uses: swatinem/rust-cache@v2
         with:
           workspaces: src-tauri
+          # Key the cache per runner image: ubuntu-22.04 and ubuntu-24.04
+          # both report runner.os=Linux, so a cross-image restore can run a
+          # build-script binary against the wrong glibc (GLIBC_2.39 not found).
+          prefix-key: "rust-ubuntu-latest"
       - name: Build VitePress site
         working-directory: docs
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,6 +40,10 @@ jobs:
       - uses: swatinem/rust-cache@v2
         with:
           workspaces: src-tauri
+          # Key the cache per runner image: ubuntu-22.04 and ubuntu-24.04
+          # both report runner.os=Linux, so a cross-image restore can run a
+          # build-script binary against the wrong glibc (GLIBC_2.39 not found).
+          prefix-key: "rust-ubuntu-latest"
       - name: Build VitePress site
         working-directory: docs
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -57,6 +57,10 @@ jobs:
       - uses: swatinem/rust-cache@v2
         with:
           workspaces: src-tauri
+          # Key the cache per runner image: ubuntu-22.04 and ubuntu-24.04
+          # both report runner.os=Linux, so a cross-image restore can run a
+          # build-script binary against the wrong glibc (GLIBC_2.39 not found).
+          prefix-key: "rust-${{ matrix.platform }}"
 
       - run: npm ci
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,6 +85,10 @@ jobs:
       - uses: swatinem/rust-cache@v2
         with:
           workspaces: src-tauri
+          # Key the cache per runner image: ubuntu-22.04 and ubuntu-24.04
+          # both report runner.os=Linux, so a cross-image restore can run a
+          # build-script binary against the wrong glibc (GLIBC_2.39 not found).
+          prefix-key: "rust-${{ matrix.platform }}"
 
       - run: npm ci
 
@@ -189,6 +193,10 @@ jobs:
       - uses: swatinem/rust-cache@v2
         with:
           workspaces: src-tauri
+          # Fixed windows-latest runner; key per image for consistency with
+          # the Linux jobs, where 22.04/24.04 sharing runner.os=Linux caused a
+          # cross-image GLIBC mismatch building gtk.
+          prefix-key: "rust-windows-latest"
 
       - run: npm ci
 


### PR DESCRIPTION
## Summary

`swatinem/rust-cache` keys its cache on `runner.os` — which is `"Linux"` for **both** `ubuntu-22.04` and `ubuntu-24.04` (= `ubuntu-latest`). So a 22.04 job can restore a cache saved by a 24.04 job and then try to run a **glibc-2.39 build-script binary** that 22.04's glibc-2.35 can't load:

```
error: failed to run custom build command for `gtk v0.18.2`
  build-script-build: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found
```

It stays dormant because the exact cache key includes the `Cargo.lock` hash — but any change to `Cargo.lock` invalidates that and forces a **restore-key fallback** onto a poisoned cross-image cache. That's exactly what #139 ([#165](https://github.com/drmowinckels/entracte/pull/165)) hit the moment it added a direct `gtk` dependency: the Linux preview-installer build started failing on the GLIBC mismatch even though the same gtk compiles fine in the regular `rust (ubuntu-22.04)` job.

## Fix

Add a per-image `prefix-key` to every `swatinem/rust-cache@v2` step so each runner image keeps its own cache namespace and a 22.04 job can never restore a 24.04 cache:

| Workflow | Job | `prefix-key` |
|----------|-----|--------------|
| ci.yml | matrix | `rust-${{ matrix.platform }}` |
| release.yml | build matrix | `rust-${{ matrix.platform }}` |
| release.yml | windows | `rust-windows-latest` |
| e2e.yml | matrix | `rust-${{ matrix.platform }}` |
| audit.yml | ubuntu-22.04 | `rust-ubuntu-22.04` |
| docs.yml | ubuntu-latest | `rust-ubuntu-latest` |
| docs-preview.yml | ubuntu-latest | `rust-ubuntu-latest` |

`build-preview.yml` already received the same fix in #165 (that's how the Linux `.deb` for #139 testing got unblocked).

## Test plan

- All six workflow files parse as valid YAML.
- Mechanical, behaviour-neutral change: it only renames cache key namespaces. First run per image rebuilds from scratch (cold cache, one-time), then each image caches independently and the cross-glibc restore can't recur.
- No application code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)