### PR TITLE
chore(release): v0.0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Versions on the `0.0.X` line are public beta releases; `0.1.X` and onwards will 
 
 ## [Unreleased]
 
+## [0.0.8] — 2026-06-18
+
 ### Added
 
 - **Active hours can target specific weekdays.** The Schedule tab's **Active hours** section gains an **On these days** picker, so the work window can apply only on the days you actually work — turn off Saturday and Sunday and Entracte stays quiet while you game or relax at the weekend, no need to remember to pause it. The first-run onboarding offers the same picker when you set your working hours, so you can skip the weekend from the start. Defaults to every day, so existing setups are unchanged on upgrade. A window that runs past midnight (e.g. 22:00–06:00) counts its early-morning hours as part of the day it started. ([#204](https://github.com/drmowinckels/entracte/issues/204))

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "entracte-desktop",
   "private": true,
-  "version": "0.0.7",
+  "version": "0.0.8",
   "type": "module",
   "engines": {
     "node": "^20.19.0 || >=22.12.0"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1581,7 +1581,7 @@ checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
 
 [[package]]
 name = "entracte"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "entracte"
-version = "0.0.7"
+version = "0.0.8"
 description = "Cross-platform break reminder"
 authors = ["Athanasia Mowinckel"]
 license = "Apache-2.0"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Entracte",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "identifier": "io.drmowinckels.entracte",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary

Release prep for the **v0.0.8** public beta. Version bump 0.0.7 → 0.0.8 across the four lockstep files (`package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`, `src-tauri/Cargo.lock`) and dates the CHANGELOG `[0.0.8]` section.

Once merged, tagging `v0.0.8` on `main` triggers `release.yml`, which builds the platform bundles into a **draft** release for human review + publish (per `docs/developer/releases.md`).

## What's in this beta (from the CHANGELOG)

**Added**
- Active hours can target specific weekdays — Schedule tab **On these days** picker, also offered in first-run onboarding ([#204])
- Preset-duration pause hotkeys (15 / 30 / 60 min) ([#211])

**Fixed**
- A stale routine filter no longer resets your whole profile ([#212])
- The hook Test button can't be flooded into hogging memory ([#213])
- Pauses from the tray, a hotkey, or the CLI now persist, count in stats, and fire hooks ([#218])

[#204]: https://github.com/drmowinckels/entracte/issues/204
[#211]: https://github.com/drmowinckels/entracte/issues/211
[#212]: https://github.com/drmowinckels/entracte/issues/212
[#213]: https://github.com/drmowinckels/entracte/issues/213
[#218]: https://github.com/drmowinckels/entracte/issues/218

🤖 Generated with [Claude Code](https://claude.com/claude-code)