### PR TITLE
feat(plugins): export adapter delivery on events (#156)

### DIFF
--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -2,7 +2,7 @@
 
 Entracte can be extended with **local-only plugins** — files you choose from disk that add capability without forking the app. There is no plugin store, no account, and no network: a plugin is a file you already have, and installing it never contacts a server. The design and roadmap live in [the plugin API design doc](developer/plugin-api-design.md) ([#156](https://github.com/drmowinckels/entracte/issues/156)).
 
-This release ships the first plugin kind: **content providers**.
+Three plugin kinds are installable: **content providers**, **local context detectors**, and **local export adapters**.
 
 ## Content providers
 
@@ -14,6 +14,24 @@ A content provider supplies break **ideas** and guided **routines**. Installing 
 
 Installed plugins are recorded in `plugins.json` in your app config directory, written with the same owner-only (`0o600`) atomic write as the rest of your Entracte data. The record is small provenance plus the list of what each plugin added — the merged content itself lives in your profile, as if you'd typed it.
 
+## Local context detectors
+
+A detector is a small **sandboxed WebAssembly module** that votes on whether to suppress the next break — an extra "don't interrupt me right now" signal beyond the built-in ones (DND, camera, video, app-pause). For example, a detector might suppress breaks while a particular focus app is running.
+
+- **Install:** the same Plugins panel. Because a detector runs code, its confirmation dialog lists the **exact permissions** it is granted — and _only_ those (e.g. "check whether a named process is running"). It can do nothing else.
+- **How it runs:** Entracte evaluates installed detectors a few seconds apart, off the main timer, inside a capability sandbox (no filesystem, no network, no ambient access; bounded memory, fuel, and time). The module never sees raw system data — it asks a granted host function a yes/no question and gets back only a boolean. If any detector votes to suppress, the next break is held, shown in the tray as "plugin".
+- **Fail-safe:** a detector that is broken, slow, or hostile simply doesn't suppress — it can never _force_ a break, lengthen one, or skip one. The worst an installed detector can do is hold your breaks; uninstalling it restores them.
+
+## Local export adapters
+
+An export adapter pushes your break **statistics** to a destination _you_ control — a local file, or an HTTP endpoint you run. It is **declarative**: it runs no code at all. The manifest names a sink (`file` or `http`), a format (`csv` or `json`), the events to deliver on, and a fixed destination. Entracte renders your own stats and delivers them.
+
+- **Install:** the confirmation dialog shows the destination in full. For an `http` adapter it adds an explicit warning that this **sends data off your machine** to that address — the only plugin capability that ever leaves the device.
+- **The destination is fixed at signing time.** Because it lives in the signed manifest and is shown in the dialog, the plugin can never redirect your data somewhere else. HTTP delivery uses a short timeout and **follows no redirects**, so a server can't bounce the data to another host.
+- **Delivery** happens on the events you'd expect (a break ending, a pause starting, …), off the main timer and best-effort: a slow or unreachable endpoint is logged and dropped, never retried, and never blocks Entracte.
+
+A detector or export module is stored beside `plugins.json` and removed on uninstall.
+
 ## Signing
 
 Every plugin is **signed** (ed25519). The signature covers the whole manifest, so a file that's been tampered with after signing fails to install. The install dialog shows a short fingerprint of the signing key so a returning user can recognise a familiar author — and notice if a plugin claiming to be from them is signed by a different key.
@@ -22,18 +40,18 @@ Signing proves **integrity and origin**, not safety. A valid signature means "th
 
 ## What plugins can and cannot do
 
-Content providers are **pure data** — a list of ideas and routines. They run no code, touch no files, and reach no network. Installing one can, at most, add break suggestions to your profile.
+- **Content providers** and **export adapters** are **pure data** — they run no code. A content provider can at most add break suggestions to your profile; an export adapter can at most deliver your own break stats to the one destination shown in its install dialog.
+- **Detectors** run code, but only inside a capability sandbox with **no ambient access**: no filesystem, no network, no environment — a detector can do **only** what a permission you explicitly granted allows, enforced by Entracte, and the only thing it can affect is whether a break is held.
 
-Two further plugin kinds are designed but **not yet installable** — they need a sandboxed runtime that a later release adds:
-
-- **Local context detectors** — extra break-suppression signals (e.g. "don't interrupt while a focus app is frontmost").
-- **Local export adapters** — push your break statistics to a destination you control (a local file, a self-hosted endpoint).
-
-When those land they will run inside a capability sandbox with no ambient access: a plugin will be able to do **only** what a permission you explicitly grant allows, enforced by Entracte, and never anything involving a cloud service or account. Until then, Entracte will refuse to install a detector or export plugin.
+No plugin of any kind involves a cloud service or an account. The only capability that sends data off your machine is an `http` export adapter, to the exact address you saw and approved at install.
 
 ## Threat model
 
 A content plugin is data the merge code validates against the same hard caps as a content pack (size, count, and string-length limits), so a malformed or hostile file can't bloat your settings or stall the app. It executes no code.
+
+A **detector**'s module runs in a WebAssembly sandbox with WASI off and bounded memory, fuel, and wall-clock time; host functions are registered _only_ for the capabilities you granted, so an import the manifest didn't declare fails to link. The module receives no system data directly — only booleans from host-run probes — and its only effect is a suppress/don't vote. A broken or hostile detector fails closed (no suppression).
+
+An **export adapter** runs no code; its only power is delivering your break stats to its fixed, signed destination. The payload is your own statistics (no credentials or secrets), size-capped; HTTP delivery is time-bounded and follows no redirects, so a hostile endpoint can neither stall Entracte nor redirect the data elsewhere. The worst a malicious export adapter you install can do is receive stats you agreed to send it.
 
 The trust boundary is the **install confirmation dialog**, exactly as with [hooks](HOOKS.md): installing is the moment you vouch for a file. Treat plugin files like any other file you'd run — only install ones from sources you trust, and read the dialog before clicking Install. The signing-key fingerprint is there to help you spot a substituted plugin.
 

--- a/src-tauri/src/plugins/registry.rs
+++ b/src-tauri/src/plugins/registry.rs
@@ -129,6 +129,17 @@ impl PluginRegistry {
         self.plugins.iter().map(PluginSummary::from).collect()
     }
 
+    /// The export configs of every installed export adapter subscribed to
+    /// `event`, for the delivery path. Install order.
+    pub fn export_configs_for(&self, event: crate::hooks::HookEvent) -> Vec<ExportConfig> {
+        self.plugins
+            .iter()
+            .filter(|p| p.kind == PluginKind::Export)
+            .filter_map(|p| p.export.clone())
+            .filter(|cfg| cfg.on.contains(&event))
+            .collect()
+    }
+
     /// What the off-tick eval task needs for each installed detector: id (to
     /// load its module), parsed granted capabilities (to rebuild the sandbox),
     /// and the process pattern. Capability strings that fail to parse are

--- a/src-tauri/src/scheduler/commands/breaks.rs
+++ b/src-tauri/src/scheduler/commands/breaks.rs
@@ -67,6 +67,7 @@ pub async fn pause_impl(scheduler: &Scheduler, duration_secs: Option<u64>) {
             HookEvent::PauseStart,
             HookContext::empty(),
         );
+        crate::scheduler::exports::deliver_on_event(scheduler, HookEvent::PauseStart);
     }
 }
 
@@ -89,6 +90,7 @@ pub async fn resume_impl(scheduler: &Scheduler) {
             HookEvent::PauseEnd,
             HookContext::empty(),
         );
+        crate::scheduler::exports::deliver_on_event(scheduler, HookEvent::PauseEnd);
     }
 }
 
@@ -186,6 +188,7 @@ pub async fn trigger_break_from_cli<R: Runtime>(
         HookEvent::BreakStart,
         HookContext::with_kind_duration(kind, duration_secs),
     );
+    crate::scheduler::exports::deliver_on_event(scheduler, HookEvent::BreakStart);
 }
 
 /// Renderer hook to fire a break immediately — used by the "Test now"
@@ -255,6 +258,7 @@ pub async fn end_break<R: Runtime>(
                 HookEvent::BreakEnd,
                 HookContext::with_kind_outcome(kind, reason.clone()),
             );
+            crate::scheduler::exports::deliver_on_event(scheduler.inner(), HookEvent::BreakEnd);
         }
     }
 
@@ -367,6 +371,7 @@ pub async fn postpone_break_impl(
         minutes: minutes_logged.max(1),
     });
     hooks::run_hooks(&s, HookEvent::BreakPostponed, HookContext::with_kind(kind));
+    crate::scheduler::exports::deliver_on_event(scheduler, HookEvent::BreakPostponed);
     {
         let mut t = scheduler.timers.lock().await;
         t.active_break = None;
@@ -444,6 +449,7 @@ pub async fn skip_next_break_impl(scheduler: &Scheduler, kind: BreakKind) -> Res
         source: SkipSource::User,
     });
     hooks::run_hooks(&s, HookEvent::BreakSkipped, HookContext::with_kind(kind));
+    crate::scheduler::exports::deliver_on_event(scheduler, HookEvent::BreakSkipped);
     Ok(())
 }
 
@@ -581,6 +587,7 @@ pub async fn resume_last_break_impl<R: Runtime>(
         HookEvent::BreakStart,
         HookContext::with_kind_duration(kind, duration_secs),
     );
+    crate::scheduler::exports::deliver_on_event(scheduler, HookEvent::BreakStart);
     {
         let mut t = scheduler.timers.lock().await;
         let now = Instant::now();

--- a/src-tauri/src/scheduler/exports.rs
+++ b/src-tauri/src/scheduler/exports.rs
@@ -1,0 +1,288 @@
+//! Declarative export-adapter delivery (#156, slice 6b).
+//!
+//! On a scheduler event, every installed export adapter subscribed to it has
+//! the host render its *own* break stats (CSV/JSON) and deliver them to the
+//! adapter's consent-fixed destination: a local file, or an HTTP POST — the
+//! only path in the app that sends data off the machine. The plugin runs no
+//! code and cannot influence the destination (fixed in the signed manifest,
+//! shown in full in the consent dialog).
+//!
+//! Delivery is fire-and-forget on a spawned task so it never blocks the
+//! scheduler tick, and bounded (payload cap + HTTP timeout + no redirects) so
+//! a slow or hostile endpoint can't stall or redirect it. Any failure is
+//! logged, never surfaced — a broken sink must not break breaks.
+
+use std::time::Duration;
+
+use crate::hooks::HookEvent;
+use crate::plugins::{ExportConfig, ExportFormat, ExportSink};
+use crate::stats::{self, LoggedEvent};
+
+use super::Scheduler;
+
+/// Hard cap on a rendered payload. Generous for a break-stats log; bounds the
+/// write/POST so an ever-growing event history can't produce an unbounded
+/// request.
+const MAX_EXPORT_BYTES: usize = 5 * 1024 * 1024;
+
+/// Timeout for the whole HTTP delivery, so a hung endpoint can't pin the task.
+const HTTP_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Render the logged events in the requested format. Pure.
+fn render_stats(events: &[LoggedEvent], format: ExportFormat) -> String {
+    match format {
+        ExportFormat::Csv => stats::export_csv(events),
+        ExportFormat::Json => serde_json::to_string(events).unwrap_or_else(|_| "[]".to_string()),
+    }
+}
+
+/// Deliver one rendered payload to its configured sink. Over-cap payloads are
+/// dropped; all failures are logged, never propagated.
+async fn deliver_one(cfg: &ExportConfig, payload: String) {
+    if payload.len() > MAX_EXPORT_BYTES {
+        log::warn!(
+            "export: skipping delivery to {} — payload {} bytes exceeds the {MAX_EXPORT_BYTES}-byte cap",
+            cfg.destination,
+            payload.len()
+        );
+        return;
+    }
+    match cfg.sink {
+        ExportSink::File => {
+            if let Err(e) = std::fs::write(&cfg.destination, payload.as_bytes()) {
+                log::warn!("export: write to {} failed: {e}", cfg.destination);
+            }
+        }
+        ExportSink::Http => post(cfg, payload).await,
+    }
+}
+
+/// POST `payload` to the adapter's URL. A fresh client per call with a hard
+/// timeout and **redirects disabled** — a redirect could bounce the data to a
+/// different host than the one the user consented to.
+async fn post(cfg: &ExportConfig, payload: String) {
+    let content_type = match cfg.format {
+        ExportFormat::Csv => "text/csv",
+        ExportFormat::Json => "application/json",
+    };
+    let client = match reqwest::Client::builder()
+        .timeout(HTTP_TIMEOUT)
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            log::warn!("export: HTTP client build failed: {e}");
+            return;
+        }
+    };
+    if let Err(e) = client
+        .post(&cfg.destination)
+        .header(reqwest::header::CONTENT_TYPE, content_type)
+        .body(payload)
+        .send()
+        .await
+    {
+        log::warn!("export: POST to {} failed: {e}", cfg.destination);
+    }
+}
+
+/// Fire-and-forget: deliver the current break stats to every export adapter
+/// subscribed to `event`. Snapshots the configs under the registry lock, then
+/// renders + delivers off the lock on a spawned task. No subscribers → no
+/// work (and no file read).
+pub fn deliver_on_event(scheduler: &Scheduler, event: HookEvent) {
+    let registry = scheduler.plugins.clone();
+    let events_path = scheduler.events_path.clone();
+    tauri::async_runtime::spawn(run_delivery(registry, events_path, event));
+}
+
+/// The delivery body, split from the spawn wrapper so it's directly awaitable
+/// in tests. Snapshots subscribers under the lock, then renders + delivers off
+/// it.
+async fn run_delivery(
+    registry: std::sync::Arc<tokio::sync::Mutex<crate::plugins::PluginRegistry>>,
+    events_path: std::path::PathBuf,
+    event: HookEvent,
+) {
+    let configs = { registry.lock().await.export_configs_for(event) };
+    if configs.is_empty() {
+        return;
+    }
+    let events = stats::read_all(&events_path);
+    for cfg in configs {
+        let payload = render_stats(&events, cfg.format);
+        deliver_one(&cfg, payload).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::stats::{EventPayload, LoggedEvent};
+    use std::io::{Read, Write};
+
+    fn sample_events() -> Vec<LoggedEvent> {
+        vec![LoggedEvent {
+            t: "2026-06-10T00:00:00Z"
+                .parse::<chrono::DateTime<chrono::Utc>>()
+                .unwrap(),
+            event: EventPayload::BreakResumed {
+                kind: crate::scheduler::BreakKind::Micro,
+            },
+        }]
+    }
+
+    #[test]
+    fn render_stats_csv_and_json_differ_and_carry_the_event() {
+        let events = sample_events();
+        let csv = render_stats(&events, ExportFormat::Csv);
+        let json = render_stats(&events, ExportFormat::Json);
+        assert!(csv.contains("break_resumed") || csv.contains("micro"));
+        assert!(json.starts_with('[') && json.contains("break_resumed"));
+        assert_ne!(csv, json);
+    }
+
+    #[tokio::test]
+    async fn file_sink_writes_the_payload() {
+        let dir = crate::test_support::temp_dir();
+        let dest = dir.path().join("breaks.json");
+        let cfg = ExportConfig {
+            sink: ExportSink::File,
+            format: ExportFormat::Json,
+            destination: dest.display().to_string(),
+            on: vec![HookEvent::BreakEnd],
+        };
+        deliver_one(&cfg, "[{\"x\":1}]".to_string()).await;
+        assert_eq!(std::fs::read_to_string(&dest).unwrap(), "[{\"x\":1}]");
+    }
+
+    #[tokio::test]
+    async fn oversized_payload_is_dropped_not_written() {
+        let dir = crate::test_support::temp_dir();
+        let dest = dir.path().join("breaks.csv");
+        let cfg = ExportConfig {
+            sink: ExportSink::File,
+            format: ExportFormat::Csv,
+            destination: dest.display().to_string(),
+            on: vec![HookEvent::BreakEnd],
+        };
+        deliver_one(&cfg, "x".repeat(MAX_EXPORT_BYTES + 1)).await;
+        assert!(!dest.exists(), "over-cap payload must not be written");
+    }
+
+    #[tokio::test]
+    async fn file_sink_write_failure_is_logged_not_panicked() {
+        // Destination is a directory → write fails; must not panic.
+        let dir = crate::test_support::temp_dir();
+        let cfg = ExportConfig {
+            sink: ExportSink::File,
+            format: ExportFormat::Json,
+            destination: dir.path().display().to_string(),
+            on: vec![HookEvent::BreakEnd],
+        };
+        deliver_one(&cfg, "[]".to_string()).await;
+    }
+
+    #[tokio::test]
+    async fn http_post_failure_is_logged_not_panicked() {
+        // Port 1 on loopback refuses/!listens → send() errors; must not panic.
+        let cfg = ExportConfig {
+            sink: ExportSink::Http,
+            format: ExportFormat::Csv,
+            destination: "http://127.0.0.1:1/ingest".to_string(),
+            on: vec![HookEvent::BreakEnd],
+        };
+        post(&cfg, "ts\n".to_string()).await;
+    }
+
+    #[tokio::test]
+    async fn run_delivery_renders_and_delivers_to_subscribers_only() {
+        use crate::plugins::{InstalledPlugin, Manifest, PluginKind, Signature, MANIFEST_VERSION};
+        use std::sync::Arc;
+        use tokio::sync::Mutex;
+
+        let dir = crate::test_support::temp_dir();
+        let events = dir.path().join("events.jsonl");
+        std::fs::write(
+            &events,
+            b"{\"t\":\"2026-06-10T00:00:00Z\",\"type\":\"break_resumed\",\"kind\":\"micro\"}\n",
+        )
+        .unwrap();
+        let dest = dir.path().join("out.json");
+
+        let manifest = Manifest {
+            manifest_version: MANIFEST_VERSION,
+            id: "com.x.exp".to_string(),
+            name: "E".to_string(),
+            version: "1.0.0".to_string(),
+            author: String::new(),
+            description: String::new(),
+            kind: PluginKind::Export,
+            module: None,
+            module_base64: None,
+            abi_version: None,
+            imports: vec![],
+            detect: None,
+            export: Some(ExportConfig {
+                sink: ExportSink::File,
+                format: ExportFormat::Json,
+                destination: dest.display().to_string(),
+                on: vec![HookEvent::BreakEnd],
+            }),
+            content: None,
+            signature: Signature {
+                alg: "ed25519".to_string(),
+                public_key: String::new(),
+                sig: String::new(),
+            },
+        };
+        let mut reg = crate::plugins::PluginRegistry::default();
+        reg.insert(InstalledPlugin::from_export(&manifest));
+        let reg = Arc::new(Mutex::new(reg));
+
+        // A non-subscribed event delivers nothing.
+        run_delivery(reg.clone(), events.clone(), HookEvent::PauseStart).await;
+        assert!(!dest.exists());
+
+        // The subscribed event renders the stats to the file.
+        run_delivery(reg, events, HookEvent::BreakEnd).await;
+        let written = std::fs::read_to_string(&dest).unwrap();
+        assert!(written.contains("break_resumed"));
+    }
+
+    #[tokio::test]
+    async fn http_sink_posts_the_payload_to_the_destination() {
+        // A one-shot raw HTTP listener: accept one connection, read the
+        // request, reply 200. Proves the POST reaches the consented address
+        // with the body.
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let handle = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut buf = [0u8; 2048];
+            let n = stream.read(&mut buf).unwrap();
+            let req = String::from_utf8_lossy(&buf[..n]).to_string();
+            stream
+                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n")
+                .unwrap();
+            req
+        });
+
+        let cfg = ExportConfig {
+            sink: ExportSink::Http,
+            format: ExportFormat::Json,
+            destination: format!("http://{addr}/ingest"),
+            on: vec![HookEvent::BreakEnd],
+        };
+        // Route through `deliver_one` so its Http arm is exercised too.
+        deliver_one(&cfg, "[{\"break\":1}]".to_string()).await;
+
+        let req = handle.join().unwrap();
+        assert!(req.starts_with("POST /ingest "), "got: {req}");
+        assert!(req.contains("[{\"break\":1}]"), "body delivered: {req}");
+        assert!(req
+            .to_lowercase()
+            .contains("content-type: application/json"));
+    }
+}

--- a/src-tauri/src/scheduler/mod.rs
+++ b/src-tauri/src/scheduler/mod.rs
@@ -1,6 +1,7 @@
 mod break_stats;
 mod commands;
 pub(crate) mod content_pack;
+mod exports;
 mod hotkeys;
 mod overlay;
 mod pause;

--- a/src-tauri/src/scheduler/run_loop.rs
+++ b/src-tauri/src/scheduler/run_loop.rs
@@ -243,6 +243,7 @@ pub(super) async fn run_loop(app: AppHandle, sched: Scheduler) {
                     HookEvent::BreakStart,
                     HookContext::with_kind_duration(BreakKind::Sleep, s.bedtime_duration_secs),
                 );
+                super::exports::deliver_on_event(&sched, HookEvent::BreakStart);
                 sched.logger.log(EventPayload::BreakStart {
                     kind: BreakKind::Sleep,
                     duration_secs: s.bedtime_duration_secs,
@@ -558,6 +559,7 @@ async fn deliver_scheduled_break<R: Runtime>(
         HookEvent::BreakStart,
         HookContext::with_kind_duration(kind, duration_secs),
     );
+    super::exports::deliver_on_event(sched, HookEvent::BreakStart);
     sched.logger.log(EventPayload::BreakStart {
         kind,
         duration_secs,


### PR DESCRIPTION
## Summary

Slice 6b — the **delivery half** of export adapters, completing slice 6 and the plugin epic. On a scheduler event, every installed export adapter subscribed to it has the host render its **own** break stats and deliver them to the adapter's consent-fixed destination. This is the only path in the app that sends data **off the machine**.

- **`scheduler::exports`:** `render_stats` (CSV via `stats::export_csv`, JSON via serde) + `deliver_one` (file write, or HTTP POST). `deliver_on_event` spawns `run_delivery`: snapshot subscribers under the registry lock, then render + deliver off the lock. Fire-and-forget — never blocks the tick.
- **Bounded egress:** destination fixed in the signed manifest (the plugin can't redirect), a 5 MiB payload cap, a 10 s HTTP timeout, and **redirects disabled** (no bouncing the data to another host). Every failure is logged, never propagated — a broken sink must not break breaks.
- **`registry::export_configs_for(event)`** returns the subscribed adapters' configs. Delivery is wired at all **nine** `run_hooks` sites (the existing event vocabulary): break start/end/postponed/skipped, pause start/end.
- **docs/PLUGINS.md:** documents detectors *and* export adapters as installable (backfilling slice 5's doc gap), the sandbox/egress boundaries, and a per-kind threat model.

## Reviews (inline; dedicated egress security pass)
- **Security:** destination consent-fixed + shown in the dialog; **no redirects**; timeout + size cap; payload is the user's own stats (no secrets); off-tick fire-and-forget; fails closed.
- **Critical:** snapshot-under-lock then deliver off-lock; no-subscribers skips the file read.
- **Simplify / altitude:** clean render/deliver split; the nine adjacent `deliver_on_event` calls are a deliberate low-risk choice over refactoring the hook dispatch into a shared `fire_event` (possible follow-up).

## Test Plan
Render CSV/JSON; file write (+ over-cap dropped, + write-failure logged not panicked); **HTTP POST to a one-shot local listener** (asserts method + path + body + content-type); POST-failure logged; `run_delivery` delivers to subscribers only (non-subscribed event is a no-op). **Rust lib suite 1031 green;** clippy/fmt/cargo-doc/cspell clean. `exports` + `registry` at 100% line coverage bar 4 defensive lines.

### codecov/patch note
The residual uncovered lines are a `log::warn!` argument (elided when logging is disabled in tests) and the unreachable `reqwest::Client::builder().build()` error arm (can't fail with static rustls options) — documented admin-merge shim.

Refs #156. Builds on #178. **Completes slice 6 — and the local plugin API epic.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)