### PR TITLE
feat(plugins): detector eval worker + break suppression (#156)

### DIFF
--- a/src-tauri/src/plugin_store.rs
+++ b/src-tauri/src/plugin_store.rs
@@ -36,6 +36,23 @@ pub fn save_module(registry_path: &Path, id: &str, bytes: &[u8]) -> io::Result<(
     write_user_only(&module_path(registry_path, id), bytes)
 }
 
+/// Cap on a module read back from disk — matches the install-time decode cap.
+const MAX_MODULE_BYTES: u64 = 16 * 1024 * 1024;
+
+/// Read a plugin's wasm module from disk (size-capped). Errors if missing,
+/// oversized, or unreadable — callers treat that as "no detector to run".
+pub fn load_module(registry_path: &Path, id: &str) -> io::Result<Vec<u8>> {
+    let path = module_path(registry_path, id);
+    let meta = std::fs::metadata(&path)?;
+    if meta.len() > MAX_MODULE_BYTES {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "plugin module exceeds the size cap",
+        ));
+    }
+    std::fs::read(&path)
+}
+
 /// Remove a plugin's module file. Missing is fine (idempotent uninstall).
 pub fn delete_module(registry_path: &Path, id: &str) {
     let path = module_path(registry_path, id);
@@ -115,6 +132,24 @@ mod tests {
         assert!(!mp.exists());
         // Idempotent: deleting again is a no-op, not an error.
         delete_module(&path, "com.x.detector");
+    }
+
+    #[test]
+    fn load_module_reads_saved_and_errors_on_missing_or_oversized() {
+        let (_d, path) = temp_path();
+        assert!(load_module(&path, "com.x.det").is_err(), "missing → err");
+
+        save_module(&path, "com.x.det", b"\0asm bytes").unwrap();
+        assert_eq!(load_module(&path, "com.x.det").unwrap(), b"\0asm bytes");
+
+        save_module(
+            &path,
+            "com.x.big",
+            &vec![0u8; (MAX_MODULE_BYTES + 1) as usize],
+        )
+        .unwrap();
+        let err = load_module(&path, "com.x.big").unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
     }
 
     #[test]

--- a/src-tauri/src/plugins/detect.rs
+++ b/src-tauri/src/plugins/detect.rs
@@ -7,11 +7,6 @@
 //! `sysinfo` process read is cross-platform (so it's exercised on every OS,
 //! per the coverage policy) rather than a per-OS FFI shim.
 
-// Consumed by the sandbox host functions in `runtime`, which in turn has no
-// non-test caller until the detector eval worker (slice 5b) wires it into the
-// run loop. Scoped allow until then; the tests exercise these directly.
-#![allow(dead_code)]
-
 use std::path::Path;
 
 use sysinfo::{ProcessesToUpdate, System};

--- a/src-tauri/src/plugins/eval.rs
+++ b/src-tauri/src/plugins/eval.rs
@@ -1,0 +1,95 @@
+//! Aggregating installed detectors into a single suppress / don't verdict
+//! (#156, slice 5b). The off-tick detector-eval task snapshots the installed
+//! detectors, loads each module, and asks [`any_detector_suppresses`]; the
+//! result feeds the 1Hz loop's suppression chain via `Scheduler::plugin_suppress`.
+//!
+//! The aggregation is pure (the module loader is injected), so it's
+//! unit-testable with wat modules and a fake loader — no disk, no scheduler.
+
+use super::manifest::Capability;
+use super::runtime::evaluate_detector;
+
+/// The minimum a detector needs to be evaluated: its id (to load the module),
+/// its granted capabilities (to rebuild the sandbox), and its process pattern.
+#[derive(Debug, Clone)]
+pub struct DetectorSnapshot {
+    pub id: String,
+    pub capabilities: Vec<Capability>,
+    pub process_pattern: Option<String>,
+}
+
+/// Whether **any** snapshotted detector votes to suppress the next break.
+/// `load` fetches a detector's module bytes by id (`None` → skip it, e.g. a
+/// missing/unreadable module). Short-circuits on the first suppressing
+/// detector. A detector whose module fails to build or run contributes no
+/// suppression (see [`evaluate_detector`]).
+pub fn any_detector_suppresses(
+    detectors: &[DetectorSnapshot],
+    load: impl Fn(&str) -> Option<Vec<u8>>,
+) -> bool {
+    detectors.iter().any(|d| match load(&d.id) {
+        Some(module) => evaluate_detector(&module, &d.capabilities, d.process_pattern.clone()),
+        None => false,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A detector module that votes suppress (via host_suppress) iff the
+    /// granted process probe matches.
+    fn suppress_if_process_module() -> Vec<u8> {
+        wat::parse_str(
+            r#"(module
+                 (import "extism:host/user" "host_process_running" (func $proc (result i64)))
+                 (import "extism:host/user" "host_suppress" (func $suppress))
+                 (memory (export "memory") 1)
+                 (func (export "detect") (result i32)
+                   (if (i64.ne (call $proc) (i64.const 0)) (then (call $suppress)))
+                   (i32.const 0)))"#,
+        )
+        .unwrap()
+    }
+
+    fn snapshot(id: &str, pattern: &str) -> DetectorSnapshot {
+        DetectorSnapshot {
+            id: id.to_string(),
+            capabilities: vec![Capability::DetectProcesses],
+            process_pattern: Some(pattern.to_string()),
+        }
+    }
+
+    #[test]
+    fn suppresses_when_any_detector_votes() {
+        let module = suppress_if_process_module();
+        let load = |_id: &str| Some(module.clone());
+        // "entracte" matches the test binary → that detector votes suppress.
+        let detectors = vec![
+            snapshot("com.x.idle", "entracte-no-such-zzz"),
+            snapshot("com.x.focus", "entracte"),
+        ];
+        assert!(any_detector_suppresses(&detectors, load));
+    }
+
+    #[test]
+    fn no_suppression_when_none_vote() {
+        let module = suppress_if_process_module();
+        let detectors = vec![snapshot("com.x.idle", "entracte-no-such-zzz")];
+        assert!(!any_detector_suppresses(&detectors, |_| Some(
+            module.clone()
+        )));
+    }
+
+    #[test]
+    fn a_missing_module_is_skipped() {
+        let detectors = vec![snapshot("com.x.gone", "entracte")];
+        // Loader returns None (module gone) → no suppression, no panic.
+        assert!(!any_detector_suppresses(&detectors, |_| None));
+    }
+
+    #[test]
+    fn empty_set_does_not_suppress() {
+        assert!(!any_detector_suppresses(&[], |_| Some(vec![1, 2, 3])));
+    }
+}

--- a/src-tauri/src/plugins/mod.rs
+++ b/src-tauri/src/plugins/mod.rs
@@ -16,11 +16,14 @@
 //! the wasm runtime (a later slice).
 
 mod detect;
+mod eval;
 mod install;
 mod manifest;
 pub(crate) mod registry;
 mod runtime;
 mod signature;
+
+pub use eval::any_detector_suppresses;
 
 pub use install::prepare_content_install;
 #[allow(unused_imports)]

--- a/src-tauri/src/plugins/registry.rs
+++ b/src-tauri/src/plugins/registry.rs
@@ -105,6 +105,26 @@ impl PluginRegistry {
     pub fn summaries(&self) -> Vec<PluginSummary> {
         self.plugins.iter().map(PluginSummary::from).collect()
     }
+
+    /// What the off-tick eval task needs for each installed detector: id (to
+    /// load its module), parsed granted capabilities (to rebuild the sandbox),
+    /// and the process pattern. Capability strings that fail to parse are
+    /// dropped — they were validated at install, so this is belt-and-braces.
+    pub fn detector_snapshots(&self) -> Vec<super::eval::DetectorSnapshot> {
+        self.plugins
+            .iter()
+            .filter(|p| p.kind == PluginKind::Detector)
+            .map(|p| super::eval::DetectorSnapshot {
+                id: p.id.clone(),
+                capabilities: p
+                    .capabilities
+                    .iter()
+                    .filter_map(|c| super::manifest::Capability::parse(c).ok())
+                    .collect(),
+                process_pattern: p.detect.as_ref().and_then(|d| d.process_name.clone()),
+            })
+            .collect()
+    }
 }
 
 /// What the Settings UI shows per installed plugin. Counts come from the
@@ -160,6 +180,38 @@ mod tests {
             capabilities: Vec::new(),
             detect: None,
         }
+    }
+
+    fn detector_record(id: &str) -> InstalledPlugin {
+        InstalledPlugin {
+            id: id.to_string(),
+            name: "Detector".to_string(),
+            author: "Me".to_string(),
+            version: "1.0.0".to_string(),
+            kind: PluginKind::Detector,
+            public_key: "AA==".to_string(),
+            added: AddedContent::default(),
+            // One valid capability + one junk string that must be dropped.
+            capabilities: vec!["detect:processes".to_string(), "garbage".to_string()],
+            detect: Some(DetectConfig {
+                process_name: Some("zoom".to_string()),
+            }),
+        }
+    }
+
+    #[test]
+    fn detector_snapshots_parses_caps_and_excludes_content() {
+        use super::super::manifest::Capability;
+        let mut reg = PluginRegistry::default();
+        reg.insert(record("com.x.content")); // content → excluded
+        reg.insert(detector_record("com.x.det"));
+
+        let snaps = reg.detector_snapshots();
+        assert_eq!(snaps.len(), 1);
+        assert_eq!(snaps[0].id, "com.x.det");
+        // The junk capability string was dropped; the valid one parsed.
+        assert_eq!(snaps[0].capabilities, vec![Capability::DetectProcesses]);
+        assert_eq!(snaps[0].process_pattern, Some("zoom".to_string()));
     }
 
     #[test]

--- a/src-tauri/src/plugins/runtime.rs
+++ b/src-tauri/src/plugins/runtime.rs
@@ -18,13 +18,6 @@
 //! scope-checked implementations (read the foreground window, POST to the
 //! granted origin, …).
 
-// Foundational slice: the sandbox builder + ABI mapping have no in-crate
-// caller yet (the detector and export slices consume them per the design
-// doc's staging plan), so they read as dead in the non-test build. The
-// wat-driven tests exercise them directly. Scoped to this module; removed
-// when the first consumer lands.
-#![allow(dead_code)]
-
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;

--- a/src-tauri/src/plugins/signature.rs
+++ b/src-tauri/src/plugins/signature.rs
@@ -19,10 +19,8 @@ use sha2::{Digest, Sha256};
 use super::manifest::Manifest;
 
 /// SHA-256 of `bytes`, as a fixed 32-byte array. Used to hash a plugin's
-/// wasm module for inclusion in the signed payload. Only code-bearing
-/// plugins ship a module, so this has no non-test caller until the runtime
-/// slice; content plugins sign over the manifest alone.
-#[allow(dead_code)]
+/// wasm module for inclusion in the signed payload (content plugins sign over
+/// the manifest alone).
 pub fn sha256(bytes: &[u8]) -> [u8; 32] {
     let mut hasher = Sha256::new();
     hasher.update(bytes);

--- a/src-tauri/src/scheduler/mod.rs
+++ b/src-tauri/src/scheduler/mod.rs
@@ -16,6 +16,13 @@ mod types;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 use std::sync::Arc;
+use std::time::Duration;
+
+/// How often the off-tick task re-evaluates installed detector plugins.
+/// Detectors gate breaks, which fire on the order of minutes, so a few
+/// seconds of latency on a context change is imperceptible while keeping the
+/// wasm work infrequent.
+const DETECTOR_EVAL_INTERVAL: Duration = Duration::from_secs(5);
 
 use log::warn;
 use tauri::AppHandle;
@@ -135,6 +142,11 @@ pub struct Scheduler {
     pub pause_state: Arc<Mutex<PauseState>>,
     pub camera_active: Arc<AtomicBool>,
     pub video_active: Arc<AtomicBool>,
+    /// Whether any installed detector plugin currently votes to suppress
+    /// breaks. Written by the off-tick detector-eval task, read by the 1Hz
+    /// loop's suppression chain — like `camera_active`, an atomic so the
+    /// per-tick read is free.
+    pub plugin_suppress: Arc<AtomicBool>,
     /// 0 = not auto-suppressed; otherwise `SuppressReason::from_u8`
     /// decodes which guard fired. The tray reads this each tick to
     /// pick between the Inactive icon + reason tooltip vs the Normal
@@ -204,6 +216,7 @@ impl Scheduler {
             pause_state: Arc::new(Mutex::new(pause_state)),
             camera_active,
             video_active,
+            plugin_suppress: Arc::new(AtomicBool::new(false)),
             auto_suppress_reason,
             config_path,
             pause_path,
@@ -232,6 +245,39 @@ impl Scheduler {
         tauri::async_runtime::spawn(async move {
             run_loop::run_loop(app, me).await;
         });
+        self.spawn_detector_eval();
+    }
+
+    /// Run the installed detector plugins off the 1Hz tick, on a throttled
+    /// interval, and publish their aggregate verdict to `plugin_suppress` for
+    /// the run loop to read. The wasm work happens on a blocking thread so it
+    /// never stalls the scheduler tick; building/running a detector is
+    /// fail-closed (a broken detector never suppresses). No detectors → the
+    /// flag is cleared and the loop short-circuits.
+    fn spawn_detector_eval(&self) {
+        let registry = self.plugins.clone();
+        let plugins_path = self.plugins_path.clone();
+        let suppress = self.plugin_suppress.clone();
+        tauri::async_runtime::spawn(async move {
+            let mut interval = tokio::time::interval(DETECTOR_EVAL_INTERVAL);
+            loop {
+                interval.tick().await;
+                let snapshots = registry.lock().await.detector_snapshots();
+                if snapshots.is_empty() {
+                    suppress.store(false, Ordering::Relaxed);
+                    continue;
+                }
+                let path = plugins_path.clone();
+                let verdict = tauri::async_runtime::spawn_blocking(move || {
+                    crate::plugins::any_detector_suppresses(&snapshots, |id| {
+                        crate::plugin_store::load_module(&path, id).ok()
+                    })
+                })
+                .await
+                .unwrap_or(false);
+                suppress.store(verdict, Ordering::Relaxed);
+            }
+        });
     }
 
     /// Sibling of `Scheduler::new` for the integration-test rig
@@ -258,6 +304,7 @@ impl Scheduler {
             pause_state: Arc::new(Mutex::new(PauseState::Running)),
             camera_active: Arc::new(AtomicBool::new(false)),
             video_active: Arc::new(AtomicBool::new(false)),
+            plugin_suppress: Arc::new(AtomicBool::new(false)),
             auto_suppress_reason: Arc::new(AtomicU8::new(0)),
             config_path: dir.join("settings.json"),
             pause_path: dir.join("pause.json"),

--- a/src-tauri/src/scheduler/run_loop.rs
+++ b/src-tauri/src/scheduler/run_loop.rs
@@ -317,6 +317,7 @@ pub(super) async fn run_loop(app: AppHandle, sched: Scheduler) {
             camera_live,
             video_live,
             app_pause_active,
+            sched.plugin_suppress.load(Ordering::Relaxed),
         ) {
             let mut t = sched.timers.lock().await;
             if let Some(guard_reason) = outcome.log_as {
@@ -718,6 +719,7 @@ pub(super) fn evaluate_guards(
     camera_active: bool,
     video_active: bool,
     app_pause_active: bool,
+    plugin_suppress: bool,
 ) -> Option<GuardOutcome> {
     if s.work_window_enabled && !in_window(now_min, s.work_start_minutes, s.work_end_minutes) {
         return Some(GuardOutcome {
@@ -747,6 +749,15 @@ pub(super) fn evaluate_guards(
         return Some(GuardOutcome {
             reason: SuppressReason::AppPause,
             log_as: Some(GuardReason::AppPause),
+        });
+    }
+    // A detector plugin voted to suppress. No settings gate: installing a
+    // detector (with consent) is the opt-in, and `plugin_suppress` is only
+    // true when an installed detector's `detect()` returned a verdict.
+    if plugin_suppress {
+        return Some(GuardOutcome {
+            reason: SuppressReason::Plugin,
+            log_as: Some(GuardReason::Plugin),
         });
     }
     None
@@ -1808,7 +1819,7 @@ mod tests {
     #[test]
     fn evaluate_guards_returns_none_when_all_off() {
         let s = settings_for_guards(false, false, false, false, false);
-        assert!(evaluate_guards(&s, INSIDE_WORK_WINDOW, true, true, true, true).is_none());
+        assert!(evaluate_guards(&s, INSIDE_WORK_WINDOW, true, true, true, true, false).is_none());
     }
 
     #[test]
@@ -1816,7 +1827,9 @@ mod tests {
         // work_window_enabled with a current minute inside [start,end)
         // is the happy path — no suppression.
         let s = settings_for_guards(true, false, false, false, false);
-        assert!(evaluate_guards(&s, INSIDE_WORK_WINDOW, false, false, false, false).is_none());
+        assert!(
+            evaluate_guards(&s, INSIDE_WORK_WINDOW, false, false, false, false, false).is_none()
+        );
     }
 
     #[test]
@@ -1824,7 +1837,8 @@ mod tests {
         // Outside-hours suppression doesn't log — it's a scheduled
         // silence, not an unexpected event.
         let s = settings_for_guards(true, false, false, false, false);
-        let outcome = evaluate_guards(&s, OUTSIDE_WORK_WINDOW, false, false, false, false).unwrap();
+        let outcome =
+            evaluate_guards(&s, OUTSIDE_WORK_WINDOW, false, false, false, false, false).unwrap();
         assert_eq!(outcome.reason, SuppressReason::WorkWindow);
         assert!(
             outcome.log_as.is_none(),
@@ -1835,22 +1849,27 @@ mod tests {
     #[test]
     fn evaluate_guards_dnd_fires_only_when_setting_and_state_both_true() {
         let s_off = settings_for_guards(false, false, false, false, false);
-        assert!(evaluate_guards(&s_off, INSIDE_WORK_WINDOW, true, false, false, false).is_none());
+        assert!(
+            evaluate_guards(&s_off, INSIDE_WORK_WINDOW, true, false, false, false, false).is_none()
+        );
 
         let s_on = settings_for_guards(false, true, false, false, false);
         let outcome =
-            evaluate_guards(&s_on, INSIDE_WORK_WINDOW, true, false, false, false).unwrap();
+            evaluate_guards(&s_on, INSIDE_WORK_WINDOW, true, false, false, false, false).unwrap();
         assert_eq!(outcome.reason, SuppressReason::Dnd);
         assert_eq!(outcome.log_as, Some(GuardReason::Dnd));
 
         // Setting on but state false → no suppression.
-        assert!(evaluate_guards(&s_on, INSIDE_WORK_WINDOW, false, false, false, false).is_none());
+        assert!(
+            evaluate_guards(&s_on, INSIDE_WORK_WINDOW, false, false, false, false, false).is_none()
+        );
     }
 
     #[test]
     fn evaluate_guards_camera_logs_camera_reason() {
         let s = settings_for_guards(false, false, true, false, false);
-        let outcome = evaluate_guards(&s, INSIDE_WORK_WINDOW, false, true, false, false).unwrap();
+        let outcome =
+            evaluate_guards(&s, INSIDE_WORK_WINDOW, false, true, false, false, false).unwrap();
         assert_eq!(outcome.reason, SuppressReason::Camera);
         assert_eq!(outcome.log_as, Some(GuardReason::Camera));
     }
@@ -1858,7 +1877,8 @@ mod tests {
     #[test]
     fn evaluate_guards_video_logs_video_reason() {
         let s = settings_for_guards(false, false, false, true, false);
-        let outcome = evaluate_guards(&s, INSIDE_WORK_WINDOW, false, false, true, false).unwrap();
+        let outcome =
+            evaluate_guards(&s, INSIDE_WORK_WINDOW, false, false, true, false, false).unwrap();
         assert_eq!(outcome.reason, SuppressReason::Video);
         assert_eq!(outcome.log_as, Some(GuardReason::Video));
     }
@@ -1869,13 +1889,37 @@ mod tests {
         // so the guard must not fire even when app_pause_active is true.
         let mut s = settings_for_guards(false, false, false, false, true);
         s.app_pause_list.clear();
-        assert!(evaluate_guards(&s, INSIDE_WORK_WINDOW, false, false, false, true).is_none());
+        assert!(
+            evaluate_guards(&s, INSIDE_WORK_WINDOW, false, false, false, true, false).is_none()
+        );
 
         let with_target = settings_for_guards(false, false, false, false, true);
-        let outcome =
-            evaluate_guards(&with_target, INSIDE_WORK_WINDOW, false, false, false, true).unwrap();
+        let outcome = evaluate_guards(
+            &with_target,
+            INSIDE_WORK_WINDOW,
+            false,
+            false,
+            false,
+            true,
+            false,
+        )
+        .unwrap();
         assert_eq!(outcome.reason, SuppressReason::AppPause);
         assert_eq!(outcome.log_as, Some(GuardReason::AppPause));
+    }
+
+    #[test]
+    fn evaluate_guards_plugin_suppress_fires_without_a_settings_gate() {
+        // No setting toggles plugin suppression — a true verdict suppresses,
+        // a false one doesn't.
+        let s = settings_for_guards(false, false, false, false, false);
+        assert!(
+            evaluate_guards(&s, INSIDE_WORK_WINDOW, false, false, false, false, false).is_none()
+        );
+        let outcome =
+            evaluate_guards(&s, INSIDE_WORK_WINDOW, false, false, false, false, true).unwrap();
+        assert_eq!(outcome.reason, SuppressReason::Plugin);
+        assert_eq!(outcome.log_as, Some(GuardReason::Plugin));
     }
 
     #[test]
@@ -1884,7 +1928,8 @@ mod tests {
         // firing simultaneously, work_window short-circuits the rest
         // (and stays silent, per its no-log policy).
         let s = settings_for_guards(true, true, true, true, true);
-        let outcome = evaluate_guards(&s, OUTSIDE_WORK_WINDOW, true, true, true, true).unwrap();
+        let outcome =
+            evaluate_guards(&s, OUTSIDE_WORK_WINDOW, true, true, true, true, false).unwrap();
         assert_eq!(outcome.reason, SuppressReason::WorkWindow);
         assert!(outcome.log_as.is_none());
     }
@@ -1893,28 +1938,32 @@ mod tests {
     fn evaluate_guards_dnd_outranks_camera_video_app_pause() {
         let s = settings_for_guards(true, true, true, true, true);
         // Inside the work window, so work_window does NOT fire.
-        let outcome = evaluate_guards(&s, INSIDE_WORK_WINDOW, true, true, true, true).unwrap();
+        let outcome =
+            evaluate_guards(&s, INSIDE_WORK_WINDOW, true, true, true, true, false).unwrap();
         assert_eq!(outcome.reason, SuppressReason::Dnd);
     }
 
     #[test]
     fn evaluate_guards_camera_outranks_video_and_app_pause() {
         let s = settings_for_guards(true, true, true, true, true);
-        let outcome = evaluate_guards(&s, INSIDE_WORK_WINDOW, false, true, true, true).unwrap();
+        let outcome =
+            evaluate_guards(&s, INSIDE_WORK_WINDOW, false, true, true, true, false).unwrap();
         assert_eq!(outcome.reason, SuppressReason::Camera);
     }
 
     #[test]
     fn evaluate_guards_video_outranks_app_pause() {
         let s = settings_for_guards(true, true, true, true, true);
-        let outcome = evaluate_guards(&s, INSIDE_WORK_WINDOW, false, false, true, true).unwrap();
+        let outcome =
+            evaluate_guards(&s, INSIDE_WORK_WINDOW, false, false, true, true, false).unwrap();
         assert_eq!(outcome.reason, SuppressReason::Video);
     }
 
     #[test]
     fn evaluate_guards_app_pause_only_when_higher_guards_quiet() {
         let s = settings_for_guards(true, true, true, true, true);
-        let outcome = evaluate_guards(&s, INSIDE_WORK_WINDOW, false, false, false, true).unwrap();
+        let outcome =
+            evaluate_guards(&s, INSIDE_WORK_WINDOW, false, false, false, true, false).unwrap();
         assert_eq!(outcome.reason, SuppressReason::AppPause);
     }
 

--- a/src-tauri/src/scheduler/tray_countdown.rs
+++ b/src-tauri/src/scheduler/tray_countdown.rs
@@ -316,6 +316,7 @@ mod tests {
             pause_state: Arc::new(TokioMutex::new(PauseState::Running)),
             camera_active: Arc::new(AtomicBool::new(false)),
             video_active: Arc::new(AtomicBool::new(false)),
+            plugin_suppress: Arc::new(AtomicBool::new(false)),
             auto_suppress_reason: Arc::new(AtomicU8::new(0)),
             config_path,
             pause_path,

--- a/src-tauri/src/scheduler/types.rs
+++ b/src-tauri/src/scheduler/types.rs
@@ -97,6 +97,7 @@ pub enum SuppressReason {
     Camera,
     Video,
     AppPause,
+    Plugin,
 }
 
 impl SuppressReason {
@@ -109,6 +110,7 @@ impl SuppressReason {
             Self::Camera => 3,
             Self::Video => 4,
             Self::AppPause => 5,
+            Self::Plugin => 6,
         }
     }
 
@@ -121,6 +123,7 @@ impl SuppressReason {
             3 => Some(Self::Camera),
             4 => Some(Self::Video),
             5 => Some(Self::AppPause),
+            6 => Some(Self::Plugin),
             _ => None,
         }
     }
@@ -134,6 +137,7 @@ impl SuppressReason {
             Self::Camera => "camera",
             Self::Video => "video",
             Self::AppPause => "app paused",
+            Self::Plugin => "plugin",
         }
     }
 
@@ -146,6 +150,7 @@ impl SuppressReason {
             Self::Camera => "Camera in use (Quiet → Pause during camera)",
             Self::Video => "Video keeping the display awake (Quiet → Pause during video)",
             Self::AppPause => "A paused app is running (Quiet → App pause list)",
+            Self::Plugin => "A detector plugin is suppressing breaks (System → Plugins)",
         }
     }
 }
@@ -166,12 +171,13 @@ pub struct PostponeState {
 mod tests {
     use super::*;
 
-    const ALL_REASONS: [SuppressReason; 5] = [
+    const ALL_REASONS: [SuppressReason; 6] = [
         SuppressReason::WorkWindow,
         SuppressReason::Dnd,
         SuppressReason::Camera,
         SuppressReason::Video,
         SuppressReason::AppPause,
+        SuppressReason::Plugin,
     ];
 
     #[test]

--- a/src-tauri/src/stats.rs
+++ b/src-tauri/src/stats.rs
@@ -31,6 +31,7 @@ pub enum GuardReason {
     AppPause,
     Typing,
     Video,
+    Plugin,
 }
 
 impl GuardReason {
@@ -42,6 +43,7 @@ impl GuardReason {
             GuardReason::AppPause => "Paused-app running",
             GuardReason::Typing => "Actively typing",
             GuardReason::Video => "Video playing",
+            GuardReason::Plugin => "Plugin detector",
         }
     }
 }
@@ -586,6 +588,7 @@ fn guard_str(g: GuardReason) -> &'static str {
         GuardReason::AppPause => "app_pause",
         GuardReason::Typing => "typing",
         GuardReason::Video => "video",
+        GuardReason::Plugin => "plugin",
     }
 }
 


### PR DESCRIPTION
## Summary

The finale of detectors — **installed detector plugins now actually suppress breaks.** Closes the detector path end to end (slice 5b-3b).

- **Off-tick eval worker** (`Scheduler::spawn_detector_eval`): every 5s it snapshots the installed detectors and — on a blocking thread, *never the 1 Hz tick* — loads each module and asks `plugins::any_detector_suppresses`, publishing the aggregate verdict to a new `Scheduler::plugin_suppress` atomic. No detectors → flag cleared, short-circuit. `spawn_blocking` + `unwrap_or(false)` ⇒ a panicking/slow eval **fails closed**.
- **`run_loop` step 5:** `evaluate_guards` gains a `plugin_suppress` input (after `app_pause` in the precedence chain; **no settings gate** — installing a detector with consent is the opt-in). The loop reads the atomic each tick, exactly like `camera_active`. New `SuppressReason::Plugin` (tray tooltip *"A detector plugin is suppressing breaks"*) and `GuardReason::Plugin`.
- **`plugins::eval`:** `DetectorSnapshot` + `any_detector_suppresses` (short-circuits; **injected loader** → unit-testable with wat modules, no disk). Registry gains `detector_snapshots()`; `plugin_store` gains `load_module` (size-capped).
- Removed the now-redundant `dead_code` allows on `runtime`/`detect`/`sha256` — the worker gives the whole chain a production caller.

## Reviews (inline, per commitment)
- **Security:** a detector can only *suppress* (delay) breaks — never force/lengthen/skip; fails closed on a broken/slow/hostile module; runs off-tick so it can't stall the loop; one-way boolean verdict (no data egress). An always-suppressing detector only harms the consenting user and is reversible by uninstall (self-DoS, out of scope).
- **Critical:** the eval task clones the snapshot *before* `spawn_blocking` (snapshot-then-act, no lock held across `.await`); fails closed on task panic.
- **Simplify:** `any_detector_suppresses` short-circuits; clean.

## Test Plan
`evaluate_guards` plugin arm (fires, ungated) + suppress-reason `u8`/label round-trips; `any_detector_suppresses` (votes / none / missing-module / empty); `detector_snapshots` (parse + content-excluded); `load_module` (read / missing / oversized). **Rust lib suite 1010 green;** clippy/fmt/cargo-doc clean.

### codecov/patch note
The only uncovered patch lines are the **spawned eval task + `Scheduler` construction** — untestable spawned-loop/construction shims, same category as the existing camera/video monitor spawns. All extracted logic (`any_detector_suppresses`, `detector_snapshots`, `load_module`, `evaluate_guards`) is covered.

Refs #156. Builds on #176. **Completes slice 5 (local context detectors).**

🤖 Generated with [Claude Code](https://claude.com/claude-code)