### PR TITLE
feat(settings): add a search box that jumps to any setting

### DIFF
--- a/docs/guide/settings.md
+++ b/docs/guide/settings.md
@@ -8,6 +8,10 @@ Settings persist automatically as plain JSON in the platform app-data directory 
 Most non-obvious settings carry a small ⓘ icon next to the label — hover or focus it for a short explanation. Power-user options are tucked behind a **Show advanced** disclosure in each section.
 :::
 
+::: tip Search
+A search box at the top of the window jumps straight to any setting. Type a name or synonym (e.g. "volume", "dnd", "shortcuts") and pick a result — Entracte switches to the right tab and highlights the section. Press Enter to jump to the first match.
+:::
+
 A small handful of personalisation extras are part of the [Supporter pack](./supporter) and flagged inline below.
 
 ## Schedule

--- a/src/views/settings/components/settings-search.test.tsx
+++ b/src/views/settings/components/settings-search.test.tsx
@@ -1,0 +1,74 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { SettingsSearch } from "./settings-search";
+
+afterEach(cleanup);
+
+function input(): HTMLInputElement {
+  return screen.getByRole("searchbox", {
+    name: "Search settings",
+  }) as HTMLInputElement;
+}
+
+describe("SettingsSearch", () => {
+  it("shows no results until the user types", () => {
+    render(<SettingsSearch onNavigate={() => {}} />);
+    expect(screen.queryByRole("list")).toBeNull();
+  });
+
+  it("filters as the user types and tags each result with its tab", () => {
+    render(<SettingsSearch onNavigate={() => {}} />);
+    fireEvent.change(input(), { target: { value: "volume" } });
+    const result = screen.getByRole("button", { name: /Sound/ });
+    expect(result.textContent).toContain("Breaks");
+  });
+
+  it("only points aria-controls at the results list while it is open", () => {
+    // axe flags aria-controls referencing a non-existent element, so it must
+    // be unset until the list renders.
+    render(<SettingsSearch onNavigate={() => {}} />);
+    const box = input();
+    expect(box.getAttribute("aria-controls")).toBeNull();
+    fireEvent.change(box, { target: { value: "volume" } });
+    const controlled = box.getAttribute("aria-controls");
+    expect(controlled).toBeTruthy();
+    expect(document.getElementById(controlled as string)).not.toBeNull();
+  });
+
+  it("calls onNavigate with the chosen entry and clears the query", () => {
+    const onNavigate = vi.fn();
+    render(<SettingsSearch onNavigate={onNavigate} />);
+    fireEvent.change(input(), { target: { value: "bedtime" } });
+    fireEvent.click(screen.getByRole("button", { name: /Bedtime/ }));
+    expect(onNavigate).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "bedtime", tabId: "schedule" }),
+    );
+    expect(input().value).toBe("");
+  });
+
+  it("selects the first result on Enter", () => {
+    const onNavigate = vi.fn();
+    render(<SettingsSearch onNavigate={onNavigate} />);
+    fireEvent.change(input(), { target: { value: "volume" } });
+    fireEvent.keyDown(input(), { key: "Enter" });
+    expect(onNavigate).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "sound" }),
+    );
+  });
+
+  it("clears the query on Escape without navigating", () => {
+    const onNavigate = vi.fn();
+    render(<SettingsSearch onNavigate={onNavigate} />);
+    fireEvent.change(input(), { target: { value: "bedtime" } });
+    fireEvent.keyDown(input(), { key: "Escape" });
+    expect(input().value).toBe("");
+    expect(onNavigate).not.toHaveBeenCalled();
+  });
+
+  it("shows an empty state when nothing matches", () => {
+    render(<SettingsSearch onNavigate={() => {}} />);
+    fireEvent.change(input(), { target: { value: "xylophone" } });
+    expect(screen.getByText("No matching settings")).toBeTruthy();
+  });
+});

--- a/src/views/settings/components/settings-search.tsx
+++ b/src/views/settings/components/settings-search.tsx
@@ -1,0 +1,71 @@
+import { useId, useMemo, useState } from "react";
+import { TABS } from "../constants";
+import { filterSettingsIndex, type SettingsSearchEntry } from "../search-index";
+import type { Tab } from "../types";
+
+const TAB_LABELS = new Map<Tab, string>(TABS.map((t) => [t.id, t.label]));
+
+/** Header search box that jumps to any setting across all tabs. Filters the
+ * static {@link SETTINGS_INDEX} and reports the chosen destination via
+ * `onNavigate`; the shell switches tab and scrolls the section into view. */
+export function SettingsSearch({
+  onNavigate,
+}: {
+  onNavigate: (entry: SettingsSearchEntry) => void;
+}) {
+  const [query, setQuery] = useState("");
+  const listId = useId();
+  const results = useMemo(() => filterSettingsIndex(query), [query]);
+  const hasQuery = query.trim().length > 0;
+
+  const select = (entry: SettingsSearchEntry) => {
+    onNavigate(entry);
+    setQuery("");
+  };
+
+  return (
+    <div className="settings-search">
+      <input
+        type="search"
+        className="settings-search-input"
+        placeholder="Search settings…"
+        aria-label="Search settings"
+        aria-controls={hasQuery ? listId : undefined}
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" && results[0]) {
+            e.preventDefault();
+            select(results[0]);
+          } else if (e.key === "Escape") {
+            setQuery("");
+          }
+        }}
+      />
+      {hasQuery && (
+        <ul id={listId} className="settings-search-results">
+          {results.length === 0 ? (
+            <li className="settings-search-empty">No matching settings</li>
+          ) : (
+            results.map((entry) => (
+              <li key={entry.id}>
+                <button
+                  type="button"
+                  className="settings-search-result"
+                  onClick={() => select(entry)}
+                >
+                  <span className="settings-search-result-label">
+                    {entry.label}
+                  </span>
+                  <span className="settings-search-result-tab">
+                    {TAB_LABELS.get(entry.tabId) ?? entry.tabId}
+                  </span>
+                </button>
+              </li>
+            ))
+          )}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/views/settings/index.test.tsx
+++ b/src/views/settings/index.test.tsx
@@ -77,7 +77,12 @@ vi.mock("./tabs/schedule-tab", () => ({
   ScheduleTab: () => <div data-testid="content-schedule">schedule-content</div>,
 }));
 vi.mock("./tabs/breaks-tab", () => ({
-  BreaksTab: () => <div data-testid="content-breaks">breaks-content</div>,
+  BreaksTab: () => (
+    <div data-testid="content-breaks">
+      <span id="settings-sound" />
+      breaks-content
+    </div>
+  ),
 }));
 vi.mock("./tabs/quiet-tab", () => ({
   QuietTab: () => <div data-testid="content-quiet">quiet-content</div>,
@@ -272,6 +277,57 @@ describe("Settings shell ARIA + keyboard", () => {
       expect(panel?.textContent).toBe(expected);
     },
   );
+
+  it("searching and choosing a result switches to that setting's tab", async () => {
+    const user = userEvent.setup();
+    mockSettings = hydratedSettings;
+    render(<Settings />);
+    await user.type(
+      screen.getByRole("searchbox", { name: "Search settings" }),
+      "volume",
+    );
+    await user.click(screen.getByRole("button", { name: /Sound/ }));
+    const breaksTab = screen
+      .getAllByRole("tab")
+      .find((t) => t.id === "settings-tab-breaks");
+    expect(breaksTab?.getAttribute("aria-selected")).toBe("true");
+  });
+
+  it("flashes the matched section, then clears the highlight after a delay", () => {
+    vi.useFakeTimers();
+    try {
+      mockSettings = hydratedSettings;
+      const { container } = render(<Settings />);
+      fireEvent.change(
+        screen.getByRole("searchbox", { name: "Search settings" }),
+        { target: { value: "volume" } },
+      );
+      fireEvent.click(screen.getByRole("button", { name: /Sound/ }));
+      const el = container.querySelector("#settings-sound");
+      expect(el?.classList.contains("settings-flash")).toBe(true);
+      act(() => {
+        vi.advanceTimersByTime(1200);
+      });
+      expect(el?.classList.contains("settings-flash")).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("still switches tab when the matched section has no scrollable anchor", async () => {
+    const user = userEvent.setup();
+    mockSettings = hydratedSettings;
+    render(<Settings />);
+    await user.type(
+      screen.getByRole("searchbox", { name: "Search settings" }),
+      "diagnostics",
+    );
+    await user.click(screen.getByRole("button", { name: /Diagnostics/ }));
+    const aboutTab = screen
+      .getAllByRole("tab")
+      .find((t) => t.id === "settings-tab-about");
+    expect(aboutTab?.getAttribute("aria-selected")).toBe("true");
+  });
 
   it("shows the onboarding wizard when needed and settings are loaded", () => {
     mockSettings = hydratedSettings;

--- a/src/views/settings/index.tsx
+++ b/src/views/settings/index.tsx
@@ -1,8 +1,10 @@
-import { useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useCustomStylesheet } from "../../lib/use-custom-stylesheet";
 import { useTauriListen } from "../../lib/use-tauri-listen";
 import { OnboardingWizard } from "./components/onboarding/onboarding-wizard";
+import { SettingsSearch } from "./components/settings-search";
 import { TABS } from "./constants";
+import type { SettingsSearchEntry } from "./search-index";
 import { useHooks } from "./hooks/use-hooks";
 import { useOnboarding } from "./hooks/use-onboarding";
 import { usePause } from "./hooks/use-pause";
@@ -56,6 +58,33 @@ export default function Settings() {
     onChange: setTab,
   });
 
+  // Anchor to scroll to after a search navigation. Held in a ref (not state)
+  // so consuming it doesn't re-run the effect and clear its own flash timer;
+  // a nonce drives the effect once per navigation.
+  const pendingAnchorRef = useRef<string | null>(null);
+  const [navNonce, setNavNonce] = useState(0);
+  const onSearchNavigate = useCallback((entry: SettingsSearchEntry) => {
+    pendingAnchorRef.current = entry.anchorId;
+    setTab(entry.tabId);
+    setNavNonce((n) => n + 1);
+  }, []);
+  // After the target tab renders (its panel is no longer `hidden`), scroll the
+  // matched section into view and flash it briefly.
+  useEffect(() => {
+    const anchor = pendingAnchorRef.current;
+    if (!anchor) return;
+    pendingAnchorRef.current = null;
+    const el = document.getElementById(anchor);
+    if (!el) return;
+    el.scrollIntoView?.({ block: "start" });
+    el.classList.add("settings-flash");
+    const timer = window.setTimeout(
+      () => el.classList.remove("settings-flash"),
+      1200,
+    );
+    return () => window.clearTimeout(timer);
+  }, [navNonce]);
+
   return (
     <>
       <a className="skip-link" href={`#${tabPanelId(tab)}`}>
@@ -70,6 +99,7 @@ export default function Settings() {
             onFinish={onboarding.complete}
           />
         )}
+        <SettingsSearch onNavigate={onSearchNavigate} />
         <header className="settings-header">
           <div
             className="tabs"

--- a/src/views/settings/search-index.test.ts
+++ b/src/views/settings/search-index.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync, readdirSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { SETTINGS_INDEX, filterSettingsIndex } from "./search-index";
+import { TABS } from "./constants";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const TAB_IDS = new Set(TABS.map((t) => t.id));
+
+describe("settings search index", () => {
+  it("references only real tab ids", () => {
+    for (const entry of SETTINGS_INDEX) {
+      expect(TAB_IDS.has(entry.tabId)).toBe(true);
+    }
+  });
+
+  it("has unique entry ids and anchor ids", () => {
+    const ids = SETTINGS_INDEX.map((e) => e.id);
+    const anchors = SETTINGS_INDEX.map((e) => e.anchorId);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(new Set(anchors).size).toBe(anchors.length);
+  });
+
+  it("every anchor id is rendered as an id in the tab sources", () => {
+    // Drift guard: an entry pointing at a renamed/removed section would
+    // silently scroll nowhere. Scan the tab .tsx sources for each anchor.
+    const tabsDir = resolve(here, "tabs");
+    const sources = readdirSync(tabsDir)
+      .filter((f) => f.endsWith(".tsx") && !f.endsWith(".test.tsx"))
+      .map((f) => readFileSync(resolve(tabsDir, f), "utf8"))
+      .join("\n");
+    for (const entry of SETTINGS_INDEX) {
+      expect(sources).toContain(`id="${entry.anchorId}"`);
+    }
+  });
+});
+
+describe("filterSettingsIndex", () => {
+  it("returns nothing for an empty or blank query", () => {
+    expect(filterSettingsIndex("")).toEqual([]);
+    expect(filterSettingsIndex("   ")).toEqual([]);
+  });
+
+  it("matches on the label", () => {
+    expect(filterSettingsIndex("bedtime").map((e) => e.id)).toContain(
+      "bedtime",
+    );
+  });
+
+  it("matches on keyword synonyms, not just the label", () => {
+    expect(filterSettingsIndex("dnd").map((e) => e.id)).toContain("auto-pause");
+    expect(filterSettingsIndex("volume").map((e) => e.id)).toContain("sound");
+  });
+
+  it("is case-insensitive and requires every term to match one entry", () => {
+    expect(filterSettingsIndex("MICRO interval").map((e) => e.id)).toContain(
+      "micro-breaks",
+    );
+    // "micro" and "bedtime" never co-occur in one entry.
+    expect(filterSettingsIndex("micro bedtime")).toEqual([]);
+  });
+
+  it("caps the number of results", () => {
+    // A near-universal term still returns at most the capped count.
+    expect(filterSettingsIndex("e").length).toBeLessThanOrEqual(8);
+  });
+});

--- a/src/views/settings/search-index.ts
+++ b/src/views/settings/search-index.ts
@@ -1,0 +1,252 @@
+import type { Tab } from "./types";
+
+/** One searchable destination in the Settings window. `anchorId` must match
+ * the `id` on a section heading inside the tab named by `tabId`, so the
+ * navigator can switch to the tab and scroll the section into view. */
+export type SettingsSearchEntry = {
+  id: string;
+  label: string;
+  tabId: Tab;
+  anchorId: string;
+  /** Extra terms (synonyms, control names) folded into the match. */
+  keywords: string;
+};
+
+/** Static map of every section a user might search for. Metadata only — the
+ * controls themselves are rendered by their tab, not from this list. */
+export const SETTINGS_INDEX: SettingsSearchEntry[] = [
+  // Schedule
+  {
+    id: "active-hours",
+    label: "Active hours",
+    tabId: "schedule",
+    anchorId: "settings-active-hours",
+    keywords: "work window weekdays days start end time range when",
+  },
+  {
+    id: "micro-breaks",
+    label: "Micro breaks",
+    tabId: "schedule",
+    anchorId: "settings-micro-breaks",
+    keywords: "interval fixed times duration enable cadence frequency idle",
+  },
+  {
+    id: "long-breaks",
+    label: "Long breaks",
+    tabId: "schedule",
+    anchorId: "settings-long-breaks",
+    keywords: "interval fixed times duration enable cadence frequency idle",
+  },
+  {
+    id: "bedtime",
+    label: "Bedtime",
+    tabId: "schedule",
+    anchorId: "settings-bedtime",
+    keywords: "sleep night wind down reminder window",
+  },
+  {
+    id: "screen-time",
+    label: "Daily screen time",
+    tabId: "schedule",
+    anchorId: "settings-screen-time",
+    keywords: "budget limit usage time at keyboard wrap up",
+  },
+  // Breaks
+  {
+    id: "delivery",
+    label: "Delivery mode",
+    tabId: "breaks",
+    anchorId: "settings-delivery",
+    keywords: "overlay windowed notification fullscreen test how appears",
+  },
+  {
+    id: "overlay",
+    label: "Overlay appearance",
+    tabId: "breaks",
+    anchorId: "settings-overlay",
+    keywords:
+      "transparency opacity theme colour color text size high contrast monitor vignette",
+  },
+  {
+    id: "sound",
+    label: "Sound",
+    tabId: "breaks",
+    anchorId: "settings-sound",
+    keywords: "volume chime ambient track audio custom file",
+  },
+  {
+    id: "skip-postpone",
+    label: "Skip & postpone",
+    tabId: "breaks",
+    anchorId: "settings-skip-postpone",
+    keywords:
+      "strict mode escalation enforce manual finish cannot be dismissed snooze",
+  },
+  {
+    id: "break-ideas",
+    label: "Break ideas",
+    tabId: "breaks",
+    anchorId: "settings-break-ideas",
+    keywords: "hints routines mix physical psychological solo social guided",
+  },
+  {
+    id: "chores",
+    label: "Today's chores",
+    tabId: "breaks",
+    anchorId: "settings-chores",
+    keywords: "tasks post-it morning prompt to do list",
+  },
+  {
+    id: "content-packs",
+    label: "Content packs",
+    tabId: "breaks",
+    anchorId: "settings-content-packs",
+    keywords: "import export share routines hints json",
+  },
+  {
+    id: "custom-css",
+    label: "Custom CSS",
+    tabId: "breaks",
+    anchorId: "settings-custom-css",
+    keywords: "stylesheet style supporter overlay appearance",
+  },
+  // Pausing
+  {
+    id: "auto-pause",
+    label: "Auto-pause",
+    tabId: "quiet",
+    anchorId: "settings-auto-pause",
+    keywords:
+      "do not disturb dnd focus camera webcam fullscreen video suppress",
+  },
+  {
+    id: "during-breaks",
+    label: "Pause media during breaks",
+    tabId: "quiet",
+    anchorId: "settings-during-breaks",
+    keywords: "music spotify video play pause media",
+  },
+  {
+    id: "app-pause",
+    label: "Pause for specific apps",
+    tabId: "quiet",
+    anchorId: "settings-app-pause",
+    keywords: "zoom obs keynote running application suppress",
+  },
+  {
+    id: "manual-pause",
+    label: "Manual pause",
+    tabId: "quiet",
+    anchorId: "settings-manual-pause",
+    keywords: "pause until resume holiday snooze",
+  },
+  // System
+  {
+    id: "startup",
+    label: "Start at login",
+    tabId: "system",
+    anchorId: "settings-startup",
+    keywords: "autostart boot launch",
+  },
+  {
+    id: "display",
+    label: "Time format",
+    tabId: "system",
+    anchorId: "settings-display",
+    keywords: "clock 12 24 hour am pm",
+  },
+  {
+    id: "notifications",
+    label: "Notifications",
+    tabId: "system",
+    anchorId: "settings-notifications",
+    keywords: "pre-break heads up lead time warning",
+  },
+  {
+    id: "hotkeys",
+    label: "Global hotkeys",
+    tabId: "system",
+    anchorId: "settings-hotkeys",
+    keywords: "keyboard shortcuts accelerator pause resume trigger",
+  },
+  {
+    id: "tray",
+    label: "Tray countdown",
+    tabId: "system",
+    anchorId: "settings-tray",
+    keywords: "menu bar icon timer countdown next break",
+  },
+  {
+    id: "plugins",
+    label: "Plugins",
+    tabId: "system",
+    anchorId: "settings-plugins",
+    keywords: "extensions install content detector export",
+  },
+  {
+    id: "hooks",
+    label: "Event hooks",
+    tabId: "system",
+    anchorId: "settings-hooks",
+    keywords: "shell command script break start end advanced automation",
+  },
+  // Insights
+  {
+    id: "insights",
+    label: "Insights & stats",
+    tabId: "insights",
+    anchorId: "settings-insights",
+    keywords: "stats history breaks taken skipped dismissed heatmap session",
+  },
+  {
+    id: "manage-data",
+    label: "Manage data",
+    tabId: "insights",
+    anchorId: "settings-manage-data",
+    keywords: "export csv backup import clear history reset",
+  },
+  // Profiles
+  {
+    id: "profiles",
+    label: "Profiles",
+    tabId: "profiles",
+    anchorId: "settings-profiles",
+    keywords: "switch duplicate rename reset preset",
+  },
+  // About
+  {
+    id: "about",
+    label: "About & updates",
+    tabId: "about",
+    anchorId: "settings-about",
+    keywords: "version update check release",
+  },
+  {
+    id: "supporter",
+    label: "Supporter",
+    tabId: "about",
+    anchorId: "settings-supporter",
+    keywords: "license key unlock customisation pack donate",
+  },
+  {
+    id: "diagnostics",
+    label: "Diagnostics",
+    tabId: "about",
+    anchorId: "settings-diagnostics",
+    keywords: "report logs bug issue copy",
+  },
+];
+
+const MAX_RESULTS = 8;
+
+/** Case-insensitive AND-match over each entry's label + keywords. Returns at
+ * most {@link MAX_RESULTS} entries, in index order. */
+export function filterSettingsIndex(query: string): SettingsSearchEntry[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return [];
+  const terms = q.split(/\s+/);
+  return SETTINGS_INDEX.filter((entry) => {
+    const haystack = `${entry.label} ${entry.keywords}`.toLowerCase();
+    return terms.every((term) => haystack.includes(term));
+  }).slice(0, MAX_RESULTS);
+}

--- a/src/views/settings/settings.css
+++ b/src/views/settings/settings.css
@@ -1140,6 +1140,109 @@ body,
   opacity: 0.6;
 }
 
+.settings .settings-search {
+  position: relative;
+  margin: 0 0 0.6rem;
+}
+
+.settings .settings-search-input {
+  width: 100%;
+  box-sizing: border-box;
+  background: var(--input-bg);
+  border: 1px solid var(--input-border);
+  color: inherit;
+  border-radius: 7px;
+  padding: 0.45rem 0.7rem;
+  font-size: 0.9rem;
+  font-family: inherit;
+}
+
+.settings .settings-search-input:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.settings .settings-search-results {
+  position: absolute;
+  z-index: 20;
+  top: calc(100% + 4px);
+  left: 0;
+  right: 0;
+  margin: 0;
+  padding: 0.25rem;
+  list-style: none;
+  background: var(--input-bg);
+  border: 1px solid var(--input-border);
+  border-radius: 8px;
+  box-shadow: 0 8px 24px rgb(0 0 0 / 30%);
+  max-height: 18rem;
+  overflow-y: auto;
+}
+
+.settings .settings-search-result {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  width: 100%;
+  background: transparent;
+  border: none;
+  border-radius: 5px;
+  padding: 0.4rem 0.55rem;
+  color: var(--fg);
+  font-size: 0.9rem;
+  font-weight: 400;
+  cursor: pointer;
+  text-align: left;
+}
+
+.settings .settings-search-result:hover {
+  background: var(--input-hover);
+}
+
+.settings .settings-search-result:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+
+.settings .settings-search-result-tab {
+  flex: none;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--faint-fg);
+  border: 1px solid var(--input-border);
+  border-radius: 4px;
+  padding: 0.05rem 0.35rem;
+}
+
+.settings .settings-search-empty {
+  padding: 0.4rem 0.55rem;
+  color: var(--faint-fg);
+  font-size: 0.88rem;
+}
+
+@keyframes settings-flash {
+  from {
+    background: color-mix(in srgb, var(--accent) 28%, transparent);
+  }
+
+  to {
+    background: transparent;
+  }
+}
+
+.settings .settings-flash {
+  animation: settings-flash 1.2s ease-out;
+  border-radius: 6px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .settings .settings-flash {
+    animation: none;
+  }
+}
+
 .settings .settings-header {
   display: flex;
   align-items: flex-end;

--- a/src/views/settings/tabs/about-tab.tsx
+++ b/src/views/settings/tabs/about-tab.tsx
@@ -67,7 +67,7 @@ export function AboutTab({
 
   return (
     <>
-      <h2>About</h2>
+      <h2 id="settings-about">About</h2>
       <section>
         <div className="about-title-row">
           <p className="about-title">Entracte</p>
@@ -121,7 +121,9 @@ export function AboutTab({
         )}
       </section>
 
-      <h2>Supporter{supporter.status.is_supporter ? " ✓" : ""}</h2>
+      <h2 id="settings-supporter">
+        Supporter{supporter.status.is_supporter ? " ✓" : ""}
+      </h2>
       <section>
         {supporter.status.is_supporter ? (
           <>
@@ -217,7 +219,7 @@ export function AboutTab({
       </section>
 
       <div className="section-heading">
-        <h2>Diagnostics</h2>
+        <h2 id="settings-diagnostics">Diagnostics</h2>
         <button onClick={onCopyDiagnosticsReport}>
           Copy diagnostics report
         </button>

--- a/src/views/settings/tabs/breaks-tab.tsx
+++ b/src/views/settings/tabs/breaks-tab.tsx
@@ -129,7 +129,7 @@ export function BreaksTab({
 
   return (
     <>
-      <h2>Delivery</h2>
+      <h2 id="settings-delivery">Delivery</h2>
       <section>
         <p className="placeholder">
           How each break appears. Turn a break on or off, and set its cadence,
@@ -190,7 +190,7 @@ export function BreaksTab({
         </div>
       </section>
 
-      <h2>Overlay</h2>
+      <h2 id="settings-overlay">Overlay</h2>
       <section>
         <label className="row">
           <span>
@@ -402,7 +402,7 @@ export function BreaksTab({
         </Advanced>
       </section>
 
-      <h2>Sound</h2>
+      <h2 id="settings-sound">Sound</h2>
       <section>
         <label className="row">
           <span>Volume</span>
@@ -440,7 +440,7 @@ export function BreaksTab({
         />
       </section>
 
-      <h2>Skip & postpone</h2>
+      <h2 id="settings-skip-postpone">Skip & postpone</h2>
       <section>
         <CheckboxRow
           label="Strict mode (all breaks enforced, no skip or postpone)"
@@ -570,7 +570,7 @@ export function BreaksTab({
         </Advanced>
       </section>
 
-      <h2>Break ideas</h2>
+      <h2 id="settings-break-ideas">Break ideas</h2>
       <section>
         <p className="placeholder">
           Choose which kinds of prompt appear during each break.
@@ -663,7 +663,7 @@ export function BreaksTab({
           onChange={(v) => update("allow_plugin_sounds", v)}
           tip="When on (default), routines from plugins may play their own short sound cues — a breathing in/out tone, or a chime between exercises. Cues always follow your overall sound volume; turn this off to silence them."
         />
-        <h3>Today's chores</h3>
+        <h3 id="settings-chores">Today's chores</h3>
         <p className="placeholder">
           Jot down chores you'd like done today — one per line. During a long
           break, Entracte nudges you to knock one out (these take precedence
@@ -726,7 +726,7 @@ export function BreaksTab({
         )}
       </section>
 
-      <h2>Content packs</h2>
+      <h2 id="settings-content-packs">Content packs</h2>
       <section>
         <ContentPacks
           reload={async () => {
@@ -738,7 +738,7 @@ export function BreaksTab({
 
       {isSupporter && (
         <>
-          <h2>Custom CSS</h2>
+          <h2 id="settings-custom-css">Custom CSS</h2>
           <section>
             <p className="placeholder">
               Applied to the settings window and the break overlay. Bad CSS can

--- a/src/views/settings/tabs/insights-tab.tsx
+++ b/src/views/settings/tabs/insights-tab.tsx
@@ -134,7 +134,7 @@ export function InsightsTab({ stats }: { stats: UseStats }) {
 
   return (
     <>
-      <h2>This session</h2>
+      <h2 id="settings-insights">This session</h2>
       <section>
         <p className="placeholder">
           Live counters since this run started. They reset every time Entracte
@@ -286,7 +286,7 @@ export function InsightsTab({ stats }: { stats: UseStats }) {
             <Heatmap days={digest.by_day} />
           </section>
 
-          <h2>Manage data</h2>
+          <h2 id="settings-manage-data">Manage data</h2>
           <section>
             <div className="actions inline">
               <button onClick={onExportCsv}>Export CSV</button>

--- a/src/views/settings/tabs/profiles-tab.tsx
+++ b/src/views/settings/tabs/profiles-tab.tsx
@@ -3,7 +3,7 @@ import type { UseProfiles } from "../hooks/use-profiles";
 export function ProfilesTab({ profiles }: { profiles: UseProfiles }) {
   return (
     <>
-      <h2>Profiles</h2>
+      <h2 id="settings-profiles">Profiles</h2>
       <section>
         <p className="placeholder">
           Each profile keeps its own break cadence, hints, and overlay settings.

--- a/src/views/settings/tabs/quiet-tab.tsx
+++ b/src/views/settings/tabs/quiet-tab.tsx
@@ -40,7 +40,7 @@ export function QuietTab({
 
   return (
     <>
-      <h2>Auto-pause</h2>
+      <h2 id="settings-auto-pause">Auto-pause</h2>
       <section>
         <p className="placeholder">
           Breaks are automatically suppressed while these conditions apply.
@@ -74,7 +74,7 @@ export function QuietTab({
         />
       </section>
 
-      <h2>During breaks</h2>
+      <h2 id="settings-during-breaks">During breaks</h2>
       <section>
         <CheckboxRow
           label="Pause media while a break is showing"
@@ -89,7 +89,7 @@ export function QuietTab({
         />
       </section>
 
-      <h2>Pause for specific apps</h2>
+      <h2 id="settings-app-pause">Pause for specific apps</h2>
       <section>
         <CheckboxRow
           label="Pause when any of these apps are running"
@@ -145,7 +145,7 @@ export function QuietTab({
         )}
       </section>
 
-      <h2>Manual pause</h2>
+      <h2 id="settings-manual-pause">Manual pause</h2>
       <section>
         {pauseInfo.paused ? (
           <div className="pause-control">

--- a/src/views/settings/tabs/schedule-tab.tsx
+++ b/src/views/settings/tabs/schedule-tab.tsx
@@ -29,7 +29,7 @@ export function ScheduleTab({
 
   return (
     <>
-      <h2>Active hours</h2>
+      <h2 id="settings-active-hours">Active hours</h2>
       <section>
         <CheckboxRow
           label="Only fire breaks within set hours"
@@ -60,7 +60,7 @@ export function ScheduleTab({
         />
       </section>
 
-      <h2>Micro breaks</h2>
+      <h2 id="settings-micro-breaks">Micro breaks</h2>
       <section>
         <CheckboxRow
           label="Enable micro breaks"
@@ -138,7 +138,7 @@ export function ScheduleTab({
         )}
       </section>
 
-      <h2>Long breaks</h2>
+      <h2 id="settings-long-breaks">Long breaks</h2>
       <section>
         <CheckboxRow
           label="Enable long breaks"
@@ -216,7 +216,7 @@ export function ScheduleTab({
         )}
       </section>
 
-      <h2>Bedtime</h2>
+      <h2 id="settings-bedtime">Bedtime</h2>
       <section>
         <CheckboxRow
           label="Persistent sleep reminders within window"
@@ -268,7 +268,7 @@ export function ScheduleTab({
         )}
       </section>
 
-      <h2>Daily screen time</h2>
+      <h2 id="settings-screen-time">Daily screen time</h2>
       <section>
         <CheckboxRow
           label="Remind me to wrap up after a daily budget"

--- a/src/views/settings/tabs/system-tab.tsx
+++ b/src/views/settings/tabs/system-tab.tsx
@@ -80,7 +80,7 @@ export function SystemTab({
 
   return (
     <>
-      <h2>Startup</h2>
+      <h2 id="settings-startup">Startup</h2>
       <section>
         <CheckboxRow
           label="Start Entracte at login"
@@ -89,7 +89,7 @@ export function SystemTab({
         />
       </section>
 
-      <h2>Display</h2>
+      <h2 id="settings-display">Display</h2>
       <section>
         <label className="row">
           <span>Time format</span>
@@ -105,7 +105,7 @@ export function SystemTab({
         </label>
       </section>
 
-      <h2>Notifications</h2>
+      <h2 id="settings-notifications">Notifications</h2>
       <section>
         <CheckboxRow
           label="Notify before a break starts"
@@ -122,12 +122,12 @@ export function SystemTab({
         />
       </section>
 
-      <h2>Global hotkeys</h2>
+      <h2 id="settings-hotkeys">Global hotkeys</h2>
       <section>
         <HotkeysSection settings={settings} update={update} />
       </section>
 
-      <h2>Tray countdown</h2>
+      <h2 id="settings-tray">Tray countdown</h2>
       <section>
         <CheckboxRow
           label="Show countdown to next break in the tray"
@@ -159,13 +159,13 @@ export function SystemTab({
         </label>
       </section>
 
-      <h2>Plugins</h2>
+      <h2 id="settings-plugins">Plugins</h2>
       <section>
         <Plugins reload={reload} />
       </section>
 
       <Advanced label="Show advanced (hooks)">
-        <h3>Event hooks</h3>
+        <h3 id="settings-hooks">Event hooks</h3>
         <p className="placeholder hook-warning">
           ⚠ Hooks run shell commands on your machine with your full user
           permissions — a hostile command can read or delete your files, send


### PR DESCRIPTION
## Summary

Final step of the **"when vs. what" settings IA restructure**. Stacked on #245.

With ~90 settings across seven tabs, the remaining findability gap is "which tab is this on?". This adds a **search box at the top of the Settings window**: type a name or synonym (e.g. `volume`, `dnd`, `shortcuts`, `backup`) and pick a result — Entracte switches to the right tab and briefly highlights the section. Enter jumps to the first match; Escape clears.

How it works:

- **`search-index.ts`** — a static metadata map of every section (`label`, `tabId`, `anchorId`, synonym `keywords`) plus a small case-insensitive AND-match filter capped at 8 results. Metadata only; controls are still rendered by their own tab.
- **`SettingsSearch`** — the header search box and results list. `aria-controls` is set only while the list is open (axe `aria-valid-attr-value`).
- **Section anchors** — stable `id`s on each section heading across all six content tabs are the scroll targets. A drift test reads the tab sources and asserts every indexed `anchorId` actually exists.
- **Flash** — the matched section flashes via a CSS keyframe that respects `prefers-reduced-motion`. The pending anchor is held in a ref (not state) so consuming it doesn't re-run the effect and cancel its own clear-timer — a bug the fake-timer test caught.

## Test plan

- `npm test` — 807 passing. New `search-index.test.ts` (tab-id validity, unique ids, **anchor-exists drift guard**, filter behaviour) and `settings-search.test.tsx` (filter, tab badge, navigate+clear, Enter/Escape, empty state, aria-controls gating); plus `index.test.tsx` integration tests covering tab-switch, the flash + clear-timer, and the no-anchor path. New code is at 100% statement coverage.
- `npm run lint` / `format:check` / `lint:css` — clean.
- `npm run audit:knip` (exit 0) / `audit:spell` (0 issues).
- `npm run audit:a11y` — axe clean across 16 audits (caught and fixed a real `aria-controls` violation). `npm run audit:size` — JS 118.4 KB gz (under the 120 KB limit).

> **Review note:** base is `refactor/settings-rename-pausing` (#245); GitHub retargets each PR to `main` as the stack merges. This is the top of the 5-PR stack (#242 → #243 → #244 → #245 → this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)