### PR TITLE
test: gate the sibling enum-parity tests on exhaustiveness (#223)

### DIFF
--- a/src-tauri/src/scheduler/settings.rs
+++ b/src-tauri/src/scheduler/settings.rs
@@ -2445,17 +2445,22 @@ mod parity_tests {
     }
 
     // -- Enum *value* parity. The field-name test above proves the keys
-    //    line up; this proves the typed enums (`BreakMode`,
-    //    `ScheduleMode`, `HintMix`) serialise to exactly the string
-    //    literals the TS unions accept. A new Rust variant with no TS
-    //    counterpart (or vice versa) fails here at unit-test time rather
-    //    than as a runtime Zod rejection.
+    //    line up; this proves the typed on-disk enums (`BreakMode`,
+    //    `ScheduleMode`, `HintMix`, `HotkeyAction`, `RoutineCategory`,
+    //    `RoutineDifficulty`) serialise to exactly the string literals the TS
+    //    unions accept. Each parity array is built with `all_variants!`, whose
+    //    compile-time exhaustiveness gate makes a new Rust variant fail to
+    //    *compile* until it's listed — so a missing TS counterpart (or vice
+    //    versa) surfaces at unit-test time rather than as a runtime Zod
+    //    rejection.
 
     use super::{BreakMode, HintMix, ScheduleMode};
+    use crate::scheduler::routines::{RoutineCategory, RoutineDifficulty};
 
-    /// All on-disk strings a Rust enum can serialise to. Drives the
-    /// value-parity check from the Rust side without hand-maintaining a
-    /// list — add a variant and it shows up automatically.
+    /// All on-disk strings a Rust enum can serialise to. The caller passes the
+    /// full variant array — built with [`all_variants!`], which also gates
+    /// completeness at compile time — and this maps each through serde to its
+    /// wire string.
     fn rust_enum_values<T, const N: usize>(variants: [T; N]) -> BTreeSet<String>
     where
         T: serde::Serialize,
@@ -2504,24 +2509,34 @@ mod parity_tests {
         std::fs::read_to_string(&path).expect("read TS settings types")
     }
 
+    /// Build the full variant array for a fieldless enum **and** an
+    /// exhaustiveness gate from a single list. The `match` below covers
+    /// exactly the listed variants, so adding a variant to the enum without
+    /// listing it here fails to compile — the parity array can never silently
+    /// omit one. Replaces the array + hand-written match the hotkey gate used
+    /// to spell out per call site (#222 → #223).
+    macro_rules! all_variants {
+        ($ty:ident: $($variant:ident),+ $(,)?) => {{
+            let all = [$($ty::$variant),+];
+            for v in &all {
+                match v {
+                    $($ty::$variant => {}),+
+                }
+            }
+            all
+        }};
+    }
+
     #[test]
     fn break_mode_values_match_ts_union() {
-        let rust = rust_enum_values([
-            BreakMode::Overlay,
-            BreakMode::Windowed,
-            BreakMode::Notification,
-        ]);
+        let rust = rust_enum_values(all_variants!(BreakMode: Overlay, Windowed, Notification));
         let ts = ts_union_values(&ts_source(), "BreakDeliveryMode");
         assert_eq!(rust, ts, "BreakMode ↔ BreakDeliveryMode value drift");
     }
 
     #[test]
     fn schedule_mode_values_match_ts_union() {
-        let rust = rust_enum_values([
-            ScheduleMode::Interval,
-            ScheduleMode::Fixed,
-            ScheduleMode::Both,
-        ]);
+        let rust = rust_enum_values(all_variants!(ScheduleMode: Interval, Fixed, Both));
         let ts = ts_union_values(&ts_source(), "ScheduleMode");
         assert_eq!(rust, ts, "ScheduleMode value drift");
     }
@@ -2531,13 +2546,8 @@ mod parity_tests {
         // HintMix is one Rust enum but two TS unions (micro vs long); its
         // value set is the union of both. Splitting per-kind is a TS-only
         // nicety — Rust accepts any variant on either field.
-        let rust = rust_enum_values([
-            HintMix::Both,
-            HintMix::Physical,
-            HintMix::Psychological,
-            HintMix::Solo,
-            HintMix::Social,
-        ]);
+        let rust =
+            rust_enum_values(all_variants!(HintMix: Both, Physical, Psychological, Solo, Social));
         let src = ts_source();
         let mut ts = ts_union_values(&src, "MicroHintMix");
         ts.extend(ts_union_values(&src, "LongHintMix"));
@@ -2546,33 +2556,30 @@ mod parity_tests {
 
     #[test]
     fn hotkey_action_values_match_ts_union() {
-        use crate::scheduler::hotkeys::HotkeyAction::*;
         // The bindable actions are sync'd by hand across the Rust enum, the
         // TS union, the zod enum, and the HOTKEY_ACTIONS list; this guards the
         // Rust ↔ TS-union leg so a new variant can't silently drift.
-        let all = [
-            Pause,
-            Pause15m,
-            Pause30m,
-            Pause60m,
-            Resume,
-            TriggerMicro,
-            TriggerLong,
-            SkipMicro,
-            SkipLong,
-            CycleProfile,
-        ];
-        // Exhaustiveness gate: a new variant fails to compile here until it's
-        // added to `all` above, so the hand-listed parity set can't omit it.
-        for a in all {
-            match a {
-                Pause | Pause15m | Pause30m | Pause60m | Resume | TriggerMicro | TriggerLong
-                | SkipMicro | SkipLong | CycleProfile => {}
-            }
-        }
-        let rust = rust_enum_values(all);
+        use crate::scheduler::hotkeys::HotkeyAction;
+        let rust = rust_enum_values(all_variants!(HotkeyAction:
+            Pause, Pause15m, Pause30m, Pause60m, Resume,
+            TriggerMicro, TriggerLong, SkipMicro, SkipLong, CycleProfile));
         let ts = ts_union_values(&ts_source(), "HotkeyAction");
         assert_eq!(rust, ts, "HotkeyAction ↔ TS union value drift");
+    }
+
+    #[test]
+    fn routine_category_values_match_ts_union() {
+        let rust =
+            rust_enum_values(all_variants!(RoutineCategory: Eyes, Mobility, Breathing, DeskYoga));
+        let ts = ts_union_values(&ts_source(), "RoutineCategory");
+        assert_eq!(rust, ts, "RoutineCategory ↔ TS union value drift");
+    }
+
+    #[test]
+    fn routine_difficulty_values_match_ts_union() {
+        let rust = rust_enum_values(all_variants!(RoutineDifficulty: Gentle, Moderate, Active));
+        let ts = ts_union_values(&ts_source(), "RoutineDifficulty");
+        assert_eq!(rust, ts, "RoutineDifficulty ↔ TS union value drift");
     }
 
     #[test]

--- a/src/views/settings/components/routine-picker.test.tsx
+++ b/src/views/settings/components/routine-picker.test.tsx
@@ -2,11 +2,34 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 
-import { RoutinePicker } from "./routine-picker";
+import { CATEGORIES, DIFFICULTIES, RoutinePicker } from "./routine-picker";
+import {
+  routineCategorySchema,
+  routineDifficultySchema,
+} from "../hooks/use-settings";
 import type { Routine } from "../hooks/use-routines";
 import type { SchedulerSettings } from "../types";
 
 afterEach(cleanup);
+
+describe("routine enum parity (picker ↔ zod)", () => {
+  // The Rust enum ↔ TS union leg is guarded in settings.rs
+  // (`routine_category_values_match_ts_union` /
+  // `routine_difficulty_values_match_ts_union`); this guards the two TS runtime
+  // lists — the picker options and the zod enums — against drifting apart,
+  // mirroring the hotkey action-parity test.
+  it("the category picker and the zod category enum list the same values", () => {
+    expect(new Set(CATEGORIES.map((c) => c.id))).toEqual(
+      new Set(routineCategorySchema.options),
+    );
+  });
+
+  it("the difficulty picker and the zod difficulty enum list the same values", () => {
+    expect(new Set(DIFFICULTIES.map((d) => d.id))).toEqual(
+      new Set(routineDifficultySchema.options),
+    );
+  });
+});
 
 const ROUTINES: Routine[] = [
   {

--- a/src/views/settings/components/routine-picker.tsx
+++ b/src/views/settings/components/routine-picker.tsx
@@ -7,14 +7,16 @@ import type {
 } from "../types";
 import { InfoTip } from "./info-tip";
 
-const CATEGORIES: { id: RoutineCategory; label: string }[] = [
+// Exported for the routine enum-parity test (kept in lockstep with the zod
+// routine enums and the Rust `RoutineCategory` / `RoutineDifficulty`).
+export const CATEGORIES: { id: RoutineCategory; label: string }[] = [
   { id: "eyes", label: "Eyes" },
   { id: "mobility", label: "Mobility" },
   { id: "breathing", label: "Breathing" },
   { id: "desk_yoga", label: "Desk yoga" },
 ];
 
-const DIFFICULTIES: { id: RoutineDifficulty; label: string }[] = [
+export const DIFFICULTIES: { id: RoutineDifficulty; label: string }[] = [
   { id: "gentle", label: "Gentle" },
   { id: "moderate", label: "Moderate" },
   { id: "active", label: "Active" },

--- a/src/views/settings/hooks/use-settings.ts
+++ b/src/views/settings/hooks/use-settings.ts
@@ -47,13 +47,15 @@ export const hotkeySchema = z.object({
   accelerator: z.string(),
 });
 
-const routineCategorySchema = z.enum([
+// Exported so the routine enum-parity test can check these against the
+// picker's runtime lists (mirrors the hotkey zod↔list guard in hotkeys.test).
+export const routineCategorySchema = z.enum([
   "eyes",
   "mobility",
   "breathing",
   "desk_yoga",
 ]);
-const routineDifficultySchema = z.enum(["gentle", "moderate", "active"]);
+export const routineDifficultySchema = z.enum(["gentle", "moderate", "active"]);
 const routineSchema = z.object({
   id: z.string(),
   label: z.string(),


### PR DESCRIPTION
## Summary

Closes **#223**. #222 added a compile-time exhaustiveness gate to `hotkey_action_values_match_ts_union`, but the three sibling parity tests in [settings.rs](src-tauri/src/scheduler/settings.rs) were left with the exact weakness #222 closed: each hand-listed its variants straight into `rust_enum_values([...])`, so adding a `BreakMode`/`ScheduleMode`/`HintMix` variant and forgetting the array let the parity test pass blind. `RoutineCategory`/`RoutineDifficulty` had no Rust↔TS-union test at all.

## Changes (test-only, no behaviour change)

- **`all_variants!(Ty: A, B, C)` macro** — emits the variant array **and** a `match` over exactly those variants, so a new enum variant fails to *compile* until it's listed. Converted `break_mode` / `schedule_mode` / `hint_mix`, and folded the hand-written `HotkeyAction` gate into the same macro (kills the array/match dual-listing footgun across all 6 sites).
  - Verified the gate bites: dropping a variant from a list yields `error[E0004]: non-exhaustive patterns: …Both not covered`.
- **New `routine_category_values_match_ts_union` / `routine_difficulty_values_match_ts_union`** — the only on-disk serde enums that lacked the Rust↔TS-union leg, reusing the existing `rust_enum_values` / `ts_union_values` harness.
- **Routine zod↔list parity test** ([routine-picker.test.tsx](src/views/settings/components/routine-picker.test.tsx)) — mirrors the hotkey action-parity test: asserts the picker's `CATEGORIES`/`DIFFICULTIES` and the zod routine enums list the same values. Exports the picker lists + zod enums (as `hotkeySchema` already does for its test).
- **Fixed the overstated parity-tests comment** so it matches the now-uniform gate.

## Test plan

- `cargo test --lib` — **1175 passed** (6 parity tests incl. the 2 new routine ones).
- `cargo fmt --check` / `cargo clippy --all-targets` clean.
- `npx vitest run` — **762 passed** (incl. the 2 new routine picker↔zod parity tests).
- `npm run audit:knip` exit 0 (new exports are consumed by the test, so not flagged), `audit:spell` clean, `format:check` clean.

Closes #223.

🤖 Generated with [Claude Code](https://claude.com/claude-code)