### PR TITLE
fix(settings): tolerate unknown routine category/difficulty on load (#212)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Versions on the `0.0.X` line are public beta releases; `0.1.X` and onwards will 
 
 - **Active hours can target specific weekdays.** The Schedule tab's **Active hours** section gains an **On these days** picker, so the work window can apply only on the days you actually work — turn off Saturday and Sunday and Entracte stays quiet while you game or relax at the weekend, no need to remember to pause it. Defaults to every day, so existing setups are unchanged on upgrade. A window that runs past midnight (e.g. 22:00–06:00) counts its early-morning hours as part of the day it started. ([#204](https://github.com/drmowinckels/entracte/issues/204))
 
+### Fixed
+
+- **A stale routine filter no longer resets your whole profile.** The guided-routine **category** and **maximum difficulty** filters are stored by name; if `settings.json` carried a value an older or hand-edited build didn't recognise, the entire profile failed to load and silently reverted to defaults. Unknown categories are now dropped from the filter list and an unknown maximum difficulty falls back to its default, so the rest of your settings load untouched. Content packs stay strict — an unrecognised value there is still rejected as a malformed pack. ([#212](https://github.com/drmowinckels/entracte/issues/212))
+
 ## [0.0.7] — 2026-06-15
 
 ### Added

--- a/src-tauri/src/scheduler/content_pack.rs
+++ b/src-tauri/src/scheduler/content_pack.rs
@@ -434,6 +434,39 @@ mod tests {
         assert!(parse_pack("{ not json").is_err());
     }
 
+    // Settings load tolerates unknown routine category/difficulty values
+    // (#212), but content packs must stay strict — a pack is curated data, so
+    // an unrecognised enum is a malformed file, not something to silently
+    // coerce. Routines parse through the derived `Deserialize`, so these are
+    // rejected at parse time with a clear message.
+    #[test]
+    fn parse_rejects_routine_with_unknown_category() {
+        let json = r#"{
+            "version": 1,
+            "name": "Bad pack",
+            "routines": [{
+                "id": "r1", "label": "R", "kind": "micro",
+                "category": "telepathy", "difficulty": "gentle",
+                "steps": [{"text": "x", "seconds": 5}]
+            }]
+        }"#;
+        assert!(parse_pack(json).is_err());
+    }
+
+    #[test]
+    fn parse_rejects_routine_with_unknown_difficulty() {
+        let json = r#"{
+            "version": 1,
+            "name": "Bad pack",
+            "routines": [{
+                "id": "r1", "label": "R", "kind": "micro",
+                "category": "eyes", "difficulty": "extreme",
+                "steps": [{"text": "x", "seconds": 5}]
+            }]
+        }"#;
+        assert!(parse_pack(json).is_err());
+    }
+
     #[test]
     fn validate_rejects_wrong_version() {
         let mut p = pack_with(vec![], PackHints::default());

--- a/src-tauri/src/scheduler/routines.rs
+++ b/src-tauri/src/scheduler/routines.rs
@@ -41,6 +41,23 @@ pub enum RoutineCategory {
     DeskYoga,
 }
 
+impl RoutineCategory {
+    /// Parse the on-disk (snake_case) string; `None` for an unknown value so
+    /// a stale, hand-edited, or future category can be dropped from a
+    /// settings filter list rather than failing the whole profile load
+    /// (#212). Content packs parse routines through the strict derived
+    /// `Deserialize`, so a bad category there is still rejected.
+    pub(crate) fn from_disk_str(raw: &str) -> Option<Self> {
+        match raw {
+            "eyes" => Some(Self::Eyes),
+            "mobility" => Some(Self::Mobility),
+            "breathing" => Some(Self::Breathing),
+            "desk_yoga" => Some(Self::DeskYoga),
+            _ => None,
+        }
+    }
+}
+
 /// How demanding a routine is. Ordered `Gentle < Moderate < Active`; the
 /// per-kind `*_routine_max_difficulty` filter includes everything up to and
 /// including the chosen level.
@@ -59,6 +76,20 @@ impl RoutineDifficulty {
             Self::Gentle => 1,
             Self::Moderate => 2,
             Self::Active => 3,
+        }
+    }
+
+    /// Parse the on-disk (lowercase) string; `None` for an unknown value so a
+    /// stale `*_routine_max_difficulty` falls back to the default instead of
+    /// failing the whole profile load (#212). Content packs parse routines
+    /// through the strict derived `Deserialize`, so a bad difficulty there is
+    /// still rejected.
+    pub(crate) fn from_disk_str(raw: &str) -> Option<Self> {
+        match raw {
+            "gentle" => Some(Self::Gentle),
+            "moderate" => Some(Self::Moderate),
+            "active" => Some(Self::Active),
+            _ => None,
         }
     }
 }
@@ -377,6 +408,43 @@ pub async fn get_routines(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn routine_category_from_disk_str_round_trips_every_variant() {
+        for (raw, want) in [
+            ("eyes", RoutineCategory::Eyes),
+            ("mobility", RoutineCategory::Mobility),
+            ("breathing", RoutineCategory::Breathing),
+            ("desk_yoga", RoutineCategory::DeskYoga),
+        ] {
+            assert_eq!(RoutineCategory::from_disk_str(raw), Some(want));
+        }
+    }
+
+    #[test]
+    fn routine_category_from_disk_str_rejects_unknown() {
+        assert_eq!(RoutineCategory::from_disk_str("telepathy"), None);
+        assert_eq!(RoutineCategory::from_disk_str("Eyes"), None);
+        assert_eq!(RoutineCategory::from_disk_str(""), None);
+    }
+
+    #[test]
+    fn routine_difficulty_from_disk_str_round_trips_every_variant() {
+        for (raw, want) in [
+            ("gentle", RoutineDifficulty::Gentle),
+            ("moderate", RoutineDifficulty::Moderate),
+            ("active", RoutineDifficulty::Active),
+        ] {
+            assert_eq!(RoutineDifficulty::from_disk_str(raw), Some(want));
+        }
+    }
+
+    #[test]
+    fn routine_difficulty_from_disk_str_rejects_unknown() {
+        assert_eq!(RoutineDifficulty::from_disk_str("extreme"), None);
+        assert_eq!(RoutineDifficulty::from_disk_str("Gentle"), None);
+        assert_eq!(RoutineDifficulty::from_disk_str(""), None);
+    }
 
     #[test]
     fn starter_routines_have_unique_nonempty_ids_and_steps() {

--- a/src-tauri/src/scheduler/settings.rs
+++ b/src-tauri/src/scheduler/settings.rs
@@ -296,12 +296,21 @@ where
 
 /// Deserialise a `*_routine_categories` filter list permissively: unknown
 /// entries are dropped (each with a logged warning) instead of failing the
-/// whole profile load (#212). An empty result still means "all categories".
+/// whole profile load (#212). A wholly malformed value (not an array of
+/// strings) degrades to an empty list rather than failing the load — matching
+/// the difficulty handler's tolerance. An empty result still means "all
+/// categories".
 fn deserialize_routine_categories<'de, D>(deserializer: D) -> Result<Vec<RoutineCategory>, D::Error>
 where
     D: Deserializer<'de>,
 {
-    let raw = Vec::<String>::deserialize(deserializer)?;
+    let raw = match Vec::<String>::deserialize(deserializer) {
+        Ok(raw) => raw,
+        Err(_) => {
+            warn!("settings: routine categories not an array of strings — falling back to all");
+            return Ok(Vec::new());
+        }
+    };
     Ok(raw
         .into_iter()
         .filter_map(|s| {
@@ -1963,6 +1972,20 @@ mod tests {
             s.micro_routine_max_difficulty,
             default_routine_max_difficulty()
         );
+    }
+
+    #[test]
+    fn malformed_routine_categories_fall_back_to_all_not_a_failed_load() {
+        // Not an array, and an array with a non-string element: both degrade
+        // to "all categories" rather than failing the whole profile load.
+        let not_array = r#"{"micro_interval_secs": 99, "micro_routine_categories": "eyes"}"#;
+        let s: Settings = serde_json::from_str(not_array).unwrap();
+        assert_eq!(s.micro_interval_secs, 99);
+        assert!(s.micro_routine_categories.is_empty());
+
+        let bad_element = r#"{"long_routine_categories": ["eyes", 42]}"#;
+        let s: Settings = serde_json::from_str(bad_element).unwrap();
+        assert!(s.long_routine_categories.is_empty());
     }
 
     #[test]

--- a/src-tauri/src/scheduler/settings.rs
+++ b/src-tauri/src/scheduler/settings.rs
@@ -273,6 +273,47 @@ where
     })
 }
 
+/// Deserialise a `*_routine_max_difficulty` permissively: an unknown value
+/// (stale, hand-edited, or from a future build) falls back to the default
+/// rather than failing the whole profile load (#212). Mirrors the
+/// [`deserialize_with_fallback`] behaviour, but the fallback is the field's
+/// own default since [`RoutineDifficulty`] has no `Default`.
+fn deserialize_routine_max_difficulty<'de, D>(
+    deserializer: D,
+) -> Result<RoutineDifficulty, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let raw = match String::deserialize(deserializer) {
+        Ok(raw) => raw,
+        Err(_) => return Ok(default_routine_max_difficulty()),
+    };
+    Ok(RoutineDifficulty::from_disk_str(&raw).unwrap_or_else(|| {
+        warn!("settings: unknown routine_max_difficulty value {raw:?} — falling back to default");
+        default_routine_max_difficulty()
+    }))
+}
+
+/// Deserialise a `*_routine_categories` filter list permissively: unknown
+/// entries are dropped (each with a logged warning) instead of failing the
+/// whole profile load (#212). An empty result still means "all categories".
+fn deserialize_routine_categories<'de, D>(deserializer: D) -> Result<Vec<RoutineCategory>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let raw = Vec::<String>::deserialize(deserializer)?;
+    Ok(raw
+        .into_iter()
+        .filter_map(|s| {
+            let parsed = RoutineCategory::from_disk_str(&s);
+            if parsed.is_none() {
+                warn!("settings: dropping unknown routine category {s:?}");
+            }
+            parsed
+        })
+        .collect())
+}
+
 /// Per-break-kind audio configuration: mode + which bundled sound to play.
 /// `sound_id` is the numeric id from `src/assets/sounds/credits.json`, or
 /// the literal `"custom"` to use `custom_path` (a Supporter-pack feature).
@@ -582,13 +623,19 @@ pub struct Settings {
     /// Engine filters, applied only when the matching `*_routine` is
     /// `"random"`: the categories to draw from (empty = all) and the maximum
     /// difficulty to include.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_routine_categories")]
     pub micro_routine_categories: Vec<RoutineCategory>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_routine_categories")]
     pub long_routine_categories: Vec<RoutineCategory>,
-    #[serde(default = "default_routine_max_difficulty")]
+    #[serde(
+        default = "default_routine_max_difficulty",
+        deserialize_with = "deserialize_routine_max_difficulty"
+    )]
     pub micro_routine_max_difficulty: RoutineDifficulty,
-    #[serde(default = "default_routine_max_difficulty")]
+    #[serde(
+        default = "default_routine_max_difficulty",
+        deserialize_with = "deserialize_routine_max_difficulty"
+    )]
     pub long_routine_max_difficulty: RoutineDifficulty,
     /// User routines imported from content packs (#155), added to the bundled
     /// starters by [`super::routines::all_routines`]. Empty by default.
@@ -1861,6 +1908,61 @@ mod tests {
         assert_eq!(s.micro_break_mode, BreakMode::Windowed);
         assert_eq!(s.micro_schedule_mode, ScheduleMode::Fixed);
         assert_eq!(s.long_hint_mix, HintMix::Social);
+    }
+
+    #[test]
+    fn corrupt_routine_max_difficulty_falls_back_to_default_on_load() {
+        let json =
+            r#"{"micro_routine_max_difficulty": "garbage", "long_routine_max_difficulty": 7}"#;
+        let s: Settings = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            s.micro_routine_max_difficulty,
+            default_routine_max_difficulty()
+        );
+        assert_eq!(
+            s.long_routine_max_difficulty,
+            default_routine_max_difficulty()
+        );
+    }
+
+    #[test]
+    fn known_routine_max_difficulty_deserialises_to_its_variant() {
+        let json = r#"{"micro_routine_max_difficulty": "gentle", "long_routine_max_difficulty": "moderate"}"#;
+        let s: Settings = serde_json::from_str(json).unwrap();
+        assert_eq!(s.micro_routine_max_difficulty, RoutineDifficulty::Gentle);
+        assert_eq!(s.long_routine_max_difficulty, RoutineDifficulty::Moderate);
+    }
+
+    #[test]
+    fn unknown_routine_categories_are_dropped_keeping_the_known_ones() {
+        let json = r#"{
+            "micro_routine_categories": ["eyes", "telepathy", "mobility"],
+            "long_routine_categories": ["sky_diving"]
+        }"#;
+        let s: Settings = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            s.micro_routine_categories,
+            vec![RoutineCategory::Eyes, RoutineCategory::Mobility]
+        );
+        assert!(s.long_routine_categories.is_empty());
+    }
+
+    #[test]
+    fn one_bad_routine_enum_does_not_reset_the_whole_profile() {
+        let json = r#"{
+            "micro_interval_secs": 1234,
+            "micro_routine": "random",
+            "micro_routine_categories": ["eyes", "bogus"],
+            "micro_routine_max_difficulty": "bogus"
+        }"#;
+        let s: Settings = serde_json::from_str(json).unwrap();
+        assert_eq!(s.micro_interval_secs, 1234);
+        assert_eq!(s.micro_routine, "random");
+        assert_eq!(s.micro_routine_categories, vec![RoutineCategory::Eyes]);
+        assert_eq!(
+            s.micro_routine_max_difficulty,
+            default_routine_max_difficulty()
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

A stale, hand-edited, or future-build value in a guided-routine filter field (`micro/long_routine_categories`, `micro/long_routine_max_difficulty`) would fail the whole `Settings` deserialize and silently reset **every** setting to defaults. This makes those two fields tolerant on load, mirroring the existing `break_mode` / `hint_mix` / `schedule_mode` fallback behaviour:

- **Unknown categories** are dropped from the filter list (each with a logged warning); an empty list still means "all categories".
- **An unknown maximum difficulty** falls back to its default (`Active`); a non-string value (null/number) does too.
- The rest of the profile now loads untouched instead of reverting wholesale.

Content packs are intentionally **not** loosened — routines still parse through the strict derived `Deserialize`, so an unrecognised category/difficulty in a pack is rejected as malformed (a pack is curated data, not something to silently coerce).

Implementation: field-level `#[serde(deserialize_with = …)]` on the four settings fields plus `RoutineCategory::from_disk_str` / `RoutineDifficulty::from_disk_str`. The enum derives stay strict, so content-pack parsing is unchanged. Frontend is unaffected — `get_settings` deserializes on the Rust side first, so the renderer only ever receives cleaned values.

## Test Plan

- `routines.rs`: `from_disk_str` round-trips every variant and rejects unknown/wrong-case/empty for both enums.
- `settings.rs`: corrupt difficulty falls back to default; known difficulty deserialises; unknown categories are dropped keeping the known ones; one bad routine enum does not reset the rest of the profile.
- `content_pack.rs`: regression guards — a pack with an unknown category or difficulty is still rejected at parse.
- `cargo test --lib` = 1158 passed; `cargo fmt --check` clean; `cargo clippy --all-targets` clean.

Closes #212

🤖 Generated with [Claude Code](https://claude.com/claude-code)