### PR TITLE
fix(hooks): bound the hook test-run output capture (#213)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Versions on the `0.0.X` line are public beta releases; `0.1.X` and onwards will 
 ### Fixed
 
 - **A stale routine filter no longer resets your whole profile.** The guided-routine **category** and **maximum difficulty** filters are stored by name; if `settings.json` carried a value an older or hand-edited build didn't recognise, the entire profile failed to load and silently reverted to defaults. Unknown categories are now dropped from the filter list and an unknown maximum difficulty falls back to its default, so the rest of your settings load untouched. Content packs stay strict — an unrecognised value there is still rejected as a malformed pack. ([#212](https://github.com/drmowinckels/entracte/issues/212))
+- **The hook Test button can't be flooded into hogging memory.** Testing an event-hook command captures its output to show you stdout/stderr; a command that spewed output could previously buffer all of it in memory before it was trimmed for display. The capture is now bounded as it's read — the command still runs to completion and you still see its (truncated) output, but a runaway never balloons memory. ([#213](https://github.com/drmowinckels/entracte/issues/213))
 
 ## [0.0.7] — 2026-06-15
 

--- a/src-tauri/src/hooks.rs
+++ b/src-tauri/src/hooks.rs
@@ -341,7 +341,10 @@ pub fn run_command_capture(
     for (k, v) in env {
         cmd.env(k, v);
     }
-    match cmd.output_timeout(timeout) {
+    // Cap the capture one byte past the display limit so a flood is bounded
+    // at the read layer (#213) while `truncate_output` can still tell the
+    // output overran and add its marker.
+    match cmd.output_timeout_capped(timeout, MAX_TEST_OUTPUT_BYTES + 1) {
         Ok(output) => HookTestOutcome {
             ok: true,
             exit_code: output.status.code(),
@@ -930,6 +933,29 @@ mod tests {
                 run_command_capture("/bin/sh -c \"sleep 5\"", &[], Duration::from_millis(200));
             assert!(!outcome.ok);
             assert!(outcome.error.unwrap().contains("still running"));
+        }
+
+        #[test]
+        fn truncates_and_bounds_a_high_volume_command() {
+            // `yes` floods until `head` closes the pipe at 100 KiB — far past
+            // the 8 KiB display cap. The capture is bounded at the read layer
+            // (#213), so the command still completes and the output carries
+            // the truncation marker instead of the whole flood.
+            let outcome = run_command_capture(
+                r#"/bin/sh -c "yes entracte | head -c 100000""#,
+                &[],
+                Duration::from_secs(5),
+            );
+            assert!(outcome.ok, "command should complete, got {outcome:?}");
+            assert!(
+                outcome.stdout.contains("…[truncated]"),
+                "expected a truncation marker"
+            );
+            assert!(
+                outcome.stdout.len() <= MAX_TEST_OUTPUT_BYTES + 16,
+                "captured output should stay bounded, was {} bytes",
+                outcome.stdout.len()
+            );
         }
     }
 }

--- a/src-tauri/src/hooks.rs
+++ b/src-tauri/src/hooks.rs
@@ -937,10 +937,10 @@ mod tests {
 
         #[test]
         fn truncates_and_bounds_a_high_volume_command() {
-            // `yes` floods until `head` closes the pipe at 100 KiB — far past
-            // the 8 KiB display cap. The capture is bounded at the read layer
-            // (#213), so the command still completes and the output carries
-            // the truncation marker instead of the whole flood.
+            // End-to-end smoke test that a flood still completes and is
+            // marked truncated: `yes` floods until `head` closes the pipe at
+            // 100 KiB, far past the 8 KiB display cap. The read-layer bounding
+            // itself is unit-tested in `proc::read_capped_*`.
             let outcome = run_command_capture(
                 r#"/bin/sh -c "yes entracte | head -c 100000""#,
                 &[],

--- a/src-tauri/src/hooks.rs
+++ b/src-tauri/src/hooks.rs
@@ -951,10 +951,10 @@ mod tests {
                 outcome.stdout.contains("…[truncated]"),
                 "expected a truncation marker"
             );
+            let len = outcome.stdout.len();
             assert!(
-                outcome.stdout.len() <= MAX_TEST_OUTPUT_BYTES + 16,
-                "captured output should stay bounded, was {} bytes",
-                outcome.stdout.len()
+                len <= MAX_TEST_OUTPUT_BYTES + 16,
+                "capture not bounded: {len} bytes"
             );
         }
     }

--- a/src-tauri/src/proc.rs
+++ b/src-tauri/src/proc.rs
@@ -69,13 +69,17 @@ fn read_capped(mut reader: impl Read, cap: Option<usize>) -> Vec<u8> {
     let mut chunk = [0u8; READ_CHUNK];
     loop {
         match reader.read(&mut chunk) {
-            Ok(0) | Err(_) => break,
+            Ok(0) => break,
             Ok(n) => {
                 if buf.len() < cap {
                     let room = cap - buf.len();
                     buf.extend_from_slice(&chunk[..n.min(room)]);
                 }
             }
+            // Retry on EINTR like `read_to_end` does, so a stray signal
+            // mid-read doesn't look like EOF and stop the drain early.
+            Err(ref e) if e.kind() == io::ErrorKind::Interrupted => continue,
+            Err(_) => break,
         }
     }
     buf
@@ -171,6 +175,30 @@ mod tests {
     fn read_capped_passes_short_input_through() {
         let out = read_capped(io::Cursor::new(b"hello".to_vec()), Some(8193));
         assert_eq!(out, b"hello");
+    }
+
+    #[test]
+    fn read_capped_retries_on_interrupted() {
+        // A reader that returns EINTR once before its data. The retry branch
+        // must keep reading rather than treating EINTR as EOF (which would
+        // return an empty buffer).
+        struct Flaky {
+            step: u8,
+        }
+        impl Read for Flaky {
+            fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+                self.step += 1;
+                match self.step {
+                    1 => Err(io::Error::from(io::ErrorKind::Interrupted)),
+                    2 => {
+                        buf[..3].copy_from_slice(b"abc");
+                        Ok(3)
+                    }
+                    _ => Ok(0),
+                }
+            }
+        }
+        assert_eq!(read_capped(Flaky { step: 0 }, Some(8)), b"abc");
     }
 
     #[test]

--- a/src-tauri/src/proc.rs
+++ b/src-tauri/src/proc.rs
@@ -202,6 +202,19 @@ mod tests {
     }
 
     #[test]
+    fn read_capped_stops_on_a_hard_error() {
+        // A non-Interrupted error ends the drain (returning what was read so
+        // far) rather than looping — distinct from the EINTR retry above.
+        struct Boom;
+        impl Read for Boom {
+            fn read(&mut self, _: &mut [u8]) -> io::Result<usize> {
+                Err(io::Error::from(io::ErrorKind::BrokenPipe))
+            }
+        }
+        assert!(read_capped(Boom, Some(8)).is_empty());
+    }
+
+    #[test]
     fn read_capped_drains_the_reader_past_the_cap() {
         // Even once the retained buffer fills at `cap`, the reader is consumed
         // to EOF — so a real child pipe never blocks on a full buffer. The

--- a/src-tauri/src/proc.rs
+++ b/src-tauri/src/proc.rs
@@ -52,63 +52,137 @@ pub fn reap_or_kill(child: &mut Child, timeout: Duration) -> io::Result<Option<E
     wait_until(child, Instant::now() + timeout)
 }
 
+/// Read `reader` to EOF, retaining at most `cap` bytes when `Some`.
+///
+/// With `None` this is a plain `read_to_end`. With `Some(cap)` it still
+/// drains the pipe to EOF — so the child never blocks on a full pipe, which
+/// would turn a chatty-but-brief command into a spurious timeout — but
+/// discards everything past `cap` so a command that floods its output can't
+/// balloon memory before the caller truncates it (#213).
+fn read_capped(mut reader: impl Read, cap: Option<usize>) -> Vec<u8> {
+    let Some(cap) = cap else {
+        let mut buf = Vec::new();
+        let _ = reader.read_to_end(&mut buf);
+        return buf;
+    };
+    let mut buf = Vec::with_capacity(cap.min(READ_CHUNK));
+    let mut chunk = [0u8; READ_CHUNK];
+    loop {
+        match reader.read(&mut chunk) {
+            Ok(0) | Err(_) => break,
+            Ok(n) => {
+                if buf.len() < cap {
+                    let room = cap - buf.len();
+                    buf.extend_from_slice(&chunk[..n.min(room)]);
+                }
+            }
+        }
+    }
+    buf
+}
+
+/// Scratch buffer size for the draining read loop.
+const READ_CHUNK: usize = 8 * 1024;
+
+/// Spawn `cmd`, capture its output bounded by the wait `timeout` and an
+/// optional per-stream byte `cap`, killing and reaping the child on overrun.
+fn spawn_and_capture(
+    cmd: &mut Command,
+    timeout: Duration,
+    cap: Option<usize>,
+) -> io::Result<Output> {
+    cmd.stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let mut child = cmd.spawn()?;
+
+    let child_stdout = child.stdout.take().expect("stdout piped above");
+    let child_stderr = child.stderr.take().expect("stderr piped above");
+    let stdout_reader = thread::spawn(move || read_capped(child_stdout, cap));
+    let stderr_reader = thread::spawn(move || read_capped(child_stderr, cap));
+
+    let Some(status) = wait_until(&mut child, Instant::now() + timeout)? else {
+        // Timed out: the child was killed and reaped. Deliberately don't
+        // join the reader threads — a killed process whose child inherited
+        // the pipe (e.g. a shell that spawned the real tool) can keep them
+        // blocked on `read_to_end`, and the caller must not wait on that.
+        // Dropping the handles detaches them; a reader then outlives this
+        // call until its pipe write-end finally closes — for a wedged
+        // pipe-holding grandchild, only when that process dies or the app
+        // exits. An accepted, bounded cost on the probe path (the probed
+        // tools don't fork such children), not a guarantee of prompt
+        // cleanup.
+        return Err(io::Error::new(
+            io::ErrorKind::TimedOut,
+            "command exceeded timeout",
+        ));
+    };
+
+    let stdout = stdout_reader.join().unwrap_or_default();
+    let stderr = stderr_reader.join().unwrap_or_default();
+    Ok(Output {
+        status,
+        stdout,
+        stderr,
+    })
+}
+
 /// Drop-in replacement for [`Command::output`] that bounds the wait.
 pub trait CommandTimeoutExt {
     /// Run the command to completion, capturing its output, but kill it and
     /// return a `TimedOut` error if it runs longer than `timeout`.
     fn output_timeout(&mut self, timeout: Duration) -> io::Result<Output>;
+
+    /// Like [`output_timeout`](Self::output_timeout) but retains at most
+    /// `cap` bytes of each of stdout/stderr, draining and discarding the
+    /// rest. Bounds memory on the capture path (the hook Test button) so a
+    /// flooding command can't balloon the buffer before truncation (#213).
+    fn output_timeout_capped(&mut self, timeout: Duration, cap: usize) -> io::Result<Output>;
 }
 
 impl CommandTimeoutExt for Command {
     fn output_timeout(&mut self, timeout: Duration) -> io::Result<Output> {
-        self.stdin(Stdio::null())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped());
-        let mut child = self.spawn()?;
+        spawn_and_capture(self, timeout, None)
+    }
 
-        let mut child_stdout = child.stdout.take().expect("stdout piped above");
-        let mut child_stderr = child.stderr.take().expect("stderr piped above");
-        let stdout_reader = thread::spawn(move || {
-            let mut buf = Vec::new();
-            let _ = child_stdout.read_to_end(&mut buf);
-            buf
-        });
-        let stderr_reader = thread::spawn(move || {
-            let mut buf = Vec::new();
-            let _ = child_stderr.read_to_end(&mut buf);
-            buf
-        });
-
-        let Some(status) = wait_until(&mut child, Instant::now() + timeout)? else {
-            // Timed out: the child was killed and reaped. Deliberately don't
-            // join the reader threads — a killed process whose child inherited
-            // the pipe (e.g. a shell that spawned the real tool) can keep them
-            // blocked on `read_to_end`, and the caller must not wait on that.
-            // Dropping the handles detaches them; a reader then outlives this
-            // call until its pipe write-end finally closes — for a wedged
-            // pipe-holding grandchild, only when that process dies or the app
-            // exits. An accepted, bounded cost on the probe path (the probed
-            // tools don't fork such children), not a guarantee of prompt
-            // cleanup.
-            return Err(io::Error::new(
-                io::ErrorKind::TimedOut,
-                "command exceeded timeout",
-            ));
-        };
-
-        let stdout = stdout_reader.join().unwrap_or_default();
-        let stderr = stderr_reader.join().unwrap_or_default();
-        Ok(Output {
-            status,
-            stdout,
-            stderr,
-        })
+    fn output_timeout_capped(&mut self, timeout: Duration, cap: usize) -> io::Result<Output> {
+        spawn_and_capture(self, timeout, Some(cap))
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn read_capped_unbounded_returns_everything() {
+        let data = vec![b'x'; 100_000];
+        let out = read_capped(io::Cursor::new(data.clone()), None);
+        assert_eq!(out.len(), data.len());
+    }
+
+    #[test]
+    fn read_capped_retains_at_most_cap_bytes() {
+        let out = read_capped(io::Cursor::new(vec![b'x'; 100_000]), Some(8193));
+        assert_eq!(out.len(), 8193);
+    }
+
+    #[test]
+    fn read_capped_passes_short_input_through() {
+        let out = read_capped(io::Cursor::new(b"hello".to_vec()), Some(8193));
+        assert_eq!(out, b"hello");
+    }
+
+    #[test]
+    fn read_capped_drains_the_reader_past_the_cap() {
+        // Even once the retained buffer fills at `cap`, the reader is consumed
+        // to EOF — so a real child pipe never blocks on a full buffer. The
+        // cursor ending at its length proves every byte was read.
+        let mut cursor = io::Cursor::new(vec![b'x'; 100_000]);
+        let out = read_capped(&mut cursor, Some(16));
+        assert_eq!(out.len(), 16);
+        assert_eq!(cursor.position(), 100_000);
+    }
 
     fn echo_hello() -> Command {
         #[cfg(unix)]


### PR DESCRIPTION
## Summary

The hook **Test** capture (#154) buffered the child's full stdout/stderr via `read_to_end` before `truncate_output` trimmed it to 8 KiB for display. A command that floods output within the 10 s window could balloon memory before truncation. (The fire path has the same shape, so this isn't a regression — but worth bounding; low likelihood since it's a user-typed test command.)

This bounds the capture **at the read layer**:

- New pure helper `read_capped(reader, cap)` in `proc.rs`: with `Some(cap)` it retains at most `cap` bytes **but still drains the pipe to EOF**, so a chatty-but-brief command isn't forced into a spurious timeout by a full pipe (a child blocked on a full pipe would otherwise be killed by the wait timeout). The overflow is read and discarded, so memory stays bounded.
- New `CommandTimeoutExt::output_timeout_capped(timeout, cap)`; `output_timeout` (the probe path — `pmset`, `xprop`, `gdbus`, …) keeps the unbounded read.
- `run_command_capture` caps one byte past the 8 KiB display limit (`MAX_TEST_OUTPUT_BYTES + 1`) so `truncate_output` can still tell the output overran and add its `…[truncated]` marker.

Frontend is unaffected — the `HookTestOutcome` shape is unchanged.

## Test Plan

- `proc.rs` (cross-platform, pure — runs on all three OS CI jobs):
  - `read_capped` returns everything when unbounded,
  - retains at most `cap` bytes,
  - passes short input through untouched,
  - **drains the reader past the cap** (cursor ends at EOF — proves no pipe-blocking).
- `hooks.rs` (unix-gated, alongside the existing capture tests): `yes | head -c 100000` floods 100 KiB past the 8 KiB cap; asserts the command still completes, the output carries the truncation marker, and the captured string stays bounded.
- `cargo test --lib` green; `cargo fmt --check` clean; `cargo clippy --all-targets` clean.

Closes #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)