### PR TITLE
chore(release): v0.0.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Versions on the `0.0.X` line are public beta releases; `0.1.X` and onwards will 
 
 ## [Unreleased]
 
+## [0.0.9] — 2026-06-22
+
 ### Added
 
 - **Pause until a specific date & time.** The Quiet tab's **Manual pause** section gains a **Pause until** date-and-time picker — set it before a holiday when you'll be on the computer but not working, and Entracte stays quiet until then and resumes itself, so there's nothing to remember to switch back on. The deadline survives a restart, and the pause status now reads in days when it's that far out (e.g. _"6d 4h left"_). The menu-bar icon's quick durations are unchanged. ([#205](https://github.com/drmowinckels/entracte/issues/205))

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "entracte-desktop",
   "private": true,
-  "version": "0.0.8",
+  "version": "0.0.9",
   "type": "module",
   "engines": {
     "node": "^20.19.0 || >=22.12.0"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1581,7 +1581,7 @@ checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
 
 [[package]]
 name = "entracte"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "entracte"
-version = "0.0.8"
+version = "0.0.9"
 description = "Cross-platform break reminder"
 authors = ["Athanasia Mowinckel"]
 license = "Apache-2.0"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Entracte",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "identifier": "io.drmowinckels.entracte",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary

Release prep for **v0.0.9**: version bump across `package.json`, `tauri.conf.json`, `Cargo.toml`, `Cargo.lock`, and the CHANGELOG `[Unreleased]` → `## [0.0.9] — 2026-06-22`.

Ships:
- Overlay render fix + watchdog ([#196](https://github.com/drmowinckels/entracte/issues/196), [#226](https://github.com/drmowinckels/entracte/issues/226))
- macOS media-pause false-start fix ([#233](https://github.com/drmowinckels/entracte/issues/233))
- Chores autosave ([#225](https://github.com/drmowinckels/entracte/issues/225))
- Breath-ring sync ([#236](https://github.com/drmowinckels/entracte/issues/236))
- Enum sibling-parity gate ([#223](https://github.com/drmowinckels/entracte/issues/223))
- Update-check endpoint fix + opt-in startup auto-check ([#238](https://github.com/drmowinckels/entracte/issues/238))

Merging this, then tagging `v0.0.9` triggers the signed release build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)