### PR TITLE
feat(schedule): choose which weekdays active hours applies to (#204)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Versions on the `0.0.X` line are public beta releases; `0.1.X` and onwards will 
 
 ## [Unreleased]
 
+### Added
+
+- **Active hours can target specific weekdays.** The Schedule tab's **Active hours** section gains an **On these days** picker, so the work window can apply only on the days you actually work — turn off Saturday and Sunday and Entracte stays quiet while you game or relax at the weekend, no need to remember to pause it. Defaults to every day, so existing setups are unchanged on upgrade. A window that runs past midnight (e.g. 22:00–06:00) counts its early-morning hours as part of the day it started. ([#204](https://github.com/drmowinckels/entracte/issues/204))
+
 ## [0.0.7] — 2026-06-15
 
 ### Added

--- a/scripts/audit-a11y-settings-fixture.json
+++ b/scripts/audit-a11y-settings-fixture.json
@@ -16,6 +16,7 @@
   "work_window_enabled": true,
   "work_start_minutes": 540,
   "work_end_minutes": 1020,
+  "work_days_mask": 127,
   "bedtime_enabled": true,
   "bedtime_start_minutes": 1320,
   "bedtime_end_minutes": 1380,

--- a/src-tauri/src/scheduler/fixtures/default_settings_flat.json
+++ b/src-tauri/src/scheduler/fixtures/default_settings_flat.json
@@ -16,6 +16,7 @@
   "work_window_enabled": false,
   "work_start_minutes": 540,
   "work_end_minutes": 1020,
+  "work_days_mask": 127,
   "bedtime_enabled": false,
   "bedtime_start_minutes": 1320,
   "bedtime_end_minutes": 1380,

--- a/src-tauri/src/scheduler/run_loop.rs
+++ b/src-tauri/src/scheduler/run_loop.rs
@@ -18,9 +18,10 @@ use super::screen_time::{persist_screen_time, rollover_if_new_day, should_remind
 use super::session_lock;
 use super::settings::{delivery_for, Settings};
 use super::timers::{
-    current_minutes, decide_bedtime, in_window, interval_break_due, local_today_string,
+    current_minutes, current_weekday, decide_bedtime, interval_break_due, local_today_string,
     prebreak_warn_due, reanchor_intervals_on_resume, record_scheduled_fire,
-    should_defer_for_typing, should_fire_fixed_now, BedtimeAction, BedtimeWindow, PrebreakGate,
+    should_defer_for_typing, should_fire_fixed_now, work_window_active, BedtimeAction,
+    BedtimeWindow, PrebreakGate,
 };
 use super::types::{BreakDelivery, BreakEvent, BreakKind, SuppressReason};
 use super::Scheduler;
@@ -135,6 +136,7 @@ pub(super) async fn run_loop(app: AppHandle, sched: Scheduler) {
         // when a break fires (#77).
         crate::media::set_enabled(s.pause_media_during_breaks);
         let now_min = current_minutes();
+        let today_weekday = current_weekday();
 
         // Probing idle round-trips to the windowing system (and, on
         // GNOME/Wayland, to Mutter over the session bus) and isn't free on
@@ -257,7 +259,13 @@ pub(super) async fn run_loop(app: AppHandle, sched: Scheduler) {
         // suppressions below — it's a planning nudge, not a break.
         {
             let in_work = !s.work_window_enabled
-                || in_window(now_min, s.work_start_minutes, s.work_end_minutes);
+                || work_window_active(
+                    now_min,
+                    s.work_start_minutes,
+                    s.work_end_minutes,
+                    today_weekday,
+                    s.work_days_mask,
+                );
             let mut c = sched.chores.lock().await;
             let rolled = chores::rollover_if_new_day(&mut c, &today_str);
             let prompt = chores::should_prompt_morning_chores(
@@ -308,7 +316,10 @@ pub(super) async fn run_loop(app: AppHandle, sched: Scheduler) {
 
         if let Some(outcome) = evaluate_guards(
             &s,
-            now_min,
+            TickClock {
+                now_min,
+                weekday: today_weekday,
+            },
             dnd_live,
             camera_live,
             video_live,
@@ -766,6 +777,17 @@ pub(super) struct GuardOutcome {
     pub log_as: Option<GuardReason>,
 }
 
+/// The wall-clock decomposition the guards reason about: minute-of-day
+/// and weekday (days-since-Monday, `0`=Mon … `6`=Sun), both sampled from
+/// the single `Local::now()` taken at the top of the tick. Grouped so the
+/// two related time values travel together and `evaluate_guards` stays
+/// under the positional-argument limit.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct TickClock {
+    pub now_min: u32,
+    pub weekday: u32,
+}
+
 /// Pure decision: given the per-tick guard inputs, return which
 /// `SuppressReason` should fire (if any) and whether the run-loop
 /// should also write a `GuardSuppress` event for it.
@@ -778,14 +800,22 @@ pub(super) struct GuardOutcome {
 /// and the function applies the setting gates itself.
 pub(super) fn evaluate_guards(
     s: &Settings,
-    now_min: u32,
+    clock: TickClock,
     dnd_active: bool,
     camera_active: bool,
     video_active: bool,
     app_pause_active: bool,
     plugin_suppress: bool,
 ) -> Option<GuardOutcome> {
-    if s.work_window_enabled && !in_window(now_min, s.work_start_minutes, s.work_end_minutes) {
+    if s.work_window_enabled
+        && !work_window_active(
+            clock.now_min,
+            s.work_start_minutes,
+            s.work_end_minutes,
+            clock.weekday,
+            s.work_days_mask,
+        )
+    {
         return Some(GuardOutcome {
             reason: SuppressReason::WorkWindow,
             log_as: None,
@@ -1935,11 +1965,27 @@ mod tests {
 
     const INSIDE_WORK_WINDOW: u32 = 10 * 60;
     const OUTSIDE_WORK_WINDOW: u32 = 20 * 60;
+    // Default `work_days_mask` enables every day, so the weekday passed to
+    // these time-window tests doesn't change their outcome; the day-gating
+    // behaviour gets its own dedicated tests below.
+    const ANY_WEEKDAY: u32 = 0;
 
     #[test]
     fn evaluate_guards_returns_none_when_all_off() {
         let s = settings_for_guards(false, false, false, false, false);
-        assert!(evaluate_guards(&s, INSIDE_WORK_WINDOW, true, true, true, true, false).is_none());
+        assert!(evaluate_guards(
+            &s,
+            TickClock {
+                now_min: INSIDE_WORK_WINDOW,
+                weekday: ANY_WEEKDAY
+            },
+            true,
+            true,
+            true,
+            true,
+            false
+        )
+        .is_none());
     }
 
     #[test]
@@ -1947,9 +1993,19 @@ mod tests {
         // work_window_enabled with a current minute inside [start,end)
         // is the happy path — no suppression.
         let s = settings_for_guards(true, false, false, false, false);
-        assert!(
-            evaluate_guards(&s, INSIDE_WORK_WINDOW, false, false, false, false, false).is_none()
-        );
+        assert!(evaluate_guards(
+            &s,
+            TickClock {
+                now_min: INSIDE_WORK_WINDOW,
+                weekday: ANY_WEEKDAY
+            },
+            false,
+            false,
+            false,
+            false,
+            false
+        )
+        .is_none());
     }
 
     #[test]
@@ -1957,8 +2013,19 @@ mod tests {
         // Outside-hours suppression doesn't log — it's a scheduled
         // silence, not an unexpected event.
         let s = settings_for_guards(true, false, false, false, false);
-        let outcome =
-            evaluate_guards(&s, OUTSIDE_WORK_WINDOW, false, false, false, false, false).unwrap();
+        let outcome = evaluate_guards(
+            &s,
+            TickClock {
+                now_min: OUTSIDE_WORK_WINDOW,
+                weekday: ANY_WEEKDAY,
+            },
+            false,
+            false,
+            false,
+            false,
+            false,
+        )
+        .unwrap();
         assert_eq!(outcome.reason, SuppressReason::WorkWindow);
         assert!(
             outcome.log_as.is_none(),
@@ -1967,29 +2034,117 @@ mod tests {
     }
 
     #[test]
+    fn evaluate_guards_work_window_suppresses_on_disabled_weekday() {
+        // Inside the time window, but today's weekday bit is cleared, so the
+        // work-window guard still fires (silently) — the day toggle is the
+        // new gate for #204.
+        let mut s = settings_for_guards(true, false, false, false, false);
+        s.work_days_mask = 0b001_1111; // Mon..Fri only
+        let saturday = 5;
+        let outcome = evaluate_guards(
+            &s,
+            TickClock {
+                now_min: INSIDE_WORK_WINDOW,
+                weekday: saturday,
+            },
+            false,
+            false,
+            false,
+            false,
+            false,
+        )
+        .unwrap();
+        assert_eq!(outcome.reason, SuppressReason::WorkWindow);
+        assert!(outcome.log_as.is_none());
+    }
+
+    #[test]
+    fn evaluate_guards_work_window_allows_enabled_weekday() {
+        // Same window, but a weekday whose bit is set → happy path, no guard.
+        let mut s = settings_for_guards(true, false, false, false, false);
+        s.work_days_mask = 0b001_1111; // Mon..Fri only
+        let wednesday = 2;
+        assert!(evaluate_guards(
+            &s,
+            TickClock {
+                now_min: INSIDE_WORK_WINDOW,
+                weekday: wednesday
+            },
+            false,
+            false,
+            false,
+            false,
+            false,
+        )
+        .is_none());
+    }
+
+    #[test]
     fn evaluate_guards_dnd_fires_only_when_setting_and_state_both_true() {
         let s_off = settings_for_guards(false, false, false, false, false);
-        assert!(
-            evaluate_guards(&s_off, INSIDE_WORK_WINDOW, true, false, false, false, false).is_none()
-        );
+        assert!(evaluate_guards(
+            &s_off,
+            TickClock {
+                now_min: INSIDE_WORK_WINDOW,
+                weekday: ANY_WEEKDAY
+            },
+            true,
+            false,
+            false,
+            false,
+            false
+        )
+        .is_none());
 
         let s_on = settings_for_guards(false, true, false, false, false);
-        let outcome =
-            evaluate_guards(&s_on, INSIDE_WORK_WINDOW, true, false, false, false, false).unwrap();
+        let outcome = evaluate_guards(
+            &s_on,
+            TickClock {
+                now_min: INSIDE_WORK_WINDOW,
+                weekday: ANY_WEEKDAY,
+            },
+            true,
+            false,
+            false,
+            false,
+            false,
+        )
+        .unwrap();
         assert_eq!(outcome.reason, SuppressReason::Dnd);
         assert_eq!(outcome.log_as, Some(GuardReason::Dnd));
 
         // Setting on but state false → no suppression.
-        assert!(
-            evaluate_guards(&s_on, INSIDE_WORK_WINDOW, false, false, false, false, false).is_none()
-        );
+        assert!(evaluate_guards(
+            &s_on,
+            TickClock {
+                now_min: INSIDE_WORK_WINDOW,
+                weekday: ANY_WEEKDAY
+            },
+            false,
+            false,
+            false,
+            false,
+            false
+        )
+        .is_none());
     }
 
     #[test]
     fn evaluate_guards_camera_logs_camera_reason() {
         let s = settings_for_guards(false, false, true, false, false);
-        let outcome =
-            evaluate_guards(&s, INSIDE_WORK_WINDOW, false, true, false, false, false).unwrap();
+        let outcome = evaluate_guards(
+            &s,
+            TickClock {
+                now_min: INSIDE_WORK_WINDOW,
+                weekday: ANY_WEEKDAY,
+            },
+            false,
+            true,
+            false,
+            false,
+            false,
+        )
+        .unwrap();
         assert_eq!(outcome.reason, SuppressReason::Camera);
         assert_eq!(outcome.log_as, Some(GuardReason::Camera));
     }
@@ -1997,8 +2152,19 @@ mod tests {
     #[test]
     fn evaluate_guards_video_logs_video_reason() {
         let s = settings_for_guards(false, false, false, true, false);
-        let outcome =
-            evaluate_guards(&s, INSIDE_WORK_WINDOW, false, false, true, false, false).unwrap();
+        let outcome = evaluate_guards(
+            &s,
+            TickClock {
+                now_min: INSIDE_WORK_WINDOW,
+                weekday: ANY_WEEKDAY,
+            },
+            false,
+            false,
+            true,
+            false,
+            false,
+        )
+        .unwrap();
         assert_eq!(outcome.reason, SuppressReason::Video);
         assert_eq!(outcome.log_as, Some(GuardReason::Video));
     }
@@ -2009,14 +2175,27 @@ mod tests {
         // so the guard must not fire even when app_pause_active is true.
         let mut s = settings_for_guards(false, false, false, false, true);
         s.app_pause_list.clear();
-        assert!(
-            evaluate_guards(&s, INSIDE_WORK_WINDOW, false, false, false, true, false).is_none()
-        );
+        assert!(evaluate_guards(
+            &s,
+            TickClock {
+                now_min: INSIDE_WORK_WINDOW,
+                weekday: ANY_WEEKDAY
+            },
+            false,
+            false,
+            false,
+            true,
+            false
+        )
+        .is_none());
 
         let with_target = settings_for_guards(false, false, false, false, true);
         let outcome = evaluate_guards(
             &with_target,
-            INSIDE_WORK_WINDOW,
+            TickClock {
+                now_min: INSIDE_WORK_WINDOW,
+                weekday: ANY_WEEKDAY,
+            },
             false,
             false,
             false,
@@ -2033,11 +2212,32 @@ mod tests {
         // No setting toggles plugin suppression — a true verdict suppresses,
         // a false one doesn't.
         let s = settings_for_guards(false, false, false, false, false);
-        assert!(
-            evaluate_guards(&s, INSIDE_WORK_WINDOW, false, false, false, false, false).is_none()
-        );
-        let outcome =
-            evaluate_guards(&s, INSIDE_WORK_WINDOW, false, false, false, false, true).unwrap();
+        assert!(evaluate_guards(
+            &s,
+            TickClock {
+                now_min: INSIDE_WORK_WINDOW,
+                weekday: ANY_WEEKDAY
+            },
+            false,
+            false,
+            false,
+            false,
+            false
+        )
+        .is_none());
+        let outcome = evaluate_guards(
+            &s,
+            TickClock {
+                now_min: INSIDE_WORK_WINDOW,
+                weekday: ANY_WEEKDAY,
+            },
+            false,
+            false,
+            false,
+            false,
+            true,
+        )
+        .unwrap();
         assert_eq!(outcome.reason, SuppressReason::Plugin);
         assert_eq!(outcome.log_as, Some(GuardReason::Plugin));
     }
@@ -2048,8 +2248,19 @@ mod tests {
         // firing simultaneously, work_window short-circuits the rest
         // (and stays silent, per its no-log policy).
         let s = settings_for_guards(true, true, true, true, true);
-        let outcome =
-            evaluate_guards(&s, OUTSIDE_WORK_WINDOW, true, true, true, true, false).unwrap();
+        let outcome = evaluate_guards(
+            &s,
+            TickClock {
+                now_min: OUTSIDE_WORK_WINDOW,
+                weekday: ANY_WEEKDAY,
+            },
+            true,
+            true,
+            true,
+            true,
+            false,
+        )
+        .unwrap();
         assert_eq!(outcome.reason, SuppressReason::WorkWindow);
         assert!(outcome.log_as.is_none());
     }
@@ -2058,32 +2269,76 @@ mod tests {
     fn evaluate_guards_dnd_outranks_camera_video_app_pause() {
         let s = settings_for_guards(true, true, true, true, true);
         // Inside the work window, so work_window does NOT fire.
-        let outcome =
-            evaluate_guards(&s, INSIDE_WORK_WINDOW, true, true, true, true, false).unwrap();
+        let outcome = evaluate_guards(
+            &s,
+            TickClock {
+                now_min: INSIDE_WORK_WINDOW,
+                weekday: ANY_WEEKDAY,
+            },
+            true,
+            true,
+            true,
+            true,
+            false,
+        )
+        .unwrap();
         assert_eq!(outcome.reason, SuppressReason::Dnd);
     }
 
     #[test]
     fn evaluate_guards_camera_outranks_video_and_app_pause() {
         let s = settings_for_guards(true, true, true, true, true);
-        let outcome =
-            evaluate_guards(&s, INSIDE_WORK_WINDOW, false, true, true, true, false).unwrap();
+        let outcome = evaluate_guards(
+            &s,
+            TickClock {
+                now_min: INSIDE_WORK_WINDOW,
+                weekday: ANY_WEEKDAY,
+            },
+            false,
+            true,
+            true,
+            true,
+            false,
+        )
+        .unwrap();
         assert_eq!(outcome.reason, SuppressReason::Camera);
     }
 
     #[test]
     fn evaluate_guards_video_outranks_app_pause() {
         let s = settings_for_guards(true, true, true, true, true);
-        let outcome =
-            evaluate_guards(&s, INSIDE_WORK_WINDOW, false, false, true, true, false).unwrap();
+        let outcome = evaluate_guards(
+            &s,
+            TickClock {
+                now_min: INSIDE_WORK_WINDOW,
+                weekday: ANY_WEEKDAY,
+            },
+            false,
+            false,
+            true,
+            true,
+            false,
+        )
+        .unwrap();
         assert_eq!(outcome.reason, SuppressReason::Video);
     }
 
     #[test]
     fn evaluate_guards_app_pause_only_when_higher_guards_quiet() {
         let s = settings_for_guards(true, true, true, true, true);
-        let outcome =
-            evaluate_guards(&s, INSIDE_WORK_WINDOW, false, false, false, true, false).unwrap();
+        let outcome = evaluate_guards(
+            &s,
+            TickClock {
+                now_min: INSIDE_WORK_WINDOW,
+                weekday: ANY_WEEKDAY,
+            },
+            false,
+            false,
+            false,
+            true,
+            false,
+        )
+        .unwrap();
         assert_eq!(outcome.reason, SuppressReason::AppPause);
     }
 

--- a/src-tauri/src/scheduler/settings.rs
+++ b/src-tauri/src/scheduler/settings.rs
@@ -310,6 +310,14 @@ fn default_clock_format() -> String {
     "24h".to_string()
 }
 
+/// Every weekday enabled (`0b111_1111`). The default for `work_days_mask`,
+/// so a `settings.json` written before the field existed loads as
+/// "work window applies on all seven days" — preserving the prior
+/// behaviour where the work window had no day-of-week distinction.
+fn default_work_days_mask() -> u8 {
+    0b111_1111
+}
+
 fn default_windowed_fraction() -> f64 {
     0.8
 }
@@ -475,6 +483,17 @@ pub struct Settings {
     pub work_window_enabled: bool,
     pub work_start_minutes: u32,
     pub work_end_minutes: u32,
+    /// Which weekdays the work window applies to, as a 7-bit mask: bit `i`
+    /// (`0` = Monday … `6` = Sunday, matching chrono's
+    /// `Weekday::num_days_from_monday`) set means breaks may fire on that
+    /// day. Only consulted when `work_window_enabled` is on. Defaults to
+    /// every day (`0b111_1111`) so an upgrading user — whose `settings.json`
+    /// predates this field — keeps the old "all days" behaviour. A wrapping
+    /// window (e.g. 22:00–06:00) gates its early-morning portion on the day
+    /// it *started*, not the calendar day it spills into; see
+    /// [`super::timers::work_window_active`].
+    #[serde(default = "default_work_days_mask")]
+    pub work_days_mask: u8,
     pub bedtime_enabled: bool,
     pub bedtime_start_minutes: u32,
     pub bedtime_end_minutes: u32,
@@ -658,6 +677,7 @@ impl Default for Settings {
             work_window_enabled: false,
             work_start_minutes: 9 * 60,
             work_end_minutes: 17 * 60,
+            work_days_mask: default_work_days_mask(),
             bedtime_enabled: false,
             bedtime_start_minutes: 22 * 60,
             bedtime_end_minutes: 23 * 60,
@@ -909,6 +929,11 @@ impl Settings {
         // Time-of-day windows are minutes-since-midnight (0..1439).
         self.work_start_minutes = self.work_start_minutes.min(1_439);
         self.work_end_minutes = self.work_end_minutes.min(1_439);
+        // Only the low 7 bits are meaningful weekdays; drop any stray high
+        // bits a hand-edited settings.json might set. `0` (no days) is a
+        // valid "never inside the window" state and must survive untouched —
+        // masking, not clamping, keeps it.
+        self.work_days_mask &= 0b111_1111;
         self.bedtime_start_minutes = self.bedtime_start_minutes.min(1_439);
         self.bedtime_end_minutes = self.bedtime_end_minutes.min(1_439);
         // Visual: opacity / volume in [0, 1]; font scale in [0.5, 3.0].
@@ -1190,6 +1215,10 @@ mod tests {
         assert!(s.long_enforceable);
         assert!(!s.micro_enforceable);
         assert!(s.work_end_minutes > s.work_start_minutes);
+        assert_eq!(
+            s.work_days_mask, 0b111_1111,
+            "work window defaults to every weekday enabled"
+        );
         assert!(s.overlay_opacity > 0.0 && s.overlay_opacity <= 1.0);
         assert!(s.postpone_minutes > 0);
         assert!(s.sound_volume >= 0.0 && s.sound_volume <= 1.0);
@@ -1285,6 +1314,30 @@ mod tests {
         s.clamp();
         assert!(s.work_start_minutes <= 1_439);
         assert!(s.bedtime_end_minutes <= 1_439);
+    }
+
+    #[test]
+    fn clamp_strips_stray_high_bits_from_work_days_mask() {
+        // A hand-edited settings.json could set bits above the 7 weekday
+        // bits; masking drops them so the bit-test never reads a phantom day.
+        let mut s = Settings {
+            work_days_mask: 0b1010_1010,
+            ..Settings::default()
+        };
+        s.clamp();
+        assert_eq!(s.work_days_mask, 0b010_1010);
+    }
+
+    #[test]
+    fn clamp_keeps_zero_work_days_mask_as_no_days() {
+        // 0 = "no weekday enabled" is a deliberate state (work window on but
+        // every day toggled off). Masking must not turn it into a real day.
+        let mut s = Settings {
+            work_days_mask: 0,
+            ..Settings::default()
+        };
+        s.clamp();
+        assert_eq!(s.work_days_mask, 0);
     }
 
     #[test]

--- a/src-tauri/src/scheduler/timers.rs
+++ b/src-tauri/src/scheduler/timers.rs
@@ -1,6 +1,6 @@
 use std::time::{Duration, Instant};
 
-use chrono::{Local, Timelike};
+use chrono::{Datelike, Local, Timelike};
 
 use super::types::{BreakDelivery, BreakKind};
 
@@ -177,6 +177,13 @@ pub fn local_today_string() -> String {
     Local::now().date_naive().format("%Y-%m-%d").to_string()
 }
 
+/// The current local weekday as days-since-Monday (`0` = Monday … `6` =
+/// Sunday). Matches the bit layout of `Settings::work_days_mask` so the
+/// work-window day check can index it directly.
+pub fn current_weekday() -> u32 {
+    Local::now().weekday().num_days_from_monday()
+}
+
 /// Parse `"HH:MM"` (or `"H:MM"`) into minutes since midnight.
 /// Returns `None` on anything out of range or unparseable — used to
 /// filter the user's fixed-time list without spilling errors.
@@ -223,6 +230,32 @@ pub fn in_window(now: u32, start: u32, end: u32) -> bool {
     } else {
         now >= start || now < end
     }
+}
+
+/// True iff the work window is open right now: the time-of-day is inside
+/// `[start, end)` **and** the relevant weekday's bit is set in
+/// `days_mask`. `today` is days-since-Monday (`0`=Mon … `6`=Sun), the
+/// same layout as the mask.
+///
+/// For a window that wraps past midnight (`start > end`, e.g.
+/// 22:00–06:00) the early-morning portion is gated on the day the window
+/// *began* — Friday's 22:00 shift still covers Saturday 02:00 even when
+/// Saturday is off, and an off Sunday won't start a window that bleeds
+/// into Monday morning. A window that doesn't wrap is gated on `today`.
+///
+/// `days_mask == 0` (no day enabled) always returns false; callers gate
+/// on `work_window_enabled` before reaching here, so that simply means
+/// the window never opens.
+pub fn work_window_active(now: u32, start: u32, end: u32, today: u32, days_mask: u8) -> bool {
+    if !in_window(now, start, end) {
+        return false;
+    }
+    let window_day = if start <= end || now >= start {
+        today
+    } else {
+        (today + 6) % 7
+    };
+    days_mask & (1 << window_day) != 0
 }
 
 /// True iff an interval-mode break of this kind is due to fire now.
@@ -445,6 +478,74 @@ mod tests {
     fn current_minutes_in_range() {
         let m = current_minutes();
         assert!(m < 24 * 60);
+    }
+
+    #[test]
+    fn current_weekday_in_range() {
+        assert!(current_weekday() < 7);
+    }
+
+    const ALL_DAYS: u8 = 0b111_1111;
+
+    #[test]
+    fn work_window_active_all_days_matches_in_window() {
+        // With every day enabled, the day gate is a no-op: the result is
+        // exactly `in_window` regardless of `today`.
+        for today in 0..7 {
+            assert_eq!(
+                work_window_active(800, 540, 1080, today, ALL_DAYS),
+                in_window(800, 540, 1080),
+            );
+            assert_eq!(
+                work_window_active(200, 540, 1080, today, ALL_DAYS),
+                in_window(200, 540, 1080),
+            );
+        }
+    }
+
+    #[test]
+    fn work_window_active_gates_on_enabled_day() {
+        // 09:00–17:00, weekdays only (Mon..Fri = bits 0..4).
+        let weekdays = 0b001_1111;
+        // 10:00 Wednesday (today=2) → enabled.
+        assert!(work_window_active(600, 540, 1080, 2, weekdays));
+        // 10:00 Saturday (today=5) → disabled even though inside the hours.
+        assert!(!work_window_active(600, 540, 1080, 5, weekdays));
+        // 20:00 Wednesday → outside the hours regardless of the day.
+        assert!(!work_window_active(1200, 540, 1080, 2, weekdays));
+    }
+
+    #[test]
+    fn work_window_active_empty_mask_is_never_active() {
+        for today in 0..7 {
+            assert!(!work_window_active(600, 540, 1080, today, 0));
+        }
+    }
+
+    #[test]
+    fn work_window_active_wrap_gates_morning_on_starting_day() {
+        // 22:00–06:00 window, enabled Friday only (bit 4).
+        let friday = 1 << 4;
+        // 23:00 Friday (today=4) → the window started today → active.
+        assert!(work_window_active(1380, 1320, 360, 4, friday));
+        // 02:00 Saturday (today=5) → the window started *Friday*, so it's
+        // still Friday's shift → active even though Saturday is off.
+        assert!(work_window_active(120, 1320, 360, 5, friday));
+        // 02:00 Friday (today=4) belongs to Thursday's shift → Thursday is
+        // off → not active.
+        assert!(!work_window_active(120, 1320, 360, 4, friday));
+        // 23:00 Saturday (today=5) starts Saturday's shift → off.
+        assert!(!work_window_active(1380, 1320, 360, 5, friday));
+    }
+
+    #[test]
+    fn work_window_active_wrap_sunday_to_monday_morning() {
+        // 23:00–01:00 window, enabled Sunday only (bit 6). Monday 00:30
+        // (today=0) belongs to Sunday's shift: (0 + 6) % 7 == 6 → active.
+        let sunday = 1 << 6;
+        assert!(work_window_active(30, 1380, 60, 0, sunday));
+        // Sunday 00:30 (today=6) belongs to Saturday's shift → off.
+        assert!(!work_window_active(30, 1380, 60, 6, sunday));
     }
 
     #[test]

--- a/src/lib/weekdays.test.ts
+++ b/src/lib/weekdays.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { dayActive, toggleDay, WEEKDAYS } from "./weekdays";
+
+describe("WEEKDAYS", () => {
+  it("lists Monday through Sunday with bits 0..6", () => {
+    expect(WEEKDAYS.map((d) => d.bit)).toEqual([0, 1, 2, 3, 4, 5, 6]);
+    expect(WEEKDAYS[0].name).toBe("Monday");
+    expect(WEEKDAYS[6].name).toBe("Sunday");
+  });
+});
+
+describe("dayActive", () => {
+  it("reads a single weekday bit out of the mask", () => {
+    expect(dayActive(0b000_0001, 0)).toBe(true); // Monday set
+    expect(dayActive(0b000_0001, 1)).toBe(false); // Tuesday clear
+    expect(dayActive(0b100_0000, 6)).toBe(true); // Sunday set
+  });
+
+  it("treats every bit of an all-days mask as active", () => {
+    for (const d of WEEKDAYS) {
+      expect(dayActive(0b111_1111, d.bit)).toBe(true);
+    }
+  });
+
+  it("treats every bit of an empty mask as inactive", () => {
+    for (const d of WEEKDAYS) {
+      expect(dayActive(0, d.bit)).toBe(false);
+    }
+  });
+});
+
+describe("toggleDay", () => {
+  it("flips the targeted bit and leaves the rest untouched", () => {
+    expect(toggleDay(0b111_1111, 5)).toBe(0b101_1111); // clear Saturday
+    expect(toggleDay(0b101_1111, 5)).toBe(0b111_1111); // set it back
+    expect(toggleDay(0, 0)).toBe(0b000_0001); // set Monday from empty
+  });
+
+  it("round-trips back to the original mask after two toggles", () => {
+    const mask = 0b001_1010;
+    expect(toggleDay(toggleDay(mask, 3), 3)).toBe(mask);
+  });
+});

--- a/src/lib/weekdays.ts
+++ b/src/lib/weekdays.ts
@@ -1,0 +1,24 @@
+/** Weekday metadata for the work-window day picker. `bit` matches the
+ * layout of the Rust `Settings::work_days_mask`: Monday is bit 0, Sunday
+ * is bit 6 (days-since-Monday). */
+export type Weekday = { bit: number; abbr: string; name: string };
+
+export const WEEKDAYS: Weekday[] = [
+  { bit: 0, abbr: "Mon", name: "Monday" },
+  { bit: 1, abbr: "Tue", name: "Tuesday" },
+  { bit: 2, abbr: "Wed", name: "Wednesday" },
+  { bit: 3, abbr: "Thu", name: "Thursday" },
+  { bit: 4, abbr: "Fri", name: "Friday" },
+  { bit: 5, abbr: "Sat", name: "Saturday" },
+  { bit: 6, abbr: "Sun", name: "Sunday" },
+];
+
+/** True iff the weekday `bit` is enabled in `mask`. */
+export function dayActive(mask: number, bit: number): boolean {
+  return (mask & (1 << bit)) !== 0;
+}
+
+/** Return `mask` with the weekday `bit` flipped. */
+export function toggleDay(mask: number, bit: number): number {
+  return mask ^ (1 << bit);
+}

--- a/src/views/settings/components/weekday-toggle.tsx
+++ b/src/views/settings/components/weekday-toggle.tsx
@@ -1,0 +1,54 @@
+import type { ReactNode } from "react";
+import { dayActive, toggleDay, WEEKDAYS } from "../../../lib/weekdays";
+import { InfoTip } from "./info-tip";
+
+export type WeekdayToggleProps = {
+  label: ReactNode;
+  /** 7-bit weekday mask (bit 0 = Monday … bit 6 = Sunday). */
+  mask: number;
+  onChange: (next: number) => void;
+  disabled?: boolean;
+  tip?: string;
+};
+
+/** A row of seven toggle buttons for picking which weekdays the work
+ * window applies to. Each button is a labelled `aria-pressed` toggle so
+ * screen-reader and keyboard users get the full state and a focus path. */
+export function WeekdayToggle({
+  label,
+  mask,
+  onChange,
+  disabled,
+  tip,
+}: WeekdayToggleProps) {
+  return (
+    <div className={`row weekday-row${disabled ? " disabled" : ""}`}>
+      <span>
+        {label}
+        {tip && <InfoTip text={tip} />}
+      </span>
+      <div
+        className="weekday-toggle"
+        role="group"
+        aria-label="Days the work window applies to"
+      >
+        {WEEKDAYS.map((day) => {
+          const active = dayActive(mask, day.bit);
+          return (
+            <button
+              key={day.bit}
+              type="button"
+              className={`weekday-chip${active ? " active" : ""}`}
+              aria-pressed={active}
+              aria-label={day.name}
+              disabled={disabled}
+              onClick={() => onChange(toggleDay(mask, day.bit))}
+            >
+              {day.abbr}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/views/settings/hooks/use-settings.ts
+++ b/src/views/settings/hooks/use-settings.ts
@@ -76,6 +76,7 @@ export const schedulerSettingsSchema = z.object({
   work_window_enabled: z.boolean(),
   work_start_minutes: z.number(),
   work_end_minutes: z.number(),
+  work_days_mask: z.number(),
   bedtime_enabled: z.boolean(),
   bedtime_start_minutes: z.number(),
   bedtime_end_minutes: z.number(),

--- a/src/views/settings/settings.css
+++ b/src/views/settings/settings.css
@@ -367,6 +367,39 @@ body,
   font-style: italic;
 }
 
+.settings .weekday-toggle {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.settings .weekday-chip {
+  min-width: 2.7rem;
+  padding: 0.3rem 0.55rem;
+  background: var(--input-bg);
+  color: var(--fg);
+  border: 1px solid var(--input-border);
+  border-radius: 999px;
+  font-size: 0.85rem;
+  font-weight: 400;
+}
+
+.settings .weekday-chip:hover:not(:disabled) {
+  background: var(--input-hover);
+  border-color: var(--accent);
+}
+
+.settings .weekday-chip.active {
+  background: var(--accent-strong, var(--accent));
+  border-color: var(--accent-strong, var(--accent));
+  color: white;
+}
+
+.settings .weekday-chip:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+
 .settings .hint-label {
   font-size: 0.85rem;
   color: var(--muted-fg);

--- a/src/views/settings/tabs/schedule-tab.test.tsx
+++ b/src/views/settings/tabs/schedule-tab.test.tsx
@@ -83,3 +83,39 @@ describe("ScheduleTab per-break postpone & skip", () => {
     expect(screen.queryByText("Skip long breaks")).toBeNull();
   });
 });
+
+describe("ScheduleTab active-hours weekday picker", () => {
+  it("renders a labelled toggle for each weekday reflecting the mask", () => {
+    // 0b001_1111 = Mon..Fri on, Sat/Sun off.
+    renderTab(() => {}, {
+      work_window_enabled: true,
+      work_days_mask: 0b001_1111,
+    });
+    const monday = screen.getByRole("button", { name: "Monday" });
+    const saturday = screen.getByRole("button", { name: "Saturday" });
+    expect(monday.getAttribute("aria-pressed")).toBe("true");
+    expect(saturday.getAttribute("aria-pressed")).toBe("false");
+  });
+
+  it("clicking a day toggles its bit via update", () => {
+    const update = vi.fn();
+    renderTab(update, {
+      work_window_enabled: true,
+      work_days_mask: 0b111_1111,
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Saturday" }));
+    // Saturday is bit 5: 0b111_1111 ^ (1 << 5) = 0b101_1111 = 95.
+    expect(update).toHaveBeenCalledWith("work_days_mask", 0b101_1111);
+  });
+
+  it("disables the day toggles when the work window is off", () => {
+    renderTab(() => {}, {
+      work_window_enabled: false,
+      work_days_mask: 0b111_1111,
+    });
+    expect(
+      (screen.getByRole("button", { name: "Monday" }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
+  });
+});

--- a/src/views/settings/tabs/schedule-tab.tsx
+++ b/src/views/settings/tabs/schedule-tab.tsx
@@ -6,6 +6,7 @@ import { Advanced } from "../components/advanced";
 import { BreakModeRow } from "../components/break-mode-row";
 import { CheckboxRow, NumberRow, TimeRow } from "../components/rows";
 import { SoundControls } from "../components/sound-controls";
+import { WeekdayToggle } from "../components/weekday-toggle";
 import type { UseSettings } from "../hooks/use-settings";
 import { useScreenTime } from "../hooks/use-screen-time";
 import type { SchedulerSettings, SupporterStatus } from "../types";
@@ -56,6 +57,13 @@ export function ScheduleTab({
           onChange={(v) => update("work_end_minutes", v)}
           disabled={!settings.work_window_enabled}
           format={settings.clock_format}
+        />
+        <WeekdayToggle
+          label="On these days"
+          mask={settings.work_days_mask}
+          onChange={(v) => update("work_days_mask", v)}
+          disabled={!settings.work_window_enabled}
+          tip="Breaks only fire within the hours above on the selected days — turn off weekends so Entracte stays quiet while you game or relax. A window that runs past midnight (e.g. 22:00–06:00) counts the early-morning hours as part of the day it started."
         />
       </section>
 

--- a/src/views/settings/types.ts
+++ b/src/views/settings/types.ts
@@ -132,6 +132,9 @@ export type SchedulerSettings = {
   work_window_enabled: boolean;
   work_start_minutes: number;
   work_end_minutes: number;
+  /** 7-bit weekday mask for the work window: bit 0 = Monday … bit 6 =
+   * Sunday. Only consulted when `work_window_enabled` is true. */
+  work_days_mask: number;
   bedtime_enabled: boolean;
   bedtime_start_minutes: number;
   bedtime_end_minutes: number;


### PR DESCRIPTION
Closes #204.

## Summary

The work window had no day-of-week distinction, so users who only want breaks while working had no way to keep Entracte quiet while gaming or relaxing at the weekend. This adds an **"On these days"** picker to the Schedule tab's Active hours.

- **Backend**: new `work_days_mask: u8` on `Settings` (bit 0 = Mon … bit 6 = Sun), defaulting to every day so upgrading users are unchanged; clamped by *masking* the low 7 bits so a deliberate "no days" state survives. New pure `timers::work_window_active` combines the time-of-day window with the weekday gate — a window that wraps past midnight (e.g. 22:00–06:00) gates its early-morning hours on the day it *started*. The current weekday threads into `evaluate_guards` (grouped into a `TickClock` so the function stays under clippy's arg limit) and the morning-chore prompt.
- **Frontend**: a `WeekdayToggle` of labelled `aria-pressed` toggle buttons; `work_days_mask` added to the TS `SchedulerSettings`, the zod schema, and both serde fixtures (round-trip + a11y).

## Verification

- Rust: `cargo fmt --check`, `cargo clippy --all-targets -D warnings`, `cargo test --lib` (1148) — green. New tests cover `work_window_active` (incl. wrap-around and empty-mask), `evaluate_guards` day-gating (enabled vs disabled weekday), and clamp masking + zero-preservation + default sanity.
- Frontend: `tsc --noEmit`, `npm test` (744), `npm run build`, `npm run audit:a11y` (axe clean across 16 surface×scheme), eslint/prettier/cspell/knip — all clean. New tests cover the weekday helper module and the schedule-tab picker (render, toggle→update, disabled state).
- Manual UI walk on macOS.

## Coverage note (codecov/patch)

`codecov/patch` is red by ~3 lines, all in the 1Hz scheduler tick body in `run_loop.rs`: `let today_weekday = current_weekday();`, the `work_window_active(…)` call in the morning-chore-prompt block, and the `evaluate_guards(&s, TickClock { … }, …)` call site. These run only inside `run()`, which needs a live `AppHandle` — the repo has no scheduler integration harness and AGENTS scopes `AppHandle`-bound loop code out of unit tests. All the *logic* behind those calls (`work_window_active`, `evaluate_guards`, the day-gating, the clamp) is fully unit-tested; the diff is the minimal wiring to reach it. This is the sanctioned **admin-merge** of `codecov/patch` for not-unit-reachable loop wiring (same class as prior ticker/probe PRs), not a relaxation of the 100% target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)