### PR TITLE
chore(deps): nightly security audit 2026-06-27

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4333,9 +4333,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",


### PR DESCRIPTION
## Nightly Security Audit — 2026-06-27

### Advisories resolved

| Advisory | Package | Before | After | Severity | Category |
|---|---|---|---|---|---|
| [RUSTSEC-2026-0185](https://rustsec.org/advisories/RUSTSEC-2026-0185) / GHSA-4w2j-m93h-cj5j | `quinn-proto` | 0.11.14 | 0.11.15 | HIGH (CVSS 3.1 AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H) | denial-of-service |

**RUSTSEC-2026-0185** — Remote memory exhaustion in `quinn-proto` from unbounded out-of-order stream reassembly. A remote peer can send stream fragments with deliberate gaps, causing the `Assembler` to accumulate unbounded buffer overhead and exhaust memory. No authentication required; network-exploitable.

### Audit summary

- **Rust**: 1 actionable vulnerability fixed (quinn-proto patch bump). 19 informational "unmaintained" advisories (gtk3-rs family transitive via Tauri, unic-* family, mach, proc-macro-error) — all lack patched versions and are not HIGH-severity vulnerabilities; RUSTSEC-2024-0429 (glib unsound) remains suppressed per `deny.toml` and tracked in #84.
- **Node**: 0 vulnerabilities (`npm audit` clean).

### Change

Only `src-tauri/Cargo.lock` changed — `quinn-proto` version pin updated from `0.11.14` to `0.11.15` (patch, no API changes). Frontend build confirmed clean.

🤖 Generated by nightly dep-audit routine

---
_Generated by [Claude Code](https://claude.ai/code/session_01QCXwyxjgeV79e197gtSseB)_