### PR TITLE
refactor(settings): reuse deserialize_with_fallback for routine difficulty

### DIFF
--- a/src-tauri/src/scheduler/routines.rs
+++ b/src-tauri/src/scheduler/routines.rs
@@ -60,12 +60,16 @@ impl RoutineCategory {
 
 /// How demanding a routine is. Ordered `Gentle < Moderate < Active`; the
 /// per-kind `*_routine_max_difficulty` filter includes everything up to and
-/// including the chosen level.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+/// including the chosen level. `Default` is `Active` (the most permissive
+/// filter) so a stale/unknown value can fall back through the shared
+/// `deserialize_with_fallback` helper, matching the other tolerant settings
+/// enums.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "lowercase")]
 pub enum RoutineDifficulty {
     Gentle,
     Moderate,
+    #[default]
     Active,
 }
 
@@ -444,6 +448,13 @@ mod tests {
         assert_eq!(RoutineDifficulty::from_disk_str("extreme"), None);
         assert_eq!(RoutineDifficulty::from_disk_str("Gentle"), None);
         assert_eq!(RoutineDifficulty::from_disk_str(""), None);
+    }
+
+    #[test]
+    fn routine_difficulty_defaults_to_active() {
+        // The tolerant settings deserializer falls back through this default,
+        // so it must stay the most permissive level.
+        assert_eq!(RoutineDifficulty::default(), RoutineDifficulty::Active);
     }
 
     #[test]

--- a/src-tauri/src/scheduler/settings.rs
+++ b/src-tauri/src/scheduler/settings.rs
@@ -273,25 +273,24 @@ where
     })
 }
 
-/// Deserialise a `*_routine_max_difficulty` permissively: an unknown value
-/// (stale, hand-edited, or from a future build) falls back to the default
-/// rather than failing the whole profile load (#212). Mirrors the
-/// [`deserialize_with_fallback`] behaviour, but the fallback is the field's
-/// own default since [`RoutineDifficulty`] has no `Default`.
+/// Deserialise a `*_routine_max_difficulty` permissively: an unknown or
+/// wrong-typed value (stale, hand-edited, or from a future build) falls back
+/// to [`RoutineDifficulty::default`] rather than failing the whole profile
+/// load (#212). Shares the [`deserialize_with_fallback`] helper with the
+/// other tolerant settings enums; kept as a field-level `deserialize_with`
+/// (not a type-level `Deserialize` impl) so content packs still parse
+/// routines through the strict derived `Deserialize`.
 fn deserialize_routine_max_difficulty<'de, D>(
     deserializer: D,
 ) -> Result<RoutineDifficulty, D::Error>
 where
     D: Deserializer<'de>,
 {
-    let raw = match String::deserialize(deserializer) {
-        Ok(raw) => raw,
-        Err(_) => return Ok(default_routine_max_difficulty()),
-    };
-    Ok(RoutineDifficulty::from_disk_str(&raw).unwrap_or_else(|| {
-        warn!("settings: unknown routine_max_difficulty value {raw:?} — falling back to default");
-        default_routine_max_difficulty()
-    }))
+    Ok(deserialize_with_fallback(
+        deserializer,
+        "routine_max_difficulty",
+        RoutineDifficulty::from_disk_str,
+    ))
 }
 
 /// Deserialise a `*_routine_categories` filter list permissively: unknown


### PR DESCRIPTION
## Summary

`/simplify` follow-up to #212. The reuse and simplification passes flagged that `deserialize_routine_max_difficulty` was a near-verbatim copy of the existing `deserialize_with_fallback` helper — written bespoke only because `RoutineDifficulty` had no `Default`.

This gives `RoutineDifficulty` a `#[default]` of `Active` (its existing field default, the most permissive filter) and routes the field deserializer through the shared helper, so it matches the other four tolerant settings enums (`BreakMode`, `ScheduleMode`, `HintMix`) instead of being the odd one out. Net −10 lines.

**Content packs stay strict.** The tolerance remains a field-level `#[serde(deserialize_with = …)]`; the enum's *derived* `Deserialize` is unchanged, so a content-pack routine with an unknown difficulty is still rejected at parse (guarded by the existing `parse_rejects_routine_with_unknown_difficulty` test).

## Test Plan

- Added `routine_difficulty_defaults_to_active` to lock the `#[default]` variant (the fallback path depends on it).
- Existing `corrupt_routine_max_difficulty_falls_back_to_default_on_load`, `known_routine_max_difficulty_deserialises_to_its_variant`, and the `content_pack` reject tests all still pass.
- `cargo test --lib` = 1171 passed; `cargo fmt --check` clean; `cargo clippy --all-targets` clean.

## Notes

Two other `/simplify` findings were **not** taken here:
- Collapsing #211's `pause_duration_secs` `Option<Option<u64>>` → `Option<u64>` would erase the unit test's "non-pause vs indefinite-pause" distinction; left as-is.
- The hotkey/IPC/tray pause writes all bypass the canonical `pause_impl` (no persistence / `PauseStart` logging / hooks). That's a behavior change beyond this diff — filed as a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)