### PR TITLE
chore(deps): nightly security audit 2026-06-25

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4333,9 +4333,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",


### PR DESCRIPTION
## Nightly Security Audit — 2026-06-25

### Advisories addressed

| Advisory | Package | Severity | Change |
|---|---|---|---|
| [RUSTSEC-2026-0185](https://github.com/quinn-rs/quinn/pull/2694) / GHSA-4w2j-m93h-cj5j | `quinn-proto` | **High** (CVSS 7.5, AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H) | `0.11.14` → `0.11.15` |

**RUSTSEC-2026-0185 — Remote memory exhaustion in quinn-proto:**
The `Assembler` component that reassembles unordered stream fragments incurs unbounded buffer overhead when a peer sends fragments with many gaps, enabling OOM DoS. Fixed in `>=0.11.15`.

This advisory was first surfaced in the 2026-06-23 audit (PR #241). That PR targeted a base 50 commits behind current main and was superseded by this one.

### Audit method note

The RustSec advisory database fetch was blocked by the session's network policy today (HTTP 403 on `rustsec/advisory-db`). The quinn-proto fix was applied based on the known advisory from the prior run. There may be new advisories published since 2026-06-23 that were not surfaced in this run.

### Skipped / MANUAL

| Advisory | Package | Reason |
|---|---|---|
| RUSTSEC-2024-0429 | `glib@0.18.5` (unsound) | Requires ≥0.20.0 (major version jump tied to GTK4 migration). Tracked in #84. |
| RUSTSEC-2026-0122 | `rkyv@0.7.46` (unsound) | Requires rkyv ≥0.8.16 — breaking major bump via tauri-plugin-log chain. Tracked in #125. |
| Unmaintained: atk, gdk, gtk, mach, proc-macro-error, unic-* | various | Informational only — no CVSS, no patched version, transitive GTK3/Tauri deps. |

### Node dependencies

`npm audit` returned **0 vulnerabilities**.

### Build note

`cargo test --no-run` fails in this container due to missing GTK3 system headers (`gdk-3.0`) — a pre-existing environment constraint unrelated to this change. Only `src-tauri/Cargo.lock` changed (2 lines: version + checksum for `quinn-proto`).

### Change

Only `src-tauri/Cargo.lock` changed (2 lines: version + checksum for `quinn-proto`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HfxJ91svFyKq7YGJh8CwrK)_