### PR TITLE
feat(onboarding): offer the active-hours weekday picker during setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Versions on the `0.0.X` line are public beta releases; `0.1.X` and onwards will 
 
 ### Added
 
-- **Active hours can target specific weekdays.** The Schedule tab's **Active hours** section gains an **On these days** picker, so the work window can apply only on the days you actually work — turn off Saturday and Sunday and Entracte stays quiet while you game or relax at the weekend, no need to remember to pause it. Defaults to every day, so existing setups are unchanged on upgrade. A window that runs past midnight (e.g. 22:00–06:00) counts its early-morning hours as part of the day it started. ([#204](https://github.com/drmowinckels/entracte/issues/204))
+- **Active hours can target specific weekdays.** The Schedule tab's **Active hours** section gains an **On these days** picker, so the work window can apply only on the days you actually work — turn off Saturday and Sunday and Entracte stays quiet while you game or relax at the weekend, no need to remember to pause it. The first-run onboarding offers the same picker when you set your working hours, so you can skip the weekend from the start. Defaults to every day, so existing setups are unchanged on upgrade. A window that runs past midnight (e.g. 22:00–06:00) counts its early-morning hours as part of the day it started. ([#204](https://github.com/drmowinckels/entracte/issues/204))
 - **Preset-duration pause hotkeys.** The Global hotkeys section (System tab) gains bindable **Pause for 15 / 30 / 60 minutes** actions alongside the existing indefinite Pause, mapping to the same timed-pause path as `entracte pause <duration>`. ([#211](https://github.com/drmowinckels/entracte/issues/211))
 
 ### Fixed

--- a/src/views/settings/components/onboarding/onboarding-wizard.test.tsx
+++ b/src/views/settings/components/onboarding/onboarding-wizard.test.tsx
@@ -12,6 +12,7 @@ function baseSettings(
     work_window_enabled: false,
     work_start_minutes: 9 * 60,
     work_end_minutes: 17 * 60,
+    work_days_mask: 0b111_1111,
     clock_format: "24h",
     show_hint: true,
     long_hint_mix: "both",
@@ -114,6 +115,25 @@ describe("OnboardingWizard", () => {
     await user.type(end, "18:00");
     await user.tab();
     expect(update).toHaveBeenCalledWith("work_end_minutes", 18 * 60);
+  });
+
+  it("hides the weekday picker until working hours are enabled", async () => {
+    const user = userEvent.setup();
+    renderWizard();
+    await advanceTo(user, 2);
+    expect(screen.queryByText("On these days")).toBeNull();
+  });
+
+  it("shows the weekday picker and toggles a day when the window is enabled", async () => {
+    const user = userEvent.setup();
+    const { update } = renderWizard({
+      work_window_enabled: true,
+      work_days_mask: 0b111_1111,
+    });
+    await advanceTo(user, 2);
+    expect(screen.getByText("On these days")).toBeTruthy();
+    await user.click(screen.getByRole("button", { name: "Sunday" }));
+    expect(update).toHaveBeenCalledWith("work_days_mask", 0b011_1111);
   });
 
   it("choosing the solo worker option updates long_hint_mix", async () => {

--- a/src/views/settings/components/onboarding/onboarding-wizard.tsx
+++ b/src/views/settings/components/onboarding/onboarding-wizard.tsx
@@ -3,6 +3,7 @@ import type { UseSettings } from "../../hooks/use-settings";
 import type { SchedulerSettings } from "../../types";
 import { CheckboxRow, TimeRow } from "../rows";
 import { InfoTip } from "../info-tip";
+import { WeekdayToggle } from "../weekday-toggle";
 import "./onboarding.css";
 
 type StepId = "welcome" | "login" | "window" | "hints" | "winddown" | "done";
@@ -180,6 +181,12 @@ function StepContent({
                 value={settings.work_end_minutes}
                 format={settings.clock_format}
                 onChange={(v) => update("work_end_minutes", v)}
+              />
+              <WeekdayToggle
+                label="On these days"
+                mask={settings.work_days_mask}
+                onChange={(v) => update("work_days_mask", v)}
+                tip="Turn off days you don't work — like the weekend — and Entracte stays quiet then. You can fine-tune this later under Schedule."
               />
             </>
           )}


### PR DESCRIPTION
## Summary

Per request: the work-days **On these days** picker added in #204 lived only on the Schedule tab. This adds the same `WeekdayToggle` to the onboarding **Working hours** step, so a new user can skip the weekend (or any non-working day) right from the first run instead of discovering the setting later.

- Renders inside the existing `work_window_enabled` block, right after the Start/End-of-day time rows — so it only appears once the user opts into working hours, matching the Schedule tab's gating.
- Writes through the same `update("work_days_mask", …)` helper the Schedule tab uses; reuses the self-contained `WeekdayToggle` component and `lib/weekdays` helpers (no new state, no duplication).
- Onboarding tip points the user to the Schedule tab for later fine-tuning.

## Test Plan

- `onboarding-wizard.test.tsx`: added `work_days_mask` to the fixture; new tests assert the picker is hidden until working hours are enabled, and that clicking **Sunday** toggles `work_days_mask` 127 → 63 via `update`.
- `onboarding-wizard.test.tsx` = 19 passed; full `vitest` = 747 passed; `tsc --noEmit` clean; `eslint src` clean.

Relates to #204.

🤖 Generated with [Claude Code](https://claude.com/claude-code)