### PR TITLE
chore(release): v0.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Versions on the `0.0.X` line are public beta releases; `0.1.X` and onwards will 
 
 ## [Unreleased]
 
+## [0.0.7] — 2026-06-15
+
 ### Added
 
 - **Morning chore prompt.** Since the chore post-it resets each morning, it's easy to forget to fill it in. The first time your work window opens each day with an empty list, Entracte now opens Preferences to the chore input so you can plan the day's chores in one go. It fires at most once a day and only with an empty list, so it never nags. On by default; turn it off under **Breaks → Today's chores → "Prompt me to plan chores each morning."** ([#156](https://github.com/drmowinckels/entracte/issues/156))

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "entracte-desktop",
   "private": true,
-  "version": "0.0.6",
+  "version": "0.0.7",
   "type": "module",
   "engines": {
     "node": "^20.19.0 || >=22.12.0"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1581,7 +1581,7 @@ checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
 
 [[package]]
 name = "entracte"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "entracte"
-version = "0.0.6"
+version = "0.0.7"
 description = "Cross-platform break reminder"
 authors = ["Athanasia Mowinckel"]
 license = "Apache-2.0"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Entracte",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "identifier": "io.drmowinckels.entracte",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary

Release prep for **v0.0.7** (next public beta on the `0.0.X` line). Bumps the version in `package.json`, `src-tauri/Cargo.toml`, `src-tauri/tauri.conf.json`, and `Cargo.lock`, and dates the changelog's `[Unreleased]` section as **`[0.0.7] — 2026-06-15`** (with a fresh empty `[Unreleased]` for the next cycle).

### What's in 0.0.7
- **Added**: morning chore prompt (#156); per-break postpone/skip toggles moved to the Schedule tab.
- **Fixed**: macOS 26 camera-release detection (#158); GNOME/Wayland idle via Mutter (#190); logind session-lock robustness (#191); Preferences-controls on GNOME/Wayland (#139).
- **Security**: Vite 8 / dropped vulnerable esbuild (#188).
- (Plus the overlay a11y audit + `aria-keyshortcuts` from #63.)

## After merge
Tag `v0.0.7` on `main` and push → the release workflow builds all platforms and drafts the GitHub release for review + publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)