### PR TITLE
feat(plugins): declarative export adapters — manifest + install (#156)

### DIFF
--- a/src-tauri/src/plugin_store.rs
+++ b/src-tauri/src/plugin_store.rs
@@ -108,6 +108,7 @@ mod tests {
             added: Default::default(),
             capabilities: Vec::new(),
             detect: None,
+            export: None,
         });
         reg
     }

--- a/src-tauri/src/plugins/install.rs
+++ b/src-tauri/src/plugins/install.rs
@@ -45,6 +45,34 @@ pub fn prepare_content_install(
     Ok(manifest)
 }
 
+/// Validate an incoming export-plugin manifest end to end and return it ready
+/// to register. Like content, an export adapter is declarative (no wasm), so
+/// the signature is verified over the manifest alone. Runs: parse → schema
+/// validation (which checks the export config) → export-only gate → signature
+/// → not-already-installed.
+pub fn prepare_export_install(
+    manifest_json: &str,
+    registry: &PluginRegistry,
+) -> Result<Manifest, String> {
+    let manifest = parse_manifest(manifest_json)?;
+    validate_manifest(&manifest)?;
+
+    if manifest.kind != PluginKind::Export {
+        return Err("this installer handles export plugins only".to_string());
+    }
+
+    verify_signature(&manifest, None)?;
+
+    if registry.contains(&manifest.id) {
+        return Err(format!(
+            "plugin '{}' is already installed; remove it first",
+            manifest.id
+        ));
+    }
+
+    Ok(manifest)
+}
+
 /// A detector validated and ready to install: the manifest plus its decoded,
 /// signature-verified, sandbox-linkable wasm module.
 // Fields read by the install command in the next slice.
@@ -158,6 +186,7 @@ mod tests {
             abi_version: None,
             imports: vec![],
             detect: None,
+            export: None,
             content: Some(pack()),
             signature: super::super::manifest::Signature {
                 alg: "ed25519".to_string(),
@@ -178,6 +207,70 @@ mod tests {
         let m = prepare_content_install(&json, &PluginRegistry::default()).unwrap();
         assert_eq!(m.id, "com.example.pack");
         assert!(m.content.is_some());
+    }
+
+    fn signed_export_manifest_json(id: &str) -> String {
+        use crate::plugins::{ExportConfig, ExportFormat, ExportSink};
+        let mut m = Manifest {
+            manifest_version: crate::plugins::manifest::MANIFEST_VERSION,
+            id: id.to_string(),
+            name: "JSON export".to_string(),
+            version: "1.0.0".to_string(),
+            author: "Jane".to_string(),
+            description: String::new(),
+            kind: PluginKind::Export,
+            module: None,
+            module_base64: None,
+            abi_version: None,
+            imports: vec![],
+            detect: None,
+            export: Some(ExportConfig {
+                sink: ExportSink::Http,
+                format: ExportFormat::Json,
+                destination: "https://example.test/ingest".to_string(),
+                on: vec![crate::hooks::HookEvent::BreakEnd],
+            }),
+            content: None,
+            signature: super::super::manifest::Signature {
+                alg: "ed25519".to_string(),
+                public_key: String::new(),
+                sig: String::new(),
+            },
+        };
+        let key = SigningKey::from_bytes(&[12u8; 32]);
+        m.signature.public_key = BASE64_STANDARD.encode(key.verifying_key().to_bytes());
+        m.signature.sig = BASE64_STANDARD.encode(key.sign(&signing_payload(&m, None)).to_bytes());
+        serde_json::to_string(&m).unwrap()
+    }
+
+    #[test]
+    fn accepts_a_signed_export_plugin() {
+        let json = signed_export_manifest_json("com.example.exp");
+        let m = prepare_export_install(&json, &PluginRegistry::default()).unwrap();
+        assert_eq!(m.id, "com.example.exp");
+        assert!(m.export.is_some());
+    }
+
+    #[test]
+    fn export_install_rejects_a_content_manifest() {
+        // Routed to the wrong installer: a content manifest reaches the
+        // export path and is refused before anything else.
+        let json = signed_content_manifest_json("com.example.pack");
+        assert!(prepare_export_install(&json, &PluginRegistry::default())
+            .unwrap_err()
+            .contains("handles export plugins only"));
+    }
+
+    #[test]
+    fn export_install_rejects_an_already_installed_id() {
+        let json = signed_export_manifest_json("com.example.exp");
+        let mut reg = PluginRegistry::default();
+        reg.insert(InstalledPlugin::from_export(
+            &parse_manifest(&json).unwrap(),
+        ));
+        assert!(prepare_export_install(&json, &reg)
+            .unwrap_err()
+            .contains("already installed"));
     }
 
     #[test]
@@ -205,6 +298,7 @@ mod tests {
             added: Default::default(),
             capabilities: Vec::new(),
             detect: None,
+            export: None,
         });
         assert!(prepare_content_install(&json, &reg)
             .unwrap_err()
@@ -261,6 +355,7 @@ mod tests {
             detect: (import == "detect:processes").then(|| DetectConfig {
                 process_name: Some("zoom".to_string()),
             }),
+            export: None,
             content: None,
             signature: super::super::manifest::Signature {
                 alg: "ed25519".to_string(),
@@ -310,6 +405,7 @@ mod tests {
             detect: Some(DetectConfig {
                 process_name: Some("zoom".to_string()),
             }),
+            export: None,
             content: None,
             signature: super::super::manifest::Signature {
                 alg: "ed25519".to_string(),
@@ -435,6 +531,7 @@ mod tests {
             added: Default::default(),
             capabilities: Vec::new(),
             detect: None,
+            export: None,
         });
         assert!(prepare_detector_install(&json, &reg)
             .unwrap_err()

--- a/src-tauri/src/plugins/manifest.rs
+++ b/src-tauri/src/plugins/manifest.rs
@@ -39,9 +39,10 @@ pub enum PluginKind {
 
 impl PluginKind {
     /// Whether this kind ships an executable wasm module (and therefore must
-    /// declare a `module`, an `abi_version`, and at least one import).
+    /// declare a `module`, an `abi_version`, and at least one import). Only
+    /// detectors run code; content and export plugins are declarative data.
     fn is_code_bearing(self) -> bool {
-        matches!(self, PluginKind::Detector | PluginKind::Export)
+        matches!(self, PluginKind::Detector)
     }
 }
 
@@ -134,6 +135,40 @@ pub struct DetectConfig {
     pub process_name: Option<String>,
 }
 
+/// Where a declarative export adapter delivers break stats.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ExportSink {
+    /// Write to a local file (the granted path).
+    File,
+    /// POST to a user-controlled URL — the only sink that leaves the machine.
+    Http,
+}
+
+/// The serialisation the host renders break stats in before delivery.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ExportFormat {
+    Csv,
+    Json,
+}
+
+/// A declarative export adapter: on the named events, the host renders its
+/// own break stats in `format` and delivers them to `destination` via `sink`.
+/// No wasm — the plugin runs no code; the destination is fixed here (and
+/// shown in the consent dialog), so the plugin can never redirect the data.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ExportConfig {
+    pub sink: ExportSink,
+    pub format: ExportFormat,
+    /// File path (for `file`) or URL (for `http`). For `http` it must be an
+    /// `http(s)://` URL; the origin is the consent boundary.
+    pub destination: String,
+    /// Which scheduler events trigger a delivery. Reuses the hook event
+    /// vocabulary; must be non-empty.
+    pub on: Vec<crate::hooks::HookEvent>,
+}
+
 /// The detached signature over `canonical(manifest-without-signature)` plus
 /// the module hash. ed25519; keys and signature are base64.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -171,6 +206,8 @@ pub struct Manifest {
     pub imports: Vec<String>,
     #[serde(default)]
     pub detect: Option<DetectConfig>,
+    #[serde(default)]
+    pub export: Option<ExportConfig>,
     #[serde(default)]
     pub content: Option<ContentPack>,
     pub signature: Signature,
@@ -259,20 +296,41 @@ pub fn validate_manifest(m: &Manifest) -> Result<(), String> {
         if m.content.is_some() {
             return Err("a code-bearing plugin must not carry a content payload".to_string());
         }
+        if m.export.is_some() {
+            return Err("a code-bearing plugin must not carry an export config".to_string());
+        }
     } else {
-        // Content plugins are pure data: no module, no ABI, no capabilities.
+        // Declarative kinds (content, export): no module, no ABI, no imports.
         if m.module.is_some() || m.module_base64.is_some() {
-            return Err("a content plugin must not reference a module".to_string());
+            return Err(format!("a {:?} plugin must not reference a module", m.kind).to_lowercase());
         }
         if m.abi_version.is_some() {
-            return Err("a content plugin must not declare an abi_version".to_string());
+            return Err(
+                format!("a {:?} plugin must not declare an abi_version", m.kind).to_lowercase(),
+            );
         }
         if !m.imports.is_empty() {
-            return Err("a content plugin must not import capabilities".to_string());
+            return Err(
+                format!("a {:?} plugin must not import capabilities", m.kind).to_lowercase(),
+            );
         }
-        match &m.content {
-            Some(pack) => validate_pack(pack)?,
-            None => return Err("a content plugin must carry a content payload".to_string()),
+        // Content and export are the only declarative kinds.
+        if m.kind == PluginKind::Content {
+            match &m.content {
+                Some(pack) => validate_pack(pack)?,
+                None => return Err("a content plugin must carry a content payload".to_string()),
+            }
+            if m.export.is_some() {
+                return Err("a content plugin must not carry an export config".to_string());
+            }
+        } else {
+            match &m.export {
+                Some(cfg) => validate_export_config(cfg)?,
+                None => return Err("an export plugin must carry an export config".to_string()),
+            }
+            if m.content.is_some() {
+                return Err("an export plugin must not carry a content payload".to_string());
+            }
         }
     }
 
@@ -309,6 +367,25 @@ pub fn validate_manifest(m: &Manifest) -> Result<(), String> {
     Ok(())
 }
 
+/// Validate a declarative export config: a non-empty, length-capped
+/// destination (an `http(s)://` URL for the http sink), and at least one
+/// trigger event.
+fn validate_export_config(cfg: &ExportConfig) -> Result<(), String> {
+    if cfg.destination.trim().is_empty() {
+        return Err("export destination is empty".to_string());
+    }
+    check_string(&cfg.destination, "export destination")?;
+    if cfg.sink == ExportSink::Http
+        && !(cfg.destination.starts_with("http://") || cfg.destination.starts_with("https://"))
+    {
+        return Err("an http export destination must be an http(s):// URL".to_string());
+    }
+    if cfg.on.is_empty() {
+        return Err("an export plugin must subscribe to at least one event".to_string());
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -335,6 +412,7 @@ mod tests {
             abi_version: Some(SUPPORTED_ABI_VERSION),
             imports: vec!["detect:foreground-window".to_string()],
             detect: None,
+            export: None,
             content: None,
             signature: sig(),
         }
@@ -354,6 +432,7 @@ mod tests {
             abi_version: None,
             imports: vec![],
             detect: None,
+            export: None,
             content: Some(sample_pack()),
             signature: sig(),
         }
@@ -370,6 +449,112 @@ mod tests {
             },
             routines: vec![],
         }
+    }
+
+    fn export_manifest() -> Manifest {
+        Manifest {
+            manifest_version: MANIFEST_VERSION,
+            id: "com.example.export".to_string(),
+            name: "CSV export".to_string(),
+            version: "1.0.0".to_string(),
+            author: "Jane".to_string(),
+            description: String::new(),
+            kind: PluginKind::Export,
+            module: None,
+            module_base64: None,
+            abi_version: None,
+            imports: vec![],
+            detect: None,
+            export: Some(ExportConfig {
+                sink: ExportSink::Http,
+                format: ExportFormat::Json,
+                destination: "http://127.0.0.1:8080/entracte".to_string(),
+                on: vec![crate::hooks::HookEvent::BreakEnd],
+            }),
+            content: None,
+            signature: sig(),
+        }
+    }
+
+    #[test]
+    fn validate_accepts_a_well_formed_export_plugin() {
+        assert!(validate_manifest(&export_manifest()).is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_export_without_a_config() {
+        let mut m = export_manifest();
+        m.export = None;
+        assert!(validate_manifest(&m)
+            .unwrap_err()
+            .contains("must carry an export config"));
+    }
+
+    #[test]
+    fn validate_rejects_export_with_empty_or_non_http_destination() {
+        let mut m = export_manifest();
+        m.export.as_mut().unwrap().destination = "   ".to_string();
+        assert!(validate_manifest(&m)
+            .unwrap_err()
+            .contains("destination is empty"));
+
+        let mut m = export_manifest();
+        m.export.as_mut().unwrap().destination = "ftp://evil/x".to_string();
+        assert!(validate_manifest(&m)
+            .unwrap_err()
+            .contains("must be an http(s):// URL"));
+    }
+
+    #[test]
+    fn validate_rejects_export_with_no_events() {
+        let mut m = export_manifest();
+        m.export.as_mut().unwrap().on = vec![];
+        assert!(validate_manifest(&m)
+            .unwrap_err()
+            .contains("at least one event"));
+    }
+
+    #[test]
+    fn validate_rejects_export_carrying_module_or_content() {
+        let mut m = export_manifest();
+        m.module = Some("m.wasm".to_string());
+        assert!(validate_manifest(&m)
+            .unwrap_err()
+            .contains("must not reference a module"));
+
+        let mut m = export_manifest();
+        m.content = Some(sample_pack());
+        assert!(validate_manifest(&m)
+            .unwrap_err()
+            .contains("must not carry a content payload"));
+    }
+
+    #[test]
+    fn validate_rejects_export_config_on_a_content_plugin() {
+        let mut m = content_manifest();
+        m.export = export_manifest().export;
+        assert!(validate_manifest(&m)
+            .unwrap_err()
+            .contains("must not carry an export config"));
+    }
+
+    #[test]
+    fn validate_rejects_export_config_on_a_detector() {
+        let mut m = detector_manifest();
+        m.export = export_manifest().export;
+        assert!(validate_manifest(&m)
+            .unwrap_err()
+            .contains("a code-bearing plugin must not carry an export config"));
+    }
+
+    #[test]
+    fn validate_accepts_a_file_export_with_any_destination() {
+        let mut m = export_manifest();
+        let cfg = m.export.as_mut().unwrap();
+        cfg.sink = ExportSink::File;
+        cfg.format = ExportFormat::Csv;
+        cfg.destination = "/home/me/breaks.csv".to_string();
+        assert!(validate_manifest(&m).is_ok());
     }
 
     #[test]

--- a/src-tauri/src/plugins/mod.rs
+++ b/src-tauri/src/plugins/mod.rs
@@ -25,9 +25,9 @@ mod signature;
 
 pub use eval::any_detector_suppresses;
 
-pub use install::prepare_content_install;
 #[allow(unused_imports)]
-pub use install::{prepare_detector_install, PreparedDetector};
+pub use install::PreparedDetector;
+pub use install::{prepare_content_install, prepare_detector_install, prepare_export_install};
 pub use registry::{InstalledPlugin, PluginRegistry, PluginSummary};
 
 // The full manifest/signature API surface. Some items are consumed by the
@@ -37,8 +37,8 @@ pub use registry::{InstalledPlugin, PluginRegistry, PluginSummary};
 // its consumers.
 #[allow(unused_imports)]
 pub use manifest::{
-    parse_manifest, validate_manifest, Capability, DetectConfig, Manifest, PluginKind, Signature,
-    MANIFEST_VERSION, SUPPORTED_ABI_VERSION,
+    parse_manifest, validate_manifest, Capability, DetectConfig, ExportConfig, ExportFormat,
+    ExportSink, Manifest, PluginKind, Signature, MANIFEST_VERSION, SUPPORTED_ABI_VERSION,
 };
 #[allow(unused_imports)]
 pub use signature::{sha256, signing_payload, verify_signature};

--- a/src-tauri/src/plugins/registry.rs
+++ b/src-tauri/src/plugins/registry.rs
@@ -11,7 +11,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use super::manifest::{DetectConfig, Manifest, PluginKind};
+use super::manifest::{DetectConfig, ExportConfig, Manifest, PluginKind};
 use crate::scheduler::content_pack::AddedContent;
 
 /// One installed plugin: provenance + what it added to settings.
@@ -39,6 +39,10 @@ pub struct InstalledPlugin {
     /// sandbox context at eval time. `None` for non-detectors.
     #[serde(default)]
     pub detect: Option<DetectConfig>,
+    /// Export configuration (sink / format / destination / events) for an
+    /// export adapter, read by the delivery path. `None` for non-exports.
+    #[serde(default)]
+    pub export: Option<ExportConfig>,
 }
 
 impl InstalledPlugin {
@@ -55,6 +59,7 @@ impl InstalledPlugin {
             added,
             capabilities: Vec::new(),
             detect: None,
+            export: None,
         }
     }
 
@@ -72,6 +77,24 @@ impl InstalledPlugin {
             added: AddedContent::default(),
             capabilities: manifest.imports.clone(),
             detect: manifest.detect.clone(),
+            export: None,
+        }
+    }
+
+    /// Build a registry record for an installed export adapter: its export
+    /// config travels with it so the delivery path can render + deliver stats.
+    pub fn from_export(manifest: &Manifest) -> Self {
+        Self {
+            id: manifest.id.clone(),
+            name: manifest.name.clone(),
+            author: manifest.author.clone(),
+            version: manifest.version.clone(),
+            kind: manifest.kind,
+            public_key: manifest.signature.public_key.clone(),
+            added: AddedContent::default(),
+            capabilities: Vec::new(),
+            detect: None,
+            export: manifest.export.clone(),
         }
     }
 }
@@ -179,6 +202,7 @@ mod tests {
             },
             capabilities: Vec::new(),
             detect: None,
+            export: None,
         }
     }
 
@@ -196,6 +220,7 @@ mod tests {
             detect: Some(DetectConfig {
                 process_name: Some("zoom".to_string()),
             }),
+            export: None,
         }
     }
 

--- a/src-tauri/src/plugins/signature.rs
+++ b/src-tauri/src/plugins/signature.rs
@@ -111,6 +111,7 @@ mod tests {
             abi_version: Some(SUPPORTED_ABI_VERSION),
             imports: vec!["detect:foreground-window".to_string()],
             detect: None,
+            export: None,
             content: None,
             signature: Signature {
                 alg: "ed25519".to_string(),

--- a/src-tauri/src/scheduler/commands/plugins.rs
+++ b/src-tauri/src/scheduler/commands/plugins.rs
@@ -15,8 +15,8 @@ use serde::Serialize;
 use tauri::{AppHandle, Runtime, WebviewWindow};
 
 use crate::plugins::{
-    parse_manifest, prepare_content_install, prepare_detector_install, InstalledPlugin, Manifest,
-    PluginKind, PluginSummary, PreparedDetector,
+    parse_manifest, prepare_content_install, prepare_detector_install, prepare_export_install,
+    InstalledPlugin, Manifest, PluginKind, PluginSummary, PreparedDetector,
 };
 use crate::scheduler::content_pack::{
     merge_pack_tracked, remove_content, AddedContent, MergeSummary,
@@ -78,12 +78,13 @@ pub struct InstallOutcome {
 enum Prepared {
     Content(Manifest),
     Detector(PreparedDetector),
+    Export(Manifest),
 }
 
 impl Prepared {
     fn manifest(&self) -> &Manifest {
         match self {
-            Prepared::Content(m) => m,
+            Prepared::Content(m) | Prepared::Export(m) => m,
             Prepared::Detector(p) => &p.manifest,
         }
     }
@@ -111,7 +112,7 @@ pub async fn install_plugin<R: Runtime>(
         match parse_manifest(&text)?.kind {
             PluginKind::Content => Prepared::Content(prepare_content_install(&text, &registry)?),
             PluginKind::Detector => Prepared::Detector(prepare_detector_install(&text, &registry)?),
-            PluginKind::Export => return Err("export plugins aren't supported yet".to_string()),
+            PluginKind::Export => Prepared::Export(prepare_export_install(&text, &registry)?),
         }
     };
 
@@ -135,6 +136,7 @@ pub async fn install_plugin<R: Runtime>(
     match prepared {
         Prepared::Content(manifest) => Ok(apply_install(scheduler.inner(), &manifest).await),
         Prepared::Detector(prepared) => apply_detector_install(scheduler.inner(), &prepared).await,
+        Prepared::Export(manifest) => Ok(apply_export_install(scheduler.inner(), &manifest).await),
     }
 }
 
@@ -208,6 +210,24 @@ async fn apply_detector_install(
         hints_added: 0,
         routines_added: 0,
     })
+}
+
+/// Register a validated export adapter (declarative — no module, no content
+/// merge). The export config travels in the record for the delivery path.
+/// Split out so it's unit-testable without a `WebviewWindow`/dialog.
+async fn apply_export_install(scheduler: &Scheduler, manifest: &Manifest) -> InstallOutcome {
+    {
+        let mut registry = scheduler.plugins.lock().await;
+        registry.insert(InstalledPlugin::from_export(manifest));
+    }
+    persist_plugins(scheduler).await;
+    InstallOutcome {
+        id: manifest.id.clone(),
+        name: manifest.name.clone(),
+        kind: PluginKind::Export,
+        hints_added: 0,
+        routines_added: 0,
+    }
 }
 
 /// Uninstall the plugin `id`: remove exactly the content it added from the
@@ -358,7 +378,7 @@ fn format_install_summary(manifest: &Manifest) -> String {
                 "Adds up to {hints} idea(s) and {routines} routine(s) (duplicates are skipped).\n"
             ));
         }
-        PluginKind::Detector | PluginKind::Export => {
+        PluginKind::Detector => {
             s.push_str("This plugin runs sandboxed code and is granted ONLY these permissions:\n");
             if manifest.imports.is_empty() {
                 s.push_str("• (none)\n");
@@ -371,6 +391,21 @@ fn format_install_summary(manifest: &Manifest) -> String {
                     "• … and {} more\n",
                     manifest.imports.len() - DIALOG_MAX_CAPABILITIES_SHOWN
                 ));
+            }
+        }
+        PluginKind::Export => {
+            if let Some(cfg) = &manifest.export {
+                let where_to = match cfg.sink {
+                    crate::plugins::ExportSink::File => "write your break statistics to the file",
+                    crate::plugins::ExportSink::Http => "SEND your break statistics to",
+                };
+                s.push_str(&format!(
+                    "This plugin will {where_to}:\n• {}\n",
+                    sanitize_for_dialog(&cfg.destination, 200)
+                ));
+                if cfg.sink == crate::plugins::ExportSink::Http {
+                    s.push_str("⚠ This sends data OFF your machine to that address.\n");
+                }
             }
         }
     }
@@ -423,6 +458,7 @@ mod tests {
             abi_version: None,
             imports: vec![],
             detect: None,
+            export: None,
             content: Some(ContentPack {
                 version: CONTENT_PACK_VERSION,
                 name: "Stretch pack".to_string(),
@@ -467,6 +503,7 @@ mod tests {
             detect: Some(DetectConfig {
                 process_name: Some("zoom".to_string()),
             }),
+            export: None,
             content: None,
             signature: Signature {
                 alg: "ed25519".to_string(),
@@ -474,6 +511,73 @@ mod tests {
                 sig: String::new(),
             },
         }
+    }
+
+    fn export_manifest(id: &str) -> Manifest {
+        use crate::plugins::{ExportConfig, ExportFormat, ExportSink};
+        Manifest {
+            manifest_version: crate::plugins::MANIFEST_VERSION,
+            id: id.to_string(),
+            name: "JSON export".to_string(),
+            version: "1.0.0".to_string(),
+            author: "Jane".to_string(),
+            description: String::new(),
+            kind: PluginKind::Export,
+            module: None,
+            module_base64: None,
+            abi_version: None,
+            imports: vec![],
+            detect: None,
+            export: Some(ExportConfig {
+                sink: ExportSink::Http,
+                format: ExportFormat::Json,
+                destination: "http://127.0.0.1:8080/entracte".to_string(),
+                on: vec![crate::hooks::HookEvent::BreakEnd],
+            }),
+            content: None,
+            signature: Signature {
+                alg: "ed25519".to_string(),
+                public_key: "QUJDREVGR0hJSktMTU5PUA==".to_string(),
+                sig: String::new(),
+            },
+        }
+    }
+
+    #[tokio::test]
+    async fn apply_export_install_registers_and_uninstall_removes() {
+        let (_dir, sched) = test_scheduler(crate::scheduler::Settings::default());
+        let outcome = apply_export_install(&sched, &export_manifest("com.example.exp")).await;
+        assert_eq!(outcome.kind, PluginKind::Export);
+        {
+            let reg = sched.plugins.lock().await;
+            assert!(reg.contains("com.example.exp"));
+        }
+        // Uninstall: no module on disk, just the registry record.
+        uninstall_by_id(&sched, "com.example.exp").await.unwrap();
+        assert!(!sched.plugins.lock().await.contains("com.example.exp"));
+    }
+
+    #[test]
+    fn format_install_summary_shows_export_destination_and_egress_warning() {
+        let s = format_install_summary(&export_manifest("com.example.exp"));
+        assert!(s.contains("http://127.0.0.1:8080/entracte"));
+        assert!(s.contains("SEND your break statistics"));
+        assert!(s.contains("OFF your machine"));
+        let warn = s.find("Only click Install").unwrap();
+        let body = s.find("This plugin will").unwrap();
+        assert!(warn < body);
+    }
+
+    #[test]
+    fn format_install_summary_file_export_has_no_egress_warning() {
+        let mut m = export_manifest("com.example.exp");
+        let cfg = m.export.as_mut().unwrap();
+        cfg.sink = crate::plugins::ExportSink::File;
+        cfg.destination = "/home/me/breaks.csv".to_string();
+        let s = format_install_summary(&m);
+        assert!(s.contains("write your break statistics"));
+        assert!(s.contains("/home/me/breaks.csv"));
+        assert!(!s.contains("OFF your machine"));
     }
 
     #[tokio::test]
@@ -731,6 +835,7 @@ mod mock_app_tests {
             },
             capabilities: Vec::new(),
             detect: None,
+            export: None,
         }
     }
 
@@ -844,6 +949,7 @@ mod mock_app_tests {
             abi_version: None,
             imports: vec![],
             detect: None,
+            export: None,
             content: Some(ContentPack {
                 version: CONTENT_PACK_VERSION,
                 name: "Signed pack".to_string(),
@@ -891,13 +997,13 @@ mod mock_app_tests {
     }
 
     #[tokio::test]
-    async fn install_rejects_an_export_plugin_as_unsupported() {
+    async fn install_routes_to_the_export_path_and_surfaces_its_errors() {
         let (_dir, sched) = test_scheduler(crate::scheduler::Settings::default());
         let app = wrap_in_mock_app(sched);
         let dir = temp_dir();
         let path = dir.path().join("export.json");
-        // Minimal parseable export manifest — the kind is peeked and rejected
-        // before any validation, so it needn't be otherwise well-formed.
+        // A parseable export manifest with no export config: routing reaches
+        // the export installer, which rejects it before any dialog.
         std::fs::write(
             &path,
             r#"{"manifest_version":1,"id":"com.x.exp","name":"E","version":"1.0.0","kind":"export","signature":{"alg":"ed25519","public_key":"","sig":""}}"#,
@@ -911,7 +1017,7 @@ mod mock_app_tests {
         )
         .await
         .unwrap_err();
-        assert!(err.contains("export plugins aren't supported yet"));
+        assert!(err.contains("must carry an export config"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Slice 6a — **export adapters become installable.** They are **declarative**: no wasm, no plugin code runs (a refinement of design §4.3, which specced wasm modules — declarative is simpler and strictly safer). The manifest declares a sink/format/destination/events; the host will render its *own* break stats and deliver them. **Delivery on events (file write / HTTP POST) is slice 6b**, with its own egress security review.

- **manifest:** export is no longer code-bearing (only detectors run code). New `ExportConfig { sink: file|http, format: csv|json, destination, on: [HookEvent] }` (reuses the hook event vocabulary). `validate_manifest` splits the declarative branch into content vs export: an export carries a valid export config (non-empty destination — an `http(s)://` URL for the http sink — and ≥1 event), no module/imports/content; symmetric guards keep a detector/content plugin from carrying one.
- **install:** `prepare_export_install` (declarative, like content — signature over the manifest alone, export-only gate, not-already-installed). The install command routes `Export → apply_export_install` (register via `from_export`); uninstall is registry-only.
- **consent dialog:** an export adapter's prompt shows its **destination** and, for the http sink, an explicit *"this sends data OFF your machine"* warning. The destination is fixed in the signed manifest — the plugin can never redirect the data.
- **registry:** `InstalledPlugin` carries the export config (serde-defaulted) for the delivery path.

## Reviews (inline, per commitment)
- **Security:** declarative ⇒ zero code execution for exports; the destination is consent-fixed and shown in full; http egress is called out in the dialog; **nothing delivers yet** (6b adds it, reviewed separately).
- **Simplify / Critical:** the declarative branch is `if/else` (no `unreachable!` arm); export validation is one pure function.

## Test Plan
Export validation (accepts http+file; rejects no-config / empty / non-http destination / no-events / module / content; and an export config on a detector or content plugin); `prepare_export_install` (accepts signed, rejects mis-routed content + already-installed); `apply_export_install` register + uninstall; dialog shows destination + egress warning (file sink omits it). **Rust lib suite 1024 green;** clippy/fmt/cargo-doc clean. `manifest`/`install`/`registry` at 100% line coverage.

### codecov/patch note
Residual uncovered patch lines are the **unmockable `install_plugin` command wrapper + native dialog dispatch** (incl. the new export routing arm) — the documented admin-merge shim, same as #175.

Refs #156. Builds on #177. (6b: delivery on events + user docs.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)