### PR TITLE
refactor(settings): rename the "Quiet times" tab to "Pausing"

### DIFF
--- a/docs/guide/settings.md
+++ b/docs/guide/settings.md
@@ -1,6 +1,6 @@
 # Settings
 
-All settings live in the Preferences window, reachable from the tray menu. They're grouped into seven tabs by intent: **Schedule** (when breaks fire), **Breaks** (what they look and sound like), **Quiet times** (when not to interrupt), **System** (app and OS integration), **Insights** (stats and history), **Profiles**, and **About**.
+All settings live in the Preferences window, reachable from the tray menu. They're grouped into seven tabs by intent: **Schedule** (when breaks fire), **Breaks** (what they look and sound like), **Pausing** (suppressing and pausing breaks), **System** (app and OS integration), **Insights** (stats and history), **Profiles**, and **About**.
 
 Settings persist automatically as plain JSON in the platform app-data directory (`settings.json`), atomically rewritten on every change — no save button to forget about. See [Architecture internals → On-disk state](../developer/architecture-internals#on-disk-state) for the file paths.
 
@@ -77,9 +77,9 @@ A content pack is a versioned JSON file:
 
 `Show break on` chooses where overlays appear: `Primary monitor`, `Monitor under cursor` (the display the mouse cursor is on at break-fire time), or `All monitors`. If active-monitor detection fails for any reason, Entracte falls back to the primary monitor.
 
-## Quiet times
+## Pausing
 
-The Quiet times tab covers when breaks should _not_ fire.
+The Pausing tab covers when breaks should _not_ fire — automatic suppression and manual pausing. (It was previously called "Quiet times".)
 
 - **Auto-pause** — suppress breaks while Do Not Disturb / Focus is on (macOS, Windows), while the camera is in use (all OSes), or while fullscreen video is playing. On macOS, Windows and X11 Linux the fullscreen-video check confirms a real fullscreen window, so a small background video won't hold your breaks. On Linux Wayland there is no portable way to confirm a fullscreen window, so the toggle shows a caution marker: detection falls back to "any media is keeping the display awake" and may suppress breaks for a small background video.
 - **During breaks** — _Pause media while a break is showing_ quiets whatever is playing (video or audio) when a break starts and resumes it when the break ends. On Linux this targets your media players precisely (via MPRIS); on macOS and Windows it sends a play/pause media key as a best-effort, so it works for most players but can't guarantee the exact app.

--- a/scripts/audit-a11y.mjs
+++ b/scripts/audit-a11y.mjs
@@ -29,7 +29,7 @@ const DEFAULT_SETTINGS_JSON = readFileSync(
 const TABS = [
   "Schedule",
   "Breaks",
-  "Quiet times",
+  "Pausing",
   "System",
   "Insights",
   "Profiles",

--- a/src/views/settings/constants.ts
+++ b/src/views/settings/constants.ts
@@ -37,7 +37,7 @@ export const SOUND_MODES: { id: BreakSoundMode; label: string }[] = [
 export const TABS: { id: Tab; label: string }[] = [
   { id: "schedule", label: "Schedule" },
   { id: "breaks", label: "Breaks" },
-  { id: "quiet", label: "Quiet times" },
+  { id: "quiet", label: "Pausing" },
   { id: "system", label: "System" },
   { id: "insights", label: "Insights" },
   { id: "profiles", label: "Profiles" },


### PR DESCRIPTION
## Summary

Fourth step of the **"when vs. what" settings IA restructure**. Stacked on #244.

"Quiet times" implied scheduled quiet hours, but the tab actually holds auto-pause (DnD / camera / fullscreen video), app-based suppression, and manual pause. The real scheduled quiet windows — work hours and bedtime — live on the **Schedule** tab. Renaming to **Pausing** describes what's there and stops sending users to the wrong tab.

Label-only change: the tab **id stays `quiet`**, so routing, the `chores:prompt` handler, and panel ids are untouched. Syncs the two places that hardcode the human label — the a11y audit script's tab list and the settings docs.

## Test plan

- `npm test` — passing (no test asserts the old label; `index.test.tsx` checks tab count/order and the `Schedule` label only).
- `npm run audit:a11y` — axe clean across 16 audits, driving the renamed **Pausing** tab (confirms the audit-script sync).
- `npm run format:check` / `audit:spell` — clean.

> **Review note:** base is `refactor/settings-timing-only-schedule` (#244); GitHub retargets to `main` as the stack merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)