### PR TITLE
test: guard enum exhaustiveness and the capped-capture wiring

### DIFF
--- a/src-tauri/src/proc.rs
+++ b/src-tauri/src/proc.rs
@@ -214,6 +214,25 @@ mod tests {
         assert!(read_capped(Boom, Some(8)).is_empty());
     }
 
+    // Directly exercises the `output_timeout_capped` (`Some(cap)`) wiring
+    // through a real child, not just the `read_capped` core. Unix-only: needs
+    // a shell that floods then exits when the reader stops (yes | head).
+    #[cfg(unix)]
+    #[test]
+    fn output_timeout_capped_bounds_each_stream() {
+        let mut cmd = Command::new("/bin/sh");
+        cmd.args(["-c", "yes entracte | head -c 100000"]);
+        let out = cmd
+            .output_timeout_capped(Duration::from_secs(5), 4096)
+            .expect("command completes within the timeout");
+        assert!(
+            out.stdout.len() <= 4096,
+            "stdout should be bounded by the cap, was {}",
+            out.stdout.len()
+        );
+        assert!(out.stderr.is_empty());
+    }
+
     #[test]
     fn read_capped_drains_the_reader_past_the_cap() {
         // Even once the retained buffer fills at `cap`, the reader is consumed

--- a/src-tauri/src/proc.rs
+++ b/src-tauri/src/proc.rs
@@ -225,10 +225,10 @@ mod tests {
         let out = cmd
             .output_timeout_capped(Duration::from_secs(5), 4096)
             .expect("command completes within the timeout");
+        let len = out.stdout.len();
         assert!(
-            out.stdout.len() <= 4096,
-            "stdout should be bounded by the cap, was {}",
-            out.stdout.len()
+            len <= 4096,
+            "stdout should be bounded by the cap, was {len}"
         );
         assert!(out.stderr.is_empty());
     }

--- a/src-tauri/src/scheduler/routines.rs
+++ b/src-tauri/src/scheduler/routines.rs
@@ -415,13 +415,20 @@ mod tests {
 
     #[test]
     fn routine_category_from_disk_str_round_trips_every_variant() {
-        for (raw, want) in [
-            ("eyes", RoutineCategory::Eyes),
-            ("mobility", RoutineCategory::Mobility),
-            ("breathing", RoutineCategory::Breathing),
-            ("desk_yoga", RoutineCategory::DeskYoga),
-        ] {
-            assert_eq!(RoutineCategory::from_disk_str(raw), Some(want));
+        use RoutineCategory::*;
+        for c in [Eyes, Mobility, Breathing, DeskYoga] {
+            // Exhaustive match: a new variant fails to compile here until it
+            // gains a `from_disk_str` arm, guarding against one silently
+            // parsing to `None` through that fn's `_` arm. Also pins the disk
+            // string to the serde rename in both directions.
+            let disk = match c {
+                Eyes => "eyes",
+                Mobility => "mobility",
+                Breathing => "breathing",
+                DeskYoga => "desk_yoga",
+            };
+            assert_eq!(serde_json::to_value(c).unwrap(), serde_json::json!(disk));
+            assert_eq!(RoutineCategory::from_disk_str(disk), Some(c));
         }
     }
 
@@ -434,12 +441,18 @@ mod tests {
 
     #[test]
     fn routine_difficulty_from_disk_str_round_trips_every_variant() {
-        for (raw, want) in [
-            ("gentle", RoutineDifficulty::Gentle),
-            ("moderate", RoutineDifficulty::Moderate),
-            ("active", RoutineDifficulty::Active),
-        ] {
-            assert_eq!(RoutineDifficulty::from_disk_str(raw), Some(want));
+        use RoutineDifficulty::*;
+        for d in [Gentle, Moderate, Active] {
+            // Exhaustive match: see the category test above — a new variant
+            // can't compile without a `from_disk_str` arm and a serde-rename
+            // cross-check.
+            let disk = match d {
+                Gentle => "gentle",
+                Moderate => "moderate",
+                Active => "active",
+            };
+            assert_eq!(serde_json::to_value(d).unwrap(), serde_json::json!(disk));
+            assert_eq!(RoutineDifficulty::from_disk_str(disk), Some(d));
         }
     }
 

--- a/src-tauri/src/scheduler/settings.rs
+++ b/src-tauri/src/scheduler/settings.rs
@@ -2546,7 +2546,7 @@ mod parity_tests {
 
     #[test]
     fn hotkey_action_values_match_ts_union() {
-        use crate::scheduler::hotkeys::HotkeyAction::{self, *};
+        use crate::scheduler::hotkeys::HotkeyAction::*;
         // The bindable actions are sync'd by hand across the Rust enum, the
         // TS union, the zod enum, and the HOTKEY_ACTIONS list; this guards the
         // Rust ↔ TS-union leg so a new variant can't silently drift.
@@ -2570,7 +2570,7 @@ mod parity_tests {
                 | SkipMicro | SkipLong | CycleProfile => {}
             }
         }
-        let rust = rust_enum_values::<HotkeyAction, 10>(all);
+        let rust = rust_enum_values(all);
         let ts = ts_union_values(&ts_source(), "HotkeyAction");
         assert_eq!(rust, ts, "HotkeyAction ↔ TS union value drift");
     }

--- a/src-tauri/src/scheduler/settings.rs
+++ b/src-tauri/src/scheduler/settings.rs
@@ -2546,22 +2546,31 @@ mod parity_tests {
 
     #[test]
     fn hotkey_action_values_match_ts_union() {
-        use crate::scheduler::hotkeys::HotkeyAction;
+        use crate::scheduler::hotkeys::HotkeyAction::{self, *};
         // The bindable actions are sync'd by hand across the Rust enum, the
         // TS union, the zod enum, and the HOTKEY_ACTIONS list; this guards the
         // Rust ↔ TS-union leg so a new variant can't silently drift.
-        let rust = rust_enum_values([
-            HotkeyAction::Pause,
-            HotkeyAction::Pause15m,
-            HotkeyAction::Pause30m,
-            HotkeyAction::Pause60m,
-            HotkeyAction::Resume,
-            HotkeyAction::TriggerMicro,
-            HotkeyAction::TriggerLong,
-            HotkeyAction::SkipMicro,
-            HotkeyAction::SkipLong,
-            HotkeyAction::CycleProfile,
-        ]);
+        let all = [
+            Pause,
+            Pause15m,
+            Pause30m,
+            Pause60m,
+            Resume,
+            TriggerMicro,
+            TriggerLong,
+            SkipMicro,
+            SkipLong,
+            CycleProfile,
+        ];
+        // Exhaustiveness gate: a new variant fails to compile here until it's
+        // added to `all` above, so the hand-listed parity set can't omit it.
+        for a in all {
+            match a {
+                Pause | Pause15m | Pause30m | Pause60m | Resume | TriggerMicro | TriggerLong
+                | SkipMicro | SkipLong | CycleProfile => {}
+            }
+        }
+        let rust = rust_enum_values::<HotkeyAction, 10>(all);
         let ts = ts_union_values(&ts_source(), "HotkeyAction");
         assert_eq!(rust, ts, "HotkeyAction ↔ TS union value drift");
     }

--- a/src/lib/hotkeys.test.ts
+++ b/src/lib/hotkeys.test.ts
@@ -2,10 +2,12 @@ import { describe, expect, it } from "vitest";
 import {
   acceleratorFor,
   conflictingAccelerators,
+  HOTKEY_ACTIONS,
   isValidAccelerator,
   normalizeAccelerator,
   setAccelerator,
 } from "./hotkeys";
+import { hotkeySchema } from "../views/settings/hooks/use-settings";
 import type { Hotkey } from "../views/settings/types";
 
 describe("isValidAccelerator", () => {
@@ -99,5 +101,30 @@ describe("setAccelerator", () => {
       "   ",
     );
     expect(next).toEqual([{ action: "resume", accelerator: "Ctrl+R" }]);
+  });
+});
+
+describe("hotkey action parity", () => {
+  // The Rust enum ↔ TS union leg is guarded in settings.rs
+  // (`hotkey_action_values_match_ts_union`); this guards the two TS runtime
+  // lists — the zod action enum and HOTKEY_ACTIONS — against drifting apart.
+  it("HOTKEY_ACTIONS and the zod hotkey enum list the same actions", () => {
+    const fromList = new Set(HOTKEY_ACTIONS.map((a) => a.action));
+    const fromZod = new Set(hotkeySchema.shape.action.options);
+    expect(fromZod).toEqual(fromList);
+  });
+
+  it("the zod hotkey schema accepts every HOTKEY_ACTIONS action", () => {
+    for (const { action } of HOTKEY_ACTIONS) {
+      expect(
+        hotkeySchema.safeParse({ action, accelerator: "" }).success,
+      ).toBe(true);
+    }
+  });
+
+  it("the zod hotkey schema rejects an unknown action", () => {
+    expect(
+      hotkeySchema.safeParse({ action: "teleport", accelerator: "" }).success,
+    ).toBe(false);
   });
 });

--- a/src/lib/hotkeys.test.ts
+++ b/src/lib/hotkeys.test.ts
@@ -116,9 +116,9 @@ describe("hotkey action parity", () => {
 
   it("the zod hotkey schema accepts every HOTKEY_ACTIONS action", () => {
     for (const { action } of HOTKEY_ACTIONS) {
-      expect(
-        hotkeySchema.safeParse({ action, accelerator: "" }).success,
-      ).toBe(true);
+      expect(hotkeySchema.safeParse({ action, accelerator: "" }).success).toBe(
+        true,
+      );
     }
   });
 

--- a/src/views/settings/hooks/use-settings.ts
+++ b/src/views/settings/hooks/use-settings.ts
@@ -29,7 +29,9 @@ const hookConfigSchema = z.object({
   enabled: z.boolean(),
 });
 
-const hotkeySchema = z.object({
+// Exported so the hotkey-parity test can assert the zod action enum stays in
+// sync with HOTKEY_ACTIONS (and, via the Rust-side parity test, the union).
+export const hotkeySchema = z.object({
   action: z.enum([
     "pause",
     "pause_15m",


### PR DESCRIPTION
## Summary

Test-only follow-ups surfaced by the review battery on #211–#213. No behavior change.

The recurring risk: enums whose on-disk/wire form is mirrored by hand (`from_disk_str` with a `_ => None` arm, the hand-listed parity set, the zod enum) can gain a variant that silently drifts out of one mirror. These add compile-time and runtime guards:

- **`routines.rs`** — the `RoutineCategory`/`RoutineDifficulty` `from_disk_str` round-trip tests now iterate through an **exhaustive `match`**, so a new variant fails to compile until it's handled (instead of silently parsing to `None`), and cross-check the disk string against the serde rename in both directions.
- **`settings.rs`** — `hotkey_action_values_match_ts_union` gains an exhaustive-`match` gate so the hand-listed Rust set can't omit a new `HotkeyAction` variant.
- **`hotkeys.test.ts`** — asserts the two TS runtime lists (the zod `action` enum and `HOTKEY_ACTIONS`) list the same actions, closing the 4-way Rust ↔ TS-union ↔ zod ↔ `HOTKEY_ACTIONS` sync loop (the Rust↔union leg is the settings.rs parity test; tsc covers union ⊇ `HOTKEY_ACTIONS`). Plus accept/reject coverage. `hotkeySchema` is exported for the test.
- **`proc.rs`** — a direct `output_timeout_capped` test (unix) exercising the `Some(cap)` path through a real flooding child (`yes | head`), not just the `read_capped` core.

## Test Plan

- `cargo test --lib` = 1173 passed; `cargo fmt --check` clean; `cargo clippy --all-targets` clean.
- `vitest` = 750 passed (hotkeys.test.ts: 14); `tsc --noEmit` clean; `eslint src` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)