### PR TITLE
feat(plugins): plugin sound cues for routines (#156)

### DIFF
--- a/docs/developer/plugin-authoring.md
+++ b/docs/developer/plugin-authoring.md
@@ -202,6 +202,27 @@ Phase durations (`inhale`, `hold`, `exhale`, `hold_out`) are **absolute seconds*
 
 `inhale` and `exhale` must be at least 1; `hold` and `hold_out` default to 0; no phase may exceed 3600 seconds. `cycles` optionally caps the guided portion — after that many cycles, `then` decides what happens: `"loop"` (the default) keeps cycling, `"rest"` settles into a held still state for the remainder. Users with reduced-motion enabled get the phase labels without the ring animation.
 
+### Sounds
+
+A routine can play short sound cues — a tone on the breath in and out so a user can follow with their eyes closed, or a chime between yoga poses. Sounds are **audio assets**: they ride in the same top-level `assets` array as images, just with an audio file in `data_base64` (the format is sniffed from the bytes and must be **OGG, WAV, or MP3**). A sound asset is capped tighter than an image — **256 KiB** — because a cue is a short sound, not a track.
+
+Reference a sound two ways. A routine step's `sound` plays when that step begins:
+
+```json
+{ "text": "Seated twist", "seconds": 30, "sound": "next-pose" }
+```
+
+And a breathing pattern's `sounds` give a cue per phase (any phase may be silent):
+
+```json
+"breath": {
+  "inhale": 4, "exhale": 6,
+  "sounds": { "inhale": "breathe-in", "exhale": "breathe-out" }
+}
+```
+
+A `sound` / `breath.sounds.*` value must name an **audio** asset (and a step's `asset` must name an **image** one) — mixing them is rejected. Cues always play through the user's overall sound volume, and the user can silence all plugin cues with the **Play plugin sound cues** switch in Settings → Breaks. Sounds, like images, are removed from disk when the plugin is uninstalled.
+
 Merging is additive and idempotent.
 An idea that already exists word-for-word is skipped, and a routine whose `id` collides with one already installed is skipped too, so installing your pack can never clobber what a user typed themselves.
 
@@ -408,23 +429,25 @@ Uninstalling from the same panel removes the record, the module, and — for a c
 These are the caps the validator enforces.
 They are generous for anything hand-authored and exist so a malformed or hostile file can't bloat state or stall the app.
 
-| Limit                            | Value                    |
-| -------------------------------- | ------------------------ |
-| Manifest file size               | 8 MiB                    |
-| Embedded module size             | 16 MiB                   |
-| Image assets per pack            | 64                       |
-| Image asset size (decoded)       | 512 KiB                  |
-| Image asset dimensions           | 4,000,000 px (w × h)     |
-| Image asset formats              | PNG, GIF, WebP           |
-| Any string                       | 1000 characters          |
-| Plugin `id`                      | 128 characters           |
-| Capability imports               | 16                       |
-| Capability scope (path / origin) | 512 characters           |
-| Detector memory                  | 64 pages (4 MiB)         |
-| Detector wall-clock per call     | 250 ms                   |
-| Detector fuel                    | 500 million instructions |
-| Export payload                   | 5 MiB                    |
-| Export HTTP timeout              | 10 seconds               |
+| Limit                             | Value                    |
+| --------------------------------- | ------------------------ |
+| Manifest file size                | 8 MiB                    |
+| Embedded module size              | 16 MiB                   |
+| Assets per pack (images + sounds) | 64                       |
+| Image asset size (decoded)        | 512 KiB                  |
+| Image asset dimensions            | 4,000,000 px (w × h)     |
+| Image asset formats               | PNG, GIF, WebP           |
+| Sound asset size (decoded)        | 256 KiB                  |
+| Sound asset formats               | OGG, WAV, MP3            |
+| Any string                        | 1000 characters          |
+| Plugin `id`                       | 128 characters           |
+| Capability imports                | 16                       |
+| Capability scope (path / origin)  | 512 characters           |
+| Detector memory                   | 64 pages (4 MiB)         |
+| Detector wall-clock per call      | 250 ms                   |
+| Detector fuel                     | 500 million instructions |
+| Export payload                    | 5 MiB                    |
+| Export HTTP timeout               | 10 seconds               |
 
 ## What's still rough
 

--- a/scripts/audit-a11y-settings-fixture.json
+++ b/scripts/audit-a11y-settings-fixture.json
@@ -92,5 +92,6 @@
   "micro_break_mode": "overlay",
   "long_break_mode": "overlay",
   "routine_fill": false,
+  "allow_plugin_sounds": true,
   "custom_css": ""
 }

--- a/src-tauri/src/plugins/asset.rs
+++ b/src-tauri/src/plugins/asset.rs
@@ -30,6 +30,9 @@ pub const MAX_ASSET_BYTES: usize = 512 * 1024;
 /// compressed file can claim enormous dimensions, so we reject on the declared
 /// header size before anything decodes it.
 pub const MAX_IMAGE_PIXELS: u64 = 4_000_000;
+/// Tighter byte cap for audio cues. A cue is a short sound, not a track; the
+/// size bounds the playback length without parsing every container's duration.
+pub const MAX_SOUND_BYTES: usize = 256 * 1024;
 const MAX_ASSET_ID_LEN: usize = 128;
 
 /// One inline image declared in a manifest. `data_base64` is excluded from the
@@ -69,6 +72,48 @@ impl ImageFormat {
     }
 }
 
+/// The audio formats a plugin may ship for break/routine cues. Detected by
+/// container magic bytes; the byte cap bounds their length.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AudioFormat {
+    Ogg,
+    Wav,
+    Mp3,
+}
+
+impl AudioFormat {
+    pub fn ext(self) -> &'static str {
+        match self {
+            AudioFormat::Ogg => "ogg",
+            AudioFormat::Wav => "wav",
+            AudioFormat::Mp3 => "mp3",
+        }
+    }
+}
+
+/// What a validated asset turned out to be. Routine images reference an
+/// `Image`; sound cues reference an `Audio`. The kind lets the manifest check
+/// that each reference points at the right sort of asset.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AssetKind {
+    Image(ImageFormat),
+    Audio(AudioFormat),
+}
+
+impl AssetKind {
+    /// File extension for the on-disk sidecar.
+    pub fn ext(self) -> &'static str {
+        match self {
+            AssetKind::Image(f) => f.ext(),
+            AssetKind::Audio(f) => f.ext(),
+        }
+    }
+
+    pub fn is_audio(self) -> bool {
+        matches!(self, AssetKind::Audio(_))
+    }
+}
+
 fn u16le(b: &[u8]) -> u64 {
     b[0] as u64 | (b[1] as u64) << 8
 }
@@ -105,6 +150,27 @@ pub fn sniff(bytes: &[u8]) -> Option<(ImageFormat, u64, u64)> {
 
 fn u32be(b: &[u8]) -> u64 {
     (b[0] as u64) << 24 | (b[1] as u64) << 16 | (b[2] as u64) << 8 | b[3] as u64
+}
+
+/// Identify an audio container from its magic bytes. WAV shares the `RIFF`
+/// header with WebP — the `WAVE` form type at 8..12 disambiguates.
+pub fn sniff_audio(bytes: &[u8]) -> Option<AudioFormat> {
+    if bytes.starts_with(b"OggS") {
+        return Some(AudioFormat::Ogg);
+    }
+    if bytes.starts_with(b"RIFF") && bytes.get(8..12) == Some(b"WAVE") {
+        return Some(AudioFormat::Wav);
+    }
+    // MP3: an ID3v2 tag, or a bare MPEG frame sync (11 set bits: FF Ex/Fx).
+    if bytes.starts_with(b"ID3") {
+        return Some(AudioFormat::Mp3);
+    }
+    if let Some(&[b0, b1]) = bytes.get(0..2).and_then(|s| <&[u8; 2]>::try_from(s).ok()) {
+        if b0 == 0xff && (b1 & 0xe0) == 0xe0 {
+            return Some(AudioFormat::Mp3);
+        }
+    }
+    None
 }
 
 /// Dimensions from the three WebP chunk layouts (extended, lossless, lossy).
@@ -152,7 +218,7 @@ fn is_safe_asset_id(id: &str) -> bool {
 /// and sniffed format on success. Checks, first-error-wins: a filename-safe id,
 /// a 64-char lowercase-hex sha256, valid base64, the decoded-byte cap, that the
 /// bytes hash to the declared sha256, an allowed format, and the pixel cap.
-pub fn validate_asset(asset: &ManifestAsset) -> Result<(Vec<u8>, ImageFormat), String> {
+pub fn validate_asset(asset: &ManifestAsset) -> Result<(Vec<u8>, AssetKind), String> {
     if !is_safe_asset_id(&asset.id) {
         return Err(format!(
             "asset id '{}' must be 1..={MAX_ASSET_ID_LEN} chars of [a-z0-9._-]",
@@ -190,19 +256,29 @@ pub fn validate_asset(asset: &ManifestAsset) -> Result<(Vec<u8>, ImageFormat), S
             asset.id
         ));
     }
-    let (format, w, h) = sniff(&bytes).ok_or_else(|| {
-        format!(
-            "asset '{}' is not a supported image (png, gif, webp)",
-            asset.id
-        )
-    })?;
-    if w == 0 || h == 0 || w.saturating_mul(h) > MAX_IMAGE_PIXELS {
-        return Err(format!(
-            "asset '{}' is {w}x{h}, over the {MAX_IMAGE_PIXELS}-pixel cap",
-            asset.id
-        ));
+    if let Some((format, w, h)) = sniff(&bytes) {
+        if w == 0 || h == 0 || w.saturating_mul(h) > MAX_IMAGE_PIXELS {
+            return Err(format!(
+                "asset '{}' is {w}x{h}, over the {MAX_IMAGE_PIXELS}-pixel cap",
+                asset.id
+            ));
+        }
+        return Ok((bytes, AssetKind::Image(format)));
     }
-    Ok((bytes, format))
+    if let Some(format) = sniff_audio(&bytes) {
+        if bytes.len() > MAX_SOUND_BYTES {
+            return Err(format!(
+                "sound '{}' is {} bytes, over the {MAX_SOUND_BYTES}-byte cap",
+                asset.id,
+                bytes.len()
+            ));
+        }
+        return Ok((bytes, AssetKind::Audio(format)));
+    }
+    Err(format!(
+        "asset '{}' is not a supported image (png/gif/webp) or sound (ogg/wav/mp3)",
+        asset.id
+    ))
 }
 
 fn hex_lower(bytes: &[u8]) -> String {
@@ -309,6 +385,62 @@ mod tests {
         assert_eq!(ImageFormat::Webp.ext(), "webp");
     }
 
+    fn ogg() -> Vec<u8> {
+        let mut v = b"OggS".to_vec();
+        v.extend_from_slice(&[0u8; 60]);
+        v
+    }
+
+    fn wav() -> Vec<u8> {
+        let mut v = b"RIFF".to_vec();
+        v.extend_from_slice(&[0, 0, 0, 0]);
+        v.extend_from_slice(b"WAVE");
+        v.extend_from_slice(&[0u8; 40]);
+        v
+    }
+
+    #[test]
+    fn sniffs_audio_containers() {
+        assert_eq!(sniff_audio(&ogg()), Some(AudioFormat::Ogg));
+        assert_eq!(sniff_audio(&wav()), Some(AudioFormat::Wav));
+        assert_eq!(
+            sniff_audio(&[0xff, 0xfb, 0x90, 0x00]),
+            Some(AudioFormat::Mp3)
+        );
+        assert_eq!(sniff_audio(b"ID3\x04\x00"), Some(AudioFormat::Mp3));
+        assert_eq!(sniff_audio(b"not audio"), None);
+        // Too short to hold an MPEG frame sync.
+        assert_eq!(sniff_audio(&[0xff]), None);
+        // WebP's RIFF header must not be mistaken for WAV.
+        assert_eq!(sniff_audio(&webp_vp8x(10, 10)), None);
+    }
+
+    #[test]
+    fn validates_an_audio_asset_as_audio() {
+        let (_, kind) = validate_asset(&signed("cue.ogg", &ogg())).unwrap();
+        assert_eq!(kind, AssetKind::Audio(AudioFormat::Ogg));
+        assert!(kind.is_audio());
+        assert_eq!(kind.ext(), "ogg");
+    }
+
+    #[test]
+    fn rejects_an_oversize_sound() {
+        // Valid Ogg header padded past the sound cap (but under the image cap,
+        // so it reaches the audio-specific check).
+        let mut big = b"OggS".to_vec();
+        big.resize(MAX_SOUND_BYTES + 1, 0);
+        assert!(validate_asset(&signed("cue.ogg", &big))
+            .unwrap_err()
+            .contains("over the"));
+    }
+
+    #[test]
+    fn audio_format_extensions() {
+        assert_eq!(AudioFormat::Ogg.ext(), "ogg");
+        assert_eq!(AudioFormat::Wav.ext(), "wav");
+        assert_eq!(AudioFormat::Mp3.ext(), "mp3");
+    }
+
     #[test]
     fn sniff_rejects_unknown_and_truncated() {
         assert_eq!(sniff(b"not an image"), None);
@@ -321,8 +453,8 @@ mod tests {
 
     #[test]
     fn validates_a_well_formed_asset() {
-        let (bytes, fmt) = validate_asset(&signed("twist.png", &png(100, 50))).unwrap();
-        assert_eq!(fmt, ImageFormat::Png);
+        let (bytes, kind) = validate_asset(&signed("twist.png", &png(100, 50))).unwrap();
+        assert_eq!(kind, AssetKind::Image(ImageFormat::Png));
         assert_eq!(sniff(&bytes).unwrap().0, ImageFormat::Png);
     }
 

--- a/src-tauri/src/plugins/manifest.rs
+++ b/src-tauri/src/plugins/manifest.rs
@@ -11,7 +11,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use super::asset::{validate_asset, ManifestAsset, MAX_ASSETS};
+use super::asset::{validate_asset, AssetKind, ManifestAsset, MAX_ASSETS};
 use crate::scheduler::content_pack::{validate_pack, ContentPack};
 
 /// Manifest schema version this build reads and writes. Bumped only on a
@@ -378,34 +378,57 @@ pub fn validate_manifest(m: &Manifest) -> Result<(), String> {
     Ok(())
 }
 
-/// Validate a manifest's image assets and the routine references to them.
-/// Only content plugins may carry assets; each must be a sound, in-cap image
-/// (see [`validate_asset`]) with a unique id, and every routine `step.asset`
-/// must resolve to one of them. First-error-wins, like the rest of the file.
+/// Validate a manifest's assets and the routine references to them. Only
+/// content plugins may carry assets; each must be a sound, in-cap image or
+/// audio file (see [`validate_asset`]) with a unique id. Every `step.asset`
+/// must resolve to an *image* asset, and every `step.sound` / breath phase cue
+/// to an *audio* asset. First-error-wins, like the rest of the file.
 fn validate_assets(m: &Manifest) -> Result<(), String> {
     if !m.assets.is_empty() && m.kind != PluginKind::Content {
-        return Err(format!("a {:?} plugin must not carry image assets", m.kind).to_lowercase());
+        return Err(format!("a {:?} plugin must not carry assets", m.kind).to_lowercase());
     }
     if m.assets.len() > MAX_ASSETS {
         return Err(format!("plugin carries more than {MAX_ASSETS} assets"));
     }
-    let mut ids = std::collections::HashSet::new();
+    let mut kinds: std::collections::HashMap<&str, AssetKind> = std::collections::HashMap::new();
     for asset in &m.assets {
-        validate_asset(asset)?;
-        if !ids.insert(asset.id.as_str()) {
+        let (_, kind) = validate_asset(asset)?;
+        if kinds.insert(asset.id.as_str(), kind).is_some() {
             return Err(format!("duplicate asset id '{}'", asset.id));
         }
     }
+    let resolve = |id: &str, want_audio: bool, rid: &str| -> Result<(), String> {
+        match kinds.get(id) {
+            None => Err(format!("routine '{rid}' references unknown asset '{id}'")),
+            Some(kind) if kind.is_audio() != want_audio => Err(format!(
+                "routine '{rid}' references '{id}' as {} but it is {}",
+                if want_audio { "a sound" } else { "an image" },
+                if kind.is_audio() { "audio" } else { "an image" }
+            )),
+            Some(_) => Ok(()),
+        }
+    };
     if let Some(pack) = &m.content {
         for r in &pack.routines {
             for st in &r.steps {
-                if let Some(asset_id) = &st.asset {
-                    if !ids.contains(asset_id.as_str()) {
-                        return Err(format!(
-                            "routine '{}' references unknown asset '{}'",
-                            r.id, asset_id
-                        ));
-                    }
+                if let Some(id) = &st.asset {
+                    resolve(id, false, &r.id)?;
+                }
+                if let Some(id) = &st.sound {
+                    resolve(id, true, &r.id)?;
+                }
+            }
+            if let Some(sounds) = r.breath.as_ref().and_then(|b| b.sounds.as_ref()) {
+                for id in [
+                    &sounds.inhale,
+                    &sounds.hold,
+                    &sounds.exhale,
+                    &sounds.hold_out,
+                ]
+                .into_iter()
+                .flatten()
+                {
+                    resolve(id, true, &r.id)?;
                 }
             }
         }
@@ -888,6 +911,18 @@ mod tests {
         }
     }
 
+    fn ogg_asset(id: &str) -> ManifestAsset {
+        use base64::prelude::{Engine, BASE64_STANDARD};
+        let mut bytes = b"OggS".to_vec();
+        bytes.extend_from_slice(&[0u8; 32]);
+        let hash = crate::plugins::sha256(&bytes);
+        ManifestAsset {
+            id: id.to_string(),
+            sha256: hash.iter().map(|b| format!("{b:02x}")).collect(),
+            data_base64: BASE64_STANDARD.encode(&bytes),
+        }
+    }
+
     /// A content manifest whose one routine's one step references `asset_id`.
     fn content_manifest_referencing(asset_id: &str) -> Manifest {
         use crate::scheduler::{
@@ -905,6 +940,7 @@ mod tests {
                 text: "stretch".to_string(),
                 seconds: 5,
                 asset: Some(asset_id.to_string()),
+                sound: None,
             }],
             pacing: None,
             max_step_secs: None,
@@ -933,6 +969,7 @@ mod tests {
                 text: "rest".to_string(),
                 seconds: 5,
                 asset: None,
+                sound: None,
             });
         assert!(validate_manifest(&m).is_ok());
     }
@@ -943,7 +980,7 @@ mod tests {
         m.assets = vec![png_asset("twist")];
         assert!(validate_manifest(&m)
             .unwrap_err()
-            .contains("must not carry image assets"));
+            .contains("must not carry assets"));
     }
 
     #[test]
@@ -953,6 +990,63 @@ mod tests {
         assert!(validate_manifest(&m)
             .unwrap_err()
             .contains("references unknown asset"));
+    }
+
+    /// Swap the single routine's step to reference `id` as a sound (clearing
+    /// its image ref), and optionally give the routine a breath inhale cue.
+    fn with_step_sound(asset_id: &str) -> Manifest {
+        let mut m = content_manifest_referencing("ignored");
+        let step = &mut m.content.as_mut().unwrap().routines[0].steps[0];
+        step.asset = None;
+        step.sound = Some(asset_id.to_string());
+        m
+    }
+
+    #[test]
+    fn validate_accepts_a_step_sound_referencing_audio() {
+        let mut m = with_step_sound("chime");
+        m.assets = vec![ogg_asset("chime")];
+        assert!(validate_manifest(&m).is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_a_step_sound_that_points_at_an_image() {
+        let mut m = with_step_sound("pic");
+        m.assets = vec![png_asset("pic")];
+        assert!(validate_manifest(&m)
+            .unwrap_err()
+            .contains("as a sound but it is an image"));
+    }
+
+    #[test]
+    fn validate_rejects_a_step_image_that_points_at_audio() {
+        let mut m = content_manifest_referencing("chime");
+        m.assets = vec![ogg_asset("chime")];
+        assert!(validate_manifest(&m)
+            .unwrap_err()
+            .contains("as an image but it is audio"));
+    }
+
+    #[test]
+    fn validate_accepts_breath_phase_cues_referencing_audio() {
+        use crate::scheduler::{BreathPattern, BreathSounds};
+        let mut m = content_manifest_referencing("ignored");
+        let r = &mut m.content.as_mut().unwrap().routines[0];
+        r.steps[0].asset = None;
+        r.breath = Some(BreathPattern {
+            inhale: 4,
+            hold: 0,
+            exhale: 4,
+            hold_out: 0,
+            cycles: None,
+            then: None,
+            sounds: Some(BreathSounds {
+                inhale: Some("chime".to_string()),
+                ..Default::default()
+            }),
+        });
+        m.assets = vec![ogg_asset("chime")];
+        assert!(validate_manifest(&m).is_ok());
     }
 
     #[test]

--- a/src-tauri/src/plugins/mod.rs
+++ b/src-tauri/src/plugins/mod.rs
@@ -37,7 +37,7 @@ pub use registry::{InstalledPlugin, PluginRegistry, PluginSummary};
 // allow(unused_imports) so the public API can live in one place ahead of all
 // its consumers.
 #[allow(unused_imports)]
-pub use asset::{validate_asset, ImageFormat, ManifestAsset, MAX_ASSETS};
+pub use asset::{validate_asset, AssetKind, AudioFormat, ImageFormat, ManifestAsset, MAX_ASSETS};
 #[allow(unused_imports)]
 pub use manifest::{
     parse_manifest, validate_manifest, Capability, DetectConfig, ExportConfig, ExportFormat,

--- a/src-tauri/src/scheduler/commands/content_pack.rs
+++ b/src-tauri/src/scheduler/commands/content_pack.rs
@@ -126,6 +126,7 @@ mod tests {
                     text: "Look away".to_string(),
                     seconds: 5,
                     asset: None,
+                    sound: None,
                 }],
                 pacing: None,
                 max_step_secs: None,

--- a/src-tauri/src/scheduler/commands/plugins.rs
+++ b/src-tauri/src/scheduler/commands/plugins.rs
@@ -77,6 +77,9 @@ pub struct InstallOutcome {
     /// Total decoded bytes of those images.
     #[serde(default)]
     pub images_bytes: u64,
+    /// Sound-cue assets written to disk (zero for non-content plugins).
+    #[serde(default)]
+    pub sounds_added: usize,
 }
 
 /// A validated plugin awaiting consent + apply. Holds enough to show the
@@ -166,12 +169,19 @@ async fn apply_install(
     let mut asset_paths: std::collections::HashMap<&str, String> = std::collections::HashMap::new();
     let mut prepared: Vec<(String, Vec<u8>)> = Vec::new();
     let mut images_bytes: u64 = 0;
+    let mut images_added = 0usize;
+    let mut sounds_added = 0usize;
     for asset in &manifest.assets {
-        let (bytes, format) = crate::plugins::validate_asset(asset)?;
-        let file_name = crate::plugin_store::asset_file_name(&manifest.id, &asset.id, format.ext());
+        let (bytes, kind) = crate::plugins::validate_asset(asset)?;
+        let file_name = crate::plugin_store::asset_file_name(&manifest.id, &asset.id, kind.ext());
         let path = crate::plugin_store::asset_path(&scheduler.plugins_path, &file_name);
         asset_paths.insert(asset.id.as_str(), path.to_string_lossy().into_owned());
         images_bytes += bytes.len() as u64;
+        if kind.is_audio() {
+            sounds_added += 1;
+        } else {
+            images_added += 1;
+        }
         prepared.push((file_name, bytes));
     }
     // Now write the sidecars. On any I/O failure, roll back the ones already
@@ -183,21 +193,30 @@ async fn apply_install(
             for written in &asset_files {
                 crate::plugin_store::delete_asset(&scheduler.plugins_path, written);
             }
-            return Err(format!("failed to save plugin image: {e}"));
+            return Err(format!("failed to save plugin asset: {e}"));
         }
         asset_files.push(file_name.clone());
     }
-    let images_added = manifest.assets.len();
 
     // Rewrite each step's pack-local asset id to the stored absolute path, so
     // the merged routine resolves to a real file at break time with no further
     // lookup. Steps referencing nothing (the common case) are untouched.
+    let rewrite = |slot: &mut Option<String>| {
+        if let Some(id) = slot.take() {
+            *slot = asset_paths.get(id.as_str()).cloned();
+        }
+    };
     let mut pack = pack.clone();
     for r in &mut pack.routines {
         for st in &mut r.steps {
-            if let Some(id) = st.asset.take() {
-                st.asset = asset_paths.get(id.as_str()).cloned();
-            }
+            rewrite(&mut st.asset);
+            rewrite(&mut st.sound);
+        }
+        if let Some(sounds) = r.breath.as_mut().and_then(|b| b.sounds.as_mut()) {
+            rewrite(&mut sounds.inhale);
+            rewrite(&mut sounds.hold);
+            rewrite(&mut sounds.exhale);
+            rewrite(&mut sounds.hold_out);
         }
     }
 
@@ -237,6 +256,7 @@ async fn apply_install(
         routines_added: summary.routines_added,
         images_added,
         images_bytes,
+        sounds_added,
     })
 }
 
@@ -265,6 +285,7 @@ async fn apply_detector_install(
         routines_added: 0,
         images_added: 0,
         images_bytes: 0,
+        sounds_added: 0,
     })
 }
 
@@ -285,6 +306,7 @@ async fn apply_export_install(scheduler: &Scheduler, manifest: &Manifest) -> Ins
         routines_added: 0,
         images_added: 0,
         images_bytes: 0,
+        sounds_added: 0,
     }
 }
 
@@ -449,7 +471,7 @@ fn format_install_summary(manifest: &Manifest) -> String {
                     .map(|a| a.data_base64.len() / 4 * 3)
                     .sum();
                 s.push_str(&format!(
-                    "Ships {} image(s) ({:.1} MB).\n",
+                    "Ships {} media file(s) — images and/or sounds ({:.1} MB).\n",
                     manifest.assets.len(),
                     bytes as f64 / (1024.0 * 1024.0)
                 ));
@@ -553,6 +575,7 @@ mod tests {
                         text: "Look away".to_string(),
                         seconds: 5,
                         asset: None,
+                        sound: None,
                     }],
                     pacing: None,
                     max_step_secs: None,
@@ -724,15 +747,15 @@ mod tests {
     }
 
     #[test]
-    fn format_install_summary_reports_images_for_a_content_plugin() {
+    fn format_install_summary_reports_media_for_a_content_plugin() {
         let with = format_install_summary(&content_manifest_with_image("com.example.yoga"));
         assert!(
-            with.contains("1 image(s)"),
-            "summary mentions the image: {with}"
+            with.contains("1 media file(s)"),
+            "summary mentions the media: {with}"
         );
-        // A content plugin with no images says nothing about them.
+        // A content plugin with no media says nothing about it.
         let without = format_install_summary(&content_manifest("com.example.plain"));
-        assert!(!without.contains("image(s)"));
+        assert!(!without.contains("media file(s)"));
     }
 
     #[tokio::test]
@@ -818,6 +841,65 @@ mod tests {
         m.assets = vec![png_manifest_asset("twist")];
         m.content.as_mut().unwrap().routines[0].steps[0].asset = Some("twist".to_string());
         m
+    }
+
+    fn ogg_manifest_asset(asset_id: &str) -> crate::plugins::ManifestAsset {
+        use base64::prelude::{Engine, BASE64_STANDARD};
+        let mut bytes = b"OggS".to_vec();
+        bytes.extend_from_slice(&[0u8; 32]);
+        let hash = crate::plugins::sha256(&bytes);
+        crate::plugins::ManifestAsset {
+            id: asset_id.to_string(),
+            sha256: hash.iter().map(|b| format!("{b:02x}")).collect(),
+            data_base64: BASE64_STANDARD.encode(&bytes),
+        }
+    }
+
+    #[tokio::test]
+    async fn install_rewrites_step_and_breath_sounds_and_counts_them() {
+        use crate::scheduler::{BreathPattern, BreathSounds};
+        let (_dir, sched) = test_scheduler(crate::scheduler::Settings::default());
+        let mut m = content_manifest("com.example.yoga");
+        m.assets = vec![ogg_manifest_asset("chime")];
+        let r = &mut m.content.as_mut().unwrap().routines[0];
+        r.steps[0].sound = Some("chime".to_string());
+        r.breath = Some(BreathPattern {
+            inhale: 4,
+            hold: 0,
+            exhale: 4,
+            hold_out: 0,
+            cycles: None,
+            then: None,
+            sounds: Some(BreathSounds {
+                inhale: Some("chime".to_string()),
+                ..Default::default()
+            }),
+        });
+
+        let outcome = apply_install(&sched, &m).await.unwrap();
+        assert_eq!(outcome.sounds_added, 1);
+        assert_eq!(outcome.images_added, 0);
+
+        let settings = sched.settings.lock().await;
+        let rt = settings
+            .custom_routines
+            .iter()
+            .find(|r| r.id == "plugin-rt")
+            .expect("routine merged");
+        let step_path = rt.steps[0].sound.clone().expect("step sound rewritten");
+        assert!(step_path.ends_with("com.example.yoga.chime.ogg"));
+        assert!(std::path::Path::new(&step_path).exists(), "sidecar written");
+        // The breath inhale cue is rewritten to the same stored sidecar path.
+        let breath_path = rt
+            .breath
+            .as_ref()
+            .unwrap()
+            .sounds
+            .as_ref()
+            .unwrap()
+            .inhale
+            .clone();
+        assert_eq!(breath_path, Some(step_path));
     }
 
     #[tokio::test]

--- a/src-tauri/src/scheduler/content_pack.rs
+++ b/src-tauri/src/scheduler/content_pack.rs
@@ -317,10 +317,12 @@ fn sanitize_imported_step(step: &mut RoutineStep) {
         text: _,
         seconds: _,
         asset,
+        sound,
     } = step;
-    // Images ship only in a signed plugin (with a backend-controlled sidecar
-    // path); an imported pack must never inject one.
+    // Images and sound cues ship only in a signed plugin (with backend-
+    // controlled sidecar paths); an imported pack must never inject one.
     *asset = None;
+    *sound = None;
 }
 
 /// Remove exactly the content recorded in `added` from `settings` (the
@@ -395,6 +397,7 @@ mod tests {
             hold_out: 0,
             cycles: None,
             then: None,
+            sounds: None,
         }
     }
 
@@ -409,6 +412,7 @@ mod tests {
                 text: "Look away".to_string(),
                 seconds: 5,
                 asset: None,
+                sound: None,
             }],
             pacing: None,
             max_step_secs: None,
@@ -591,6 +595,7 @@ mod tests {
         // would load — only the signed-plugin installer populates `asset`.
         let mut rt = sample_routine("rt-img");
         rt.steps[0].asset = Some("/etc/passwd-ish/evil.png".to_string());
+        rt.steps[0].sound = Some("/etc/evil.ogg".to_string());
         let pack = ContentPack {
             version: CONTENT_PACK_VERSION,
             name: "Imported".to_string(),
@@ -601,6 +606,7 @@ mod tests {
         merge_pack(&pack, &mut s);
         let merged = s.custom_routines.iter().find(|r| r.id == "rt-img").unwrap();
         assert_eq!(merged.steps[0].asset, None);
+        assert_eq!(merged.steps[0].sound, None);
     }
 
     #[test]

--- a/src-tauri/src/scheduler/fixtures/default_settings_flat.json
+++ b/src-tauri/src/scheduler/fixtures/default_settings_flat.json
@@ -155,6 +155,7 @@
   "long_routine_max_difficulty": "active",
   "custom_routines": [],
   "routine_fill": false,
+  "allow_plugin_sounds": true,
   "hint_rotate_seconds": 0,
   "delay_break_if_typing": true,
   "typing_grace_secs": 10,

--- a/src-tauri/src/scheduler/mod.rs
+++ b/src-tauri/src/scheduler/mod.rs
@@ -68,7 +68,7 @@ pub use types::{BreakKind, LastBreakInfo};
 // Re-exported for out-of-scheduler consumers (e.g. plugin manifest tests
 // constructing routines); the crate otherwise names it via `super::types`.
 #[allow(unused_imports)]
-pub use types::RoutineStep;
+pub use types::{BreathPattern, BreathSounds, RoutineStep};
 
 use timers::BreakTimers;
 

--- a/src-tauri/src/scheduler/routines.rs
+++ b/src-tauri/src/scheduler/routines.rs
@@ -95,6 +95,7 @@ fn step(text: &str, seconds: u64) -> RoutineStep {
         text: text.to_string(),
         seconds,
         asset: None,
+        sound: None,
     }
 }
 
@@ -724,6 +725,7 @@ mod tests {
             hold_out: 0,
             cycles: None,
             then: None,
+            sounds: None,
         };
         let mut s = Settings::default();
         s.custom_routines = vec![Routine {
@@ -735,7 +737,7 @@ mod tests {
             steps: vec![],
             pacing: None,
             max_step_secs: None,
-            breath: Some(pattern),
+            breath: Some(pattern.clone()),
         }];
         s.micro_routine = "478".to_string();
         let resolved = resolve_routine(BreakKind::Micro, &s);

--- a/src-tauri/src/scheduler/settings.rs
+++ b/src-tauri/src/scheduler/settings.rs
@@ -578,6 +578,11 @@ pub struct Settings {
     /// A routine's own `pacing` field always takes precedence.
     #[serde(default)]
     pub routine_fill: bool,
+    /// Whether a routine's plugin-supplied sound cues may play (default
+    /// `true`). The user's master kill switch for plugin audio; cues always
+    /// route through `sound_volume` regardless.
+    #[serde(default = "default_true")]
+    pub allow_plugin_sounds: bool,
     pub hint_rotate_seconds: u64,
     pub delay_break_if_typing: bool,
     pub typing_grace_secs: u64,
@@ -697,6 +702,7 @@ impl Default for Settings {
             long_routine_max_difficulty: default_routine_max_difficulty(),
             custom_routines: Vec::new(),
             routine_fill: false,
+            allow_plugin_sounds: true,
             hint_rotate_seconds: 0,
             delay_break_if_typing: true,
             typing_grace_secs: 10,

--- a/src-tauri/src/scheduler/types.rs
+++ b/src-tauri/src/scheduler/types.rs
@@ -41,6 +41,11 @@ pub struct RoutineStep {
     /// text-only step.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub asset: Option<String>,
+    /// Optional sound cue played when this step begins (e.g. a chime signalling
+    /// the next exercise). Like `asset`, a pack-local audio asset id rewritten
+    /// to the stored sidecar path on install. `None` for a silent step.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sound: Option<String>,
 }
 
 /// How a routine's step durations relate to the break length. Sent in
@@ -74,12 +79,27 @@ pub enum BreathThen {
     Rest,
 }
 
+/// Per-phase sound cues for a breathing pattern, so a user can follow the
+/// rhythm with their eyes closed. Each is an audio asset id (rewritten to the
+/// stored sidecar path on install); any phase may be silent.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct BreathSounds {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub inhale: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hold: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub exhale: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hold_out: Option<String>,
+}
+
 /// A guided breathing pattern, animated on the countdown ring. Phase durations
 /// are **absolute seconds** — tempo is never scaled to the break length; the
 /// cycle simply repeats. `cycles` optionally caps the guided portion, after
 /// which `then` decides whether to loop or rest. A routine carrying a `breath`
 /// takes the place of step text on the overlay.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct BreathPattern {
     /// Seconds breathing in (ring expands).
     pub inhale: u64,
@@ -97,6 +117,9 @@ pub struct BreathPattern {
     /// What to do after `cycles`. `None` is treated as `loop`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub then: Option<BreathThen>,
+    /// Optional per-phase sound cues. `None` for a silent pattern.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sounds: Option<BreathSounds>,
 }
 
 /// Payload emitted to the renderer when a break starts.

--- a/src/views/break-overlay.test.tsx
+++ b/src/views/break-overlay.test.tsx
@@ -477,6 +477,20 @@ describe("BreakOverlay guided routines", () => {
     expect(container.querySelector(".overlay-routine-image")).toBeNull();
   });
 
+  it("fires a step sound cue at break start when a step declares one", async () => {
+    const { getByText } = await startBreak(false, {
+      duration_secs: 30,
+      routine_steps: [{ text: "Seated twist", seconds: 10, sound: "/cue.ogg" }],
+    });
+    expect(getByText("Seated twist")).toBeTruthy();
+    await waitFor(() =>
+      expect(invokeMock).toHaveBeenCalledWith("play_custom_sound", {
+        path: "/cue.ogg",
+        volume: expect.any(Number),
+      }),
+    );
+  });
+
   it("renders no image when the step has no asset", async () => {
     const { container } = await startBreak(false, {
       routine_steps: [{ text: "Reach overhead", seconds: 20 }],

--- a/src/views/break-overlay.tsx
+++ b/src/views/break-overlay.tsx
@@ -24,8 +24,10 @@ import { routineProgress } from "./break-overlay/routine";
 import {
   breathAriaLabel,
   breathLabel,
+  breathPhaseCue,
   breathProgress,
 } from "./break-overlay/breath";
+import { useRoutineCues } from "./break-overlay/hooks/use-routine-cues";
 import {
   ENFORCEABLE_LONG_BREAK_HINT,
   shouldShowEnforceableHint,
@@ -110,25 +112,21 @@ export default function BreakOverlay() {
     finished,
   );
 
-  if (!active) return null;
-
-  const minutes = Math.floor(remaining / 60);
-  const seconds = remaining % 60;
-  const label = labelFor(active.kind);
-  const hintText = active.hints[hintIndex] ?? "";
-  // A selected guided routine steps through its own text on the break's
-  // own countdown and takes the place of the rotating hint. With none
-  // selected (empty steps) the overlay falls back to the hint above.
-  const routineSteps = active.routine_steps ?? [];
+  // Routine + breath progress are computed before the early return so the cue
+  // hook below runs unconditionally (rules of hooks). They reduce to
+  // null/empty when there is no active break.
+  const routineSteps = active?.routine_steps ?? [];
+  const elapsed = active ? active.duration_secs - remaining : 0;
   // Effective pacing: the routine's own declared pacing takes precedence;
   // fall back to the global `routine_fill` toggle when absent.
-  const effectivePacing =
-    active.routine_pacing ??
-    (appearance.routine_fill ? ("fill" as const) : undefined);
+  const effectivePacing = active
+    ? (active.routine_pacing ??
+      (appearance.routine_fill ? ("fill" as const) : undefined))
+    : undefined;
   const routine = routineProgress(
     routineSteps,
-    active.duration_secs - remaining,
-    effectivePacing !== undefined
+    elapsed,
+    effectivePacing !== undefined && active
       ? {
           fillToSecs: active.duration_secs,
           pacing: effectivePacing,
@@ -136,6 +134,29 @@ export default function BreakOverlay() {
         }
       : undefined,
   );
+  // A breathing routine replaces step text with phase labels and pulses the
+  // ring (driven by --breath-scale in use-overlay-css-vars). Takes precedence
+  // over step rendering when present.
+  const breath = active?.routine_breath ?? null;
+  const breathProg = breath ? breathProgress(breath, elapsed) : null;
+
+  // Plugin sound cues at step / breath-phase boundaries, gated by the user's
+  // allow-plugin-sounds switch and routed through the master volume.
+  useRoutineCues(
+    Boolean(active) && appearance.allow_plugin_sounds,
+    appearance.sound_volume,
+    routine?.index ?? null,
+    routine ? (routineSteps[routine.index].sound ?? null) : null,
+    breathProg?.phase ?? null,
+    breathProg ? breathPhaseCue(breath?.sounds, breathProg.phase) : null,
+  );
+
+  if (!active) return null;
+
+  const minutes = Math.floor(remaining / 60);
+  const seconds = remaining % 60;
+  const label = labelFor(active.kind);
+  const hintText = active.hints[hintIndex] ?? "";
   const routineText = routine ? routineSteps[routine.index].text : "";
   // A plugin-supplied image for the current step, if any. The backend sends an
   // absolute path; convertFileSrc turns it into an `asset:` URL the webview can
@@ -145,13 +166,6 @@ export default function BreakOverlay() {
   const routineImageSrc = routineAsset
     ? convertFileSrc(routineAsset)
     : undefined;
-  // A breathing routine replaces step text with phase labels and pulses the
-  // ring (driven by --breath-scale in use-overlay-css-vars). Takes precedence
-  // over step rendering when present.
-  const breath = active.routine_breath ?? null;
-  const breathProg = breath
-    ? breathProgress(breath, active.duration_secs - remaining)
-    : null;
   const intensity = clamp01(active.health_intensity);
   const dismissable = !active.enforceable && active.skip_available;
   const showPostpone = active.postpone_available && !finished;

--- a/src/views/break-overlay/breath.test.ts
+++ b/src/views/break-overlay/breath.test.ts
@@ -5,6 +5,7 @@ import {
   breathScale,
   breathLabel,
   breathAriaLabel,
+  breathPhaseCue,
 } from "./breath";
 import type { BreathPattern } from "./types";
 
@@ -106,6 +107,23 @@ describe("breathLabel / breathAriaLabel", () => {
     const p = { phase: "rest", phaseRemaining: 0, fullness: 0 } as const;
     expect(breathLabel(p)).toBe("Rest");
     expect(breathAriaLabel(p)).toBe("Rest");
+  });
+});
+
+describe("breathPhaseCue", () => {
+  const sounds = { inhale: "in.ogg", exhale: "out.ogg" };
+  it("returns the cue for a phase that declares one", () => {
+    expect(breathPhaseCue(sounds, "inhale")).toBe("in.ogg");
+    expect(breathPhaseCue(sounds, "exhale")).toBe("out.ogg");
+  });
+  it("is null for a silent phase, rest, or no sounds", () => {
+    expect(breathPhaseCue(sounds, "hold")).toBeNull();
+    expect(breathPhaseCue(sounds, "hold_out")).toBeNull();
+    expect(breathPhaseCue(sounds, "rest")).toBeNull();
+    expect(breathPhaseCue(undefined, "inhale")).toBeNull();
+    // sounds present but the queried phase absent → null.
+    expect(breathPhaseCue({}, "inhale")).toBeNull();
+    expect(breathPhaseCue({}, "exhale")).toBeNull();
   });
 });
 

--- a/src/views/break-overlay/breath.ts
+++ b/src/views/break-overlay/breath.ts
@@ -1,4 +1,4 @@
-import type { BreathPattern } from "./types";
+import type { BreathPattern, BreathSounds } from "./types";
 
 export type BreathPhase = "inhale" | "hold" | "exhale" | "hold_out" | "rest";
 
@@ -20,6 +20,27 @@ const PHASE_LABEL: Record<BreathPhase, string> = {
 
 export function breathPhaseLabel(phase: BreathPhase): string {
   return PHASE_LABEL[phase];
+}
+
+// The sound cue for a given phase, if the pattern declares one. `rest` is
+// always silent.
+export function breathPhaseCue(
+  sounds: BreathSounds | undefined,
+  phase: BreathPhase,
+): string | null {
+  if (!sounds) return null;
+  switch (phase) {
+    case "inhale":
+      return sounds.inhale ?? null;
+    case "hold":
+      return sounds.hold ?? null;
+    case "exhale":
+      return sounds.exhale ?? null;
+    case "hold_out":
+      return sounds.hold_out ?? null;
+    case "rest":
+      return null;
+  }
 }
 
 // Map a fullness (0..1) to the ring's `--breath-scale`. Reduced-motion users

--- a/src/views/break-overlay/hooks/use-routine-cues.test.ts
+++ b/src/views/break-overlay/hooks/use-routine-cues.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useRoutineCues } from "./use-routine-cues";
+
+type Props = {
+  enabled: boolean;
+  stepKey: number | null;
+  stepSound: string | null;
+  phaseKey: string | null;
+  phaseSound: string | null;
+};
+
+function setup(initial: Props) {
+  const play = vi.fn();
+  const { rerender } = renderHook(
+    (p: Props) =>
+      useRoutineCues(
+        p.enabled,
+        0.5,
+        p.stepKey,
+        p.stepSound,
+        p.phaseKey,
+        p.phaseSound,
+        { play },
+      ),
+    { initialProps: initial },
+  );
+  return { play, rerender };
+}
+
+const SILENT: Props = {
+  enabled: true,
+  stepKey: null,
+  stepSound: null,
+  phaseKey: null,
+  phaseSound: null,
+};
+
+describe("useRoutineCues", () => {
+  it("fires a step cue on the first step and again when the step changes", () => {
+    const { play, rerender } = setup({
+      ...SILENT,
+      stepKey: 0,
+      stepSound: "a.ogg",
+    });
+    expect(play).toHaveBeenCalledExactlyOnceWith("a.ogg", 0.5);
+
+    // Same step → no repeat.
+    rerender({ ...SILENT, stepKey: 0, stepSound: "a.ogg" });
+    expect(play).toHaveBeenCalledTimes(1);
+
+    // New step with a cue → fires.
+    rerender({ ...SILENT, stepKey: 1, stepSound: "b.ogg" });
+    expect(play).toHaveBeenLastCalledWith("b.ogg", 0.5);
+    expect(play).toHaveBeenCalledTimes(2);
+  });
+
+  it("fires a breath-phase cue when the phase changes", () => {
+    const { play, rerender } = setup({
+      ...SILENT,
+      phaseKey: "inhale",
+      phaseSound: "in.ogg",
+    });
+    expect(play).toHaveBeenCalledExactlyOnceWith("in.ogg", 0.5);
+    rerender({ ...SILENT, phaseKey: "exhale", phaseSound: "out.ogg" });
+    expect(play).toHaveBeenLastCalledWith("out.ogg", 0.5);
+  });
+
+  it("stays silent when disabled, even across boundaries", () => {
+    const { play, rerender } = setup({
+      ...SILENT,
+      enabled: false,
+      stepKey: 0,
+      stepSound: "a.ogg",
+    });
+    rerender({
+      ...SILENT,
+      enabled: false,
+      stepKey: 1,
+      stepSound: "b.ogg",
+    });
+    expect(play).not.toHaveBeenCalled();
+  });
+
+  it("does not fire for a boundary that has no cue", () => {
+    const { play } = setup({ ...SILENT, stepKey: 0, stepSound: null });
+    expect(play).not.toHaveBeenCalled();
+  });
+});

--- a/src/views/break-overlay/hooks/use-routine-cues.ts
+++ b/src/views/break-overlay/hooks/use-routine-cues.ts
@@ -1,0 +1,38 @@
+import { useEffect, useRef } from "react";
+import { playCustomSound as defaultPlay } from "../../../lib/sounds";
+
+export type RoutineCuesDeps = {
+  play?: (path: string, volume: number) => void;
+};
+
+// Fire one-shot routine sound cues at step / breath-phase boundaries. Plugin
+// cues are absolute sidecar paths; they play through the master `volume` and
+// only when `enabled` (the user's allow-plugin-sounds switch). Boundaries are
+// derived from the per-second countdown — the cue fires when the step index or
+// breath phase changes, so it never double-fires within a phase and is
+// naturally paused with the break.
+export function useRoutineCues(
+  enabled: boolean,
+  volume: number,
+  stepKey: number | null,
+  stepSound: string | null,
+  phaseKey: string | null,
+  phaseSound: string | null,
+  deps: RoutineCuesDeps = {},
+): void {
+  const play = deps.play ?? defaultPlay;
+  const prevStep = useRef<number | null>(null);
+  const prevPhase = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (stepKey === prevStep.current) return;
+    prevStep.current = stepKey;
+    if (enabled && stepSound) play(stepSound, volume);
+  }, [stepKey, stepSound, enabled, volume, play]);
+
+  useEffect(() => {
+    if (phaseKey === prevPhase.current) return;
+    prevPhase.current = phaseKey;
+    if (enabled && phaseSound) play(phaseSound, volume);
+  }, [phaseKey, phaseSound, enabled, volume, play]);
+}

--- a/src/views/break-overlay/schemas.ts
+++ b/src/views/break-overlay/schemas.ts
@@ -3,6 +3,7 @@ import type { BreakSound } from "../../lib/break-sound";
 import type {
   BreakEvent,
   BreathPattern,
+  BreathSounds,
   OverlaySettings,
   PostponeState,
   RoutineStep,
@@ -43,13 +44,22 @@ export const overlaySettingsSchema = z.object({
   strict_mode: z.boolean(),
   custom_css: z.string(),
   routine_fill: z.boolean(),
+  allow_plugin_sounds: z.boolean(),
 }) satisfies z.ZodType<OverlaySettings>;
 
 const routineStepSchema = z.object({
   text: z.string(),
   seconds: z.number(),
   asset: z.string().optional(),
+  sound: z.string().optional(),
 }) satisfies z.ZodType<RoutineStep>;
+
+const breathSoundsSchema = z.object({
+  inhale: z.string().optional(),
+  hold: z.string().optional(),
+  exhale: z.string().optional(),
+  hold_out: z.string().optional(),
+}) satisfies z.ZodType<BreathSounds>;
 
 const breathSchema = z.object({
   inhale: z.number(),
@@ -58,6 +68,7 @@ const breathSchema = z.object({
   hold_out: z.number().optional(),
   cycles: z.number().optional(),
   then: z.enum(["loop", "rest"]).optional(),
+  sounds: breathSoundsSchema.optional(),
 }) satisfies z.ZodType<BreathPattern>;
 
 export const breakEventSchema = z.object({

--- a/src/views/break-overlay/types.ts
+++ b/src/views/break-overlay/types.ts
@@ -12,6 +12,9 @@ export type RoutineStep = {
   // plugin's bundled asset). Absent for the common text-only step; the overlay
   // turns it into an `asset:` URL via convertFileSrc.
   asset?: string;
+  // Absolute path to a sound cue played when this step begins (resolved at
+  // install from a plugin's audio asset). Absent for a silent step.
+  sound?: string;
 };
 
 /** How a routine's step durations relate to the break length.
@@ -19,6 +22,14 @@ export type RoutineStep = {
 export type RoutinePacing = "hold" | "fill" | "loop";
 
 export type BreathThen = "loop" | "rest";
+
+// Per-phase sound cues (absolute sidecar paths). Any phase may be silent.
+export type BreathSounds = {
+  inhale?: string;
+  hold?: string;
+  exhale?: string;
+  hold_out?: string;
+};
 
 // Mirrors the Rust `BreathPattern`. Phase durations are absolute seconds.
 export type BreathPattern = {
@@ -28,6 +39,7 @@ export type BreathPattern = {
   hold_out?: number;
   cycles?: number;
   then?: BreathThen;
+  sounds?: BreathSounds;
 };
 
 export type BreakEvent = {
@@ -74,6 +86,9 @@ export type OverlaySettings = {
    *  `true` → fill mode (scale steps to fill the break);
    *  `false` (default) → hold mode (authored durations, hold last step). */
   routine_fill: boolean;
+  // Master switch for plugin-supplied routine sound cues (default true). Cues
+  // still route through `sound_volume`; this is the kill switch.
+  allow_plugin_sounds: boolean;
 };
 
 export type PostponeState = {
@@ -98,6 +113,7 @@ export const DEFAULT_OVERLAY_SETTINGS: OverlaySettings = {
   strict_mode: false,
   custom_css: "",
   routine_fill: false,
+  allow_plugin_sounds: true,
 };
 
 export const TYPING_PAUSE_THRESHOLD_SECS = 2;

--- a/src/views/settings/hooks/use-settings.ts
+++ b/src/views/settings/hooks/use-settings.ts
@@ -149,6 +149,7 @@ export const schedulerSettingsSchema = z.object({
   micro_break_mode: z.enum(["overlay", "windowed", "notification"]),
   long_break_mode: z.enum(["overlay", "windowed", "notification"]),
   routine_fill: z.boolean(),
+  allow_plugin_sounds: z.boolean(),
   custom_css: z.string(),
 }) satisfies z.ZodType<SchedulerSettings>;
 

--- a/src/views/settings/tabs/breaks-tab.test.tsx
+++ b/src/views/settings/tabs/breaks-tab.test.tsx
@@ -138,6 +138,13 @@ describe("BreaksTab guided routines", () => {
     );
     expect(update).toHaveBeenCalledWith("routine_fill", true);
   });
+
+  it("toggling plugin sound cues calls update with the new value", () => {
+    const update = vi.fn();
+    renderTab(false, update);
+    fireEvent.click(checkboxForLabel("Play plugin sound cues"));
+    expect(update).toHaveBeenCalledWith("allow_plugin_sounds", true);
+  });
 });
 
 describe("BreaksTab break ideas", () => {

--- a/src/views/settings/tabs/breaks-tab.tsx
+++ b/src/views/settings/tabs/breaks-tab.tsx
@@ -505,6 +505,12 @@ export function BreaksTab({
           onChange={(v) => update("routine_fill", v)}
           tip="When on, a routine's step durations are treated as relative weights and scaled to fill the full break length. When off (default), steps run at their authored durations and the last step holds until the break ends. A routine can override this per-routine with its own pacing field."
         />
+        <CheckboxRow
+          label="Play plugin sound cues"
+          value={settings.allow_plugin_sounds}
+          onChange={(v) => update("allow_plugin_sounds", v)}
+          tip="When on (default), routines from plugins may play their own short sound cues — a breathing in/out tone, or a chime between exercises. Cues always follow your overall sound volume; turn this off to silence them."
+        />
         {isSupporter && (
           <>
             <label className="row stacked">

--- a/src/views/settings/types.ts
+++ b/src/views/settings/types.ts
@@ -66,7 +66,12 @@ export type RoutineCategory = "eyes" | "mobility" | "breathing" | "desk_yoga";
 
 export type RoutineDifficulty = "gentle" | "moderate" | "active";
 
-export type RoutineStep = { text: string; seconds: number; asset?: string };
+export type RoutineStep = {
+  text: string;
+  seconds: number;
+  asset?: string;
+  sound?: string;
+};
 
 // Mirrors the Rust `Routine` in `src-tauri/src/scheduler/routines.rs`. Stored
 // in settings as `custom_routines` (imported from content packs, #155).
@@ -176,6 +181,7 @@ export type SchedulerSettings = {
   long_routine_max_difficulty: RoutineDifficulty;
   custom_routines: Routine[];
   routine_fill: boolean;
+  allow_plugin_sounds: boolean;
   hint_rotate_seconds: number;
   delay_break_if_typing: boolean;
   typing_grace_secs: number;


### PR DESCRIPTION
## Summary

The final overlay-extension (PR 4 of 4): a content plugin can ship short **audio cues** — a tone on the breath in/out so a user can follow a breathing routine with their eyes closed, or a chime between yoga poses. Reuses the #183 hash-bound asset pipeline.

- **Audio assets.** `plugins::asset` now sniffs **OGG/WAV/MP3** by magic bytes (WAV's `RIFF` header disambiguated from WebP's), caps a sound at **256 KiB**, and `validate_asset` returns an `AssetKind`. The manifest enforces that `step.asset` names an **image** and `step.sound` / `breath.sounds.*` name **audio** — mixing is rejected.
- **Schema.** `RoutineStep.sound` + `BreathSounds`/`BreathPattern.sounds` (Rust + TS + zod). They ride inside the existing `routine_steps`/`routine_breath` payload — **no new BreakEvent fields**. On install they're rewritten to stored sidecar paths and counted (`sounds_added`); the unsigned import path strips them (the sanitize gate from #183 caught the new field at compile time).
- **Playback.** `useRoutineCues` fires one-shot cues via `playCustomSound` at step / breath-phase boundaries, derived from the per-second countdown (so they pause with the break and never double-fire). Gated by a new **`allow_plugin_sounds`** setting (default on, **not** Supporter-gated — per the earlier free-for-all decision) with a Breaks-tab toggle, and always routed through the master sound volume.

## Test plan

- [x] `cargo fmt` / `clippy --all-targets -D warnings` clean; `cargo test --lib` — 1083 pass (audio sniff + caps, image/sound ref validation, install rewrite + count for step **and** breath cues, import strip)
- [x] `tsc` clean; `vitest run` — 716 pass (cue hook boundaries/disabled/silent; `breathPhaseCue`)
- [x] Diff verified **fully covered** locally — cargo-llvm-cov (Rust) + vitest branch report (frontend)
- [ ] 3-OS CI matrix (runs here)

Docs: a **Sounds** section in the plugin authoring guide + limits table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)