### PR TITLE
chore(deps): nightly security audit 2026-06-23

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4332,9 +4332,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",


### PR DESCRIPTION
## Nightly Security Audit — 2026-06-23

### Advisories addressed

| Advisory | Package | Severity | Change |
|---|---|---|---|
| [RUSTSEC-2026-0185](https://github.com/quinn-rs/quinn/pull/2694) / GHSA-4w2j-m93h-cj5j | `quinn-proto` | **High** (CVSS 7.5, AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H) | `0.11.14` → `0.11.15` |

**RUSTSEC-2026-0185 — Remote memory exhaustion in quinn-proto:**
The `Assembler` component that reassembles unordered stream fragments incurs unbounded buffer overhead when a peer sends fragments with many gaps, enabling OOM DoS. Fixed in `>=0.11.15`.

### Skipped / MANUAL

| Advisory | Package | Reason |
|---|---|---|
| RUSTSEC-2024-0429 | `glib@0.18.5` (unsound) | Requires ≥0.20.0 (major version jump, tied to GTK4 migration). Tracked in #84. |
| Unmaintained: atk, gdk, gtk, mach, proc-macro-error, unic-* | various | Informational only — no CVSS, no patched version, transitive GTK3/Tauri deps. |

### Node dependencies
`npm audit` returned 0 vulnerabilities.

### Build note
`cargo build` and `npm run build` both fail in this CI container due to missing GTK3 system headers and pre-existing TypeScript errors in `system-tab.tsx` respectively — these are pre-existing environment constraints unrelated to the `quinn-proto` lockfile patch.

### Change
Only `src-tauri/Cargo.lock` changed (2 lines: version + checksum for `quinn-proto`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019Zqdq6Cyr2jmngRowgqrmX)_