### PR TITLE
fix(media): detect real audio output via a CoreAudio tap, not a device-running flag (#233)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Versions on the `0.0.X` line are public beta releases; `0.1.X` and onwards will 
 
 ## [Unreleased]
 
+### Fixed
+
+- **A break no longer starts media you'd paused — for real this time (macOS).** The previous fix ([#233](https://github.com/drmowinckels/entracte/issues/233)) tried to tap the Play/Pause key only when audio was "actually playing", but it judged that from whether the sound device was _running_ — and apps like Chrome, Spotify, and Apple Music keep the device running even while paused, so a paused video or track still looked active and a break could **start** it. Entracte now briefly listens to the real audio coming out of your speakers and only taps the key when something is genuinely making sound, so paused media stays paused. (The truly accurate signal — the system's now-playing state — is locked to Apple's own apps on recent macOS, so it isn't available to Entracte.) ([#233](https://github.com/drmowinckels/entracte/issues/233))
+
 ## [0.0.9] — 2026-06-22
 
 ### Added

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1584,6 +1584,7 @@ name = "entracte"
 version = "0.0.9"
 dependencies = [
  "base64 0.22.1",
+ "block2",
  "chrono",
  "core-foundation",
  "core-graphics",
@@ -1598,6 +1599,8 @@ dependencies = [
  "objc2",
  "objc2-app-kit",
  "objc2-core-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
  "objc2-core-graphics",
  "objc2-foundation",
  "reqwest 0.12.28",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -75,9 +75,15 @@ windows-sys = { version = "0.59", features = ["Win32_System_LibraryLoader", "Win
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.6"
 objc2-app-kit = { version = "0.3", features = ["NSStatusBar", "NSStatusItem", "NSStatusBarButton", "NSButton", "NSControl", "NSFont", "NSFontDescriptor", "NSAttributedString", "NSEvent", "NSGraphicsContext", "objc2-core-graphics"] }
-objc2-foundation = { version = "0.3", features = ["NSAttributedString", "NSString", "NSDictionary", "NSArray", "NSValue", "NSGeometry"] }
 objc2-core-graphics = { version = "0.3", features = ["CGEvent", "CGEventTypes"] }
-objc2-core-audio = { version = "0.3", features = ["AudioHardware"] }
+# Default features pull in objc2/block2/dispatch2/objc2-foundation, needed for
+# the CoreAudio process-tap APIs (CATapDescription, the IOProc block, the
+# aggregate-device dictionary) used by media.rs to detect real audio output.
+objc2-core-audio = "0.3"
+objc2-core-audio-types = "0.3"
+objc2-core-foundation = { version = "0.3", features = ["CFDictionary", "CFString", "CFBase"] }
+block2 = "0.6"
+objc2-foundation = { version = "0.3", features = ["NSAttributedString", "NSString", "NSDictionary", "NSArray", "NSValue", "NSGeometry", "NSUUID"] }
 core-graphics = "0.25"
 core-foundation = "0.10"
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -83,7 +83,7 @@ objc2-core-audio = "0.3"
 objc2-core-audio-types = "0.3"
 objc2-core-foundation = { version = "0.3", features = ["CFDictionary", "CFString", "CFBase"] }
 block2 = "0.6"
-objc2-foundation = { version = "0.3", features = ["NSAttributedString", "NSString", "NSDictionary", "NSArray", "NSValue", "NSGeometry", "NSUUID"] }
+objc2-foundation = { version = "0.3", features = ["NSAttributedString", "NSString", "NSDictionary", "NSArray", "NSValue", "NSGeometry", "NSUUID", "NSProcessInfo"] }
 core-graphics = "0.25"
 core-foundation = "0.10"
 

--- a/src-tauri/Info.plist
+++ b/src-tauri/Info.plist
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!-- Entracte briefly taps the system audio output to tell whether media is
+	     actually playing before a break, so it never starts media you'd paused.
+	     macOS does not prompt for this today, but the key keeps a future OS that
+	     gates the tap from hard-crashing the app instead of degrading to "not
+	     playing". See src/media.rs `audio_tap`. -->
+	<key>NSAudioCaptureUsageDescription</key>
+	<string>Entracte checks whether audio is playing so it can pause it during breaks.</string>
+</dict>
+</plist>

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,3 +1,24 @@
 fn main() {
+    // The CoreAudio symbols that `src/media.rs` (`audio_tap`) calls are newer
+    // than the app's macOS floor:
+    //   AudioHardwareCreate/DestroyProcessTap      — macOS 14.2
+    //   AudioHardwareCreate/DestroyAggregateDevice — macOS 13.0
+    // objc2-core-audio declares them in a plain `extern` block with no
+    // availability, so the linker strong-binds them and the app would fail to
+    // LOAD (`dyld: Symbol not found`) on older macOS — before any runtime check
+    // can run. Mark them as weak references so they resolve to null on systems
+    // that lack them; `audio_tap::output_active` gates every call behind
+    // `isOperatingSystemAtLeastVersion(14.2)`, so a null symbol is never
+    // dereferenced. (`CATapDescription` needs no flag — objc2 resolves the
+    // class via a runtime `objc_getClass` lookup, not a load-time symbol.)
+    // Weak-link the whole CoreAudio framework: every symbol becomes a weak
+    // reference, so the four newer functions resolve to null on older macOS
+    // instead of aborting at load, while the long-standing CoreAudio symbols
+    // (always present on our floor) still bind normally. Per-symbol `-Wl,-U`
+    // does not work here — modern ld64 leaves link-time-resolvable symbols
+    // strong-bound — so the framework-level weak link is the mechanism.
+    #[cfg(target_os = "macos")]
+    println!("cargo:rustc-link-arg-bins=-Wl,-weak_framework,CoreAudio");
+
     tauri_build::build()
 }

--- a/src-tauri/src/media.rs
+++ b/src-tauri/src/media.rs
@@ -14,19 +14,21 @@
 //!   remember them, and resume exactly those when the break ends.
 //! - **macOS / Windows** have no portable way to enumerate players, so we
 //!   synthesise the system Play/Pause media key — a best-effort toggle.
-//!   Because the key is a toggle (there's no separate "pause" key), we
-//!   only send it when a display-wake assertion says something is likely
-//!   playing, so we don't accidentally *start* media that was paused; the
-//!   matching resume sends the same key again.
+//!   Because the key is a toggle (there's no separate "pause" key), we only
+//!   send it when an "is media actually playing?" probe says yes, so we don't
+//!   accidentally *start* media that was paused: a real CoreAudio output tap
+//!   on macOS (the one public signal that tells a paused player apart from one
+//!   merely holding the audio device open — #233), a display-wake assertion on
+//!   Windows. The matching resume sends the same key again.
 //!
 //! The testable core is pure and lives at module scope so it compiles and
 //! is unit-tested on every OS, mirroring [`crate::video`]: the gdbus output
 //! parsers and the "which players are Playing" decision (Linux), and the
 //! "may the blind toggle fire?" guards ([`media_key_pause_allowed`] /
 //! [`media_key_resume_allowed`], macOS/Windows). The guards keep the toggle
-//! from ever *starting* media the user had paused (#104): pause only when a
-//! display-wake assertion says something is playing, and resume only a
-//! toggle we ourselves sent.
+//! from ever *starting* media the user had paused (#104): pause only when the
+//! platform probe says something is playing, and resume only a toggle we
+//! ourselves sent.
 
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Mutex;
@@ -256,7 +258,7 @@ fn platform_resume(token: &ResumeToken) {
 /// break start. The toggle has no separate "pause" key, so sending it when
 /// nothing is playing would *start* media the user had paused (issue #104).
 /// We therefore only allow it when the platform's "is media actually
-/// playing?" probe says yes — real audio-device activity on macOS (#233), a
+/// playing?" probe says yes — a real audio-output tap on macOS (#233), a
 /// display-wake request on Windows. Pure so it's unit-tested without FFI on
 /// every OS.
 #[cfg_attr(not(any(target_os = "macos", target_os = "windows")), allow(dead_code))]
@@ -275,10 +277,11 @@ fn media_key_resume_allowed(token: &ResumeToken) -> bool {
 
 #[cfg(any(target_os = "macos", target_os = "windows"))]
 fn platform_pause() -> ResumeToken {
-    // macOS: a real audio-output-active probe; Windows: the display-wake
-    // request (its blind-toggle proxy is unchanged here — tracked in #234).
+    // macOS: a real audio-output tap (true only when samples are actually
+    // playing); Windows: the display-wake request (its blind-toggle proxy is
+    // unchanged here — tracked in #234).
     #[cfg(target_os = "macos")]
-    let media_likely_playing = audio_probe::output_active();
+    let media_likely_playing = audio_tap::output_active();
     #[cfg(target_os = "windows")]
     let media_likely_playing = crate::video::assertion_active();
     if !media_key_pause_allowed(media_likely_playing) {
@@ -396,71 +399,268 @@ mod media_key {
 }
 
 #[cfg(target_os = "macos")]
-mod audio_probe {
-    use std::ffi::c_void;
+mod audio_tap {
+    //! Detect whether macOS is producing *real audio output right now* by
+    //! briefly tapping the system output and measuring the actual signal.
+    //!
+    //! Every cheaper signal we tried lies about paused media: a display-wake
+    //! assertion (#103) and CoreAudio `DeviceIsRunningSomewhere` (#233) both
+    //! read "active" while Chrome / Spotify / Apple Music sit paused but keep
+    //! the output device's IOProc alive. The private MediaRemote now-playing
+    //! API reads the true state but is restricted to Apple platform binaries
+    //! on macOS 15.4+, so a third-party app can't use it. A CoreAudio *process
+    //! tap* (macOS 14.2+) is the one public, unentitled signal that reflects
+    //! reality: it captures the samples actually being mixed to the device, so
+    //! a paused player contributes digital silence (exactly 0.0) and reads as
+    //! not playing. That is what keeps a break from *starting* media the user
+    //! had paused.
+
+    use std::ffi::{c_void, CStr};
     use std::ptr::NonNull;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+    use std::time::{Duration, Instant};
 
+    use block2::RcBlock;
+    use objc2::runtime::AnyObject;
+    use objc2::AllocAnyThread;
     use objc2_core_audio::{
-        kAudioDevicePropertyDeviceIsRunningSomewhere, kAudioHardwarePropertyDefaultOutputDevice,
-        kAudioObjectPropertyElementMain, kAudioObjectPropertyScopeGlobal, kAudioObjectSystemObject,
-        AudioObjectGetPropertyData, AudioObjectID, AudioObjectPropertyAddress,
+        kAudioAggregateDeviceIsPrivateKey, kAudioAggregateDeviceNameKey,
+        kAudioAggregateDeviceTapAutoStartKey, kAudioAggregateDeviceTapListKey,
+        kAudioAggregateDeviceUIDKey, kAudioObjectPropertyElementMain,
+        kAudioObjectPropertyScopeGlobal, kAudioSubTapDriftCompensationKey, kAudioSubTapUIDKey,
+        kAudioTapPropertyUID, AudioDeviceCreateIOProcIDWithBlock, AudioDeviceDestroyIOProcID,
+        AudioDeviceIOProcID, AudioDeviceStart, AudioDeviceStop, AudioHardwareCreateAggregateDevice,
+        AudioHardwareCreateProcessTap, AudioHardwareDestroyAggregateDevice,
+        AudioHardwareDestroyProcessTap, AudioObjectGetPropertyData, AudioObjectID,
+        AudioObjectPropertyAddress, CATapDescription, CATapMuteBehavior,
     };
+    use objc2_core_audio_types::{AudioBufferList, AudioTimeStamp};
+    use objc2_core_foundation::{CFDictionary, CFRetained, CFString};
+    use objc2_foundation::{NSArray, NSDictionary, NSNumber, NSString, NSUUID};
 
-    fn global_address(selector: u32) -> AudioObjectPropertyAddress {
-        AudioObjectPropertyAddress {
-            mSelector: selector,
-            mScope: kAudioObjectPropertyScopeGlobal,
-            mElement: kAudioObjectPropertyElementMain,
+    // Samples whose absolute amplitude exceeds this count as "real audio".
+    // Digital silence is exactly 0.0, so any small positive floor cleanly
+    // separates a paused player (no samples) from an active one; the margin
+    // just ignores denormal/dither noise.
+    const SILENCE_THRESHOLD: f32 = 0.003;
+    // Upper bound on how long we wait for output before concluding it's silent.
+    // We early-exit the instant an audible sample arrives, so this only delays
+    // the "nothing playing" case (which has nothing to pause anyway).
+    const PROBE_WINDOW: Duration = Duration::from_millis(250);
+    const POLL_STEP: Duration = Duration::from_millis(10);
+
+    /// Pure decision: is a measured peak amplitude loud enough to be real
+    /// playback? Split out so the threshold is unit-tested without any FFI.
+    pub(super) fn is_audible(peak: f32) -> bool {
+        peak > SILENCE_THRESHOLD
+    }
+
+    /// True when the system is emitting real audio output right now. Opens a
+    /// private global process tap, measures the live output signal for at most
+    /// [`PROBE_WINDOW`], and tears the tap down. Any FFI failure degrades to
+    /// `false` — never a blind Play/Pause toggle on a guess.
+    pub(super) fn output_active() -> bool {
+        measure().unwrap_or(false)
+    }
+
+    /// Owns the tap + aggregate device + IOProc so every early return tears
+    /// them down in order, leaving no private CoreAudio objects behind.
+    struct TapSession {
+        tap: AudioObjectID,
+        agg: AudioObjectID,
+        proc_id: AudioDeviceIOProcID,
+        started: bool,
+    }
+
+    impl Drop for TapSession {
+        fn drop(&mut self) {
+            // SAFETY: each id is either zero/None (skipped) or a live object we
+            // created; teardown is the documented reverse of construction.
+            unsafe {
+                if self.started {
+                    AudioDeviceStop(self.agg, self.proc_id);
+                }
+                if self.proc_id.is_some() {
+                    AudioDeviceDestroyIOProcID(self.agg, self.proc_id);
+                }
+                if self.agg != 0 {
+                    AudioHardwareDestroyAggregateDevice(self.agg);
+                }
+                if self.tap != 0 {
+                    AudioHardwareDestroyProcessTap(self.tap);
+                }
+            }
         }
     }
 
-    // Read one fixed-size `u32` property of `object` into `out`. Returns
-    // false on any non-zero OSStatus so a probe failure degrades to "not
-    // playing" — never a blind toggle on a guess.
-    unsafe fn get_u32(object: AudioObjectID, selector: u32, out: &mut u32) -> bool {
-        let address = global_address(selector);
-        let mut size = std::mem::size_of::<u32>() as u32;
-        let status = AudioObjectGetPropertyData(
-            object,
-            NonNull::from(&address),
-            0,
-            std::ptr::null(),
-            NonNull::from(&mut size),
-            NonNull::from(&mut *out).cast::<c_void>(),
-        );
-        status == 0
+    fn ns(key: &CStr) -> objc2::rc::Retained<NSString> {
+        NSString::from_str(key.to_str().unwrap_or_default())
     }
 
-    /// True when the system's default output device is actively running in at
-    /// least one process — i.e. audio is *really playing right now*, not merely
-    /// "something is keeping the display awake". Paused media does no device
-    /// I/O, so this reads false and the blind Play/Pause key is never sent,
-    /// which is what stops a break from *starting* media the user had paused
-    /// (#233). A CoreAudio property read, far cheaper than the `pmset` fork the
-    /// display-assertion proxy used.
-    pub(super) fn output_active() -> bool {
-        // SAFETY: each call reads a single `u32` property into a stack slot
-        // with the matching size; `kAudioObjectSystemObject` is the documented
-        // root object and the default-output id is validated before reuse.
+    /// Read a CFString-valued audio object property into an owned `NSString`.
+    fn read_uid(object: AudioObjectID, selector: u32) -> Option<objc2::rc::Retained<NSString>> {
+        let address = AudioObjectPropertyAddress {
+            mSelector: selector,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain,
+        };
+        let mut cf: *const CFString = std::ptr::null();
+        let mut size = std::mem::size_of::<*const CFString>() as u32;
+        // SAFETY: reads a single CFStringRef-sized value into `cf`; `address`
+        // and `size` are valid for the call.
+        let status = unsafe {
+            AudioObjectGetPropertyData(
+                object,
+                NonNull::from(&address),
+                0,
+                std::ptr::null(),
+                NonNull::from(&mut size),
+                NonNull::from(&mut cf).cast::<c_void>(),
+            )
+        };
+        let cf = NonNull::new(cf as *mut CFString)?;
+        if status != 0 {
+            return None;
+        }
+        // `Get` returns a +1 reference we own; `CFRetained` releases it.
+        let owned = unsafe { CFRetained::from_raw(cf) };
+        Some(NSString::from_str(&owned.to_string()))
+    }
+
+    /// Build the aggregate-device description embedding our tap.
+    fn aggregate_description(
+        tap_uid: &NSString,
+    ) -> objc2::rc::Retained<NSDictionary<NSString, AnyObject>> {
+        let drift = NSNumber::new_i32(1);
+        let sub_keys = [
+            &*ns(kAudioSubTapUIDKey),
+            &*ns(kAudioSubTapDriftCompensationKey),
+        ];
+        let sub_vals: [&AnyObject; 2] = [tap_uid, &drift];
+        let sub = NSDictionary::<NSString, AnyObject>::from_slices(&sub_keys, &sub_vals);
+        let tap_list = NSArray::from_retained_slice(&[sub]);
+
+        let name = NSString::from_str("entracte-playing-probe-agg");
+        let uid = NSUUID::new().UUIDString();
+        let yes = NSNumber::new_i32(1);
+        let keys = [
+            &*ns(kAudioAggregateDeviceNameKey),
+            &*ns(kAudioAggregateDeviceUIDKey),
+            &*ns(kAudioAggregateDeviceIsPrivateKey),
+            &*ns(kAudioAggregateDeviceTapAutoStartKey),
+            &*ns(kAudioAggregateDeviceTapListKey),
+        ];
+        let vals: [&AnyObject; 5] = [&name, &uid, &yes, &yes, &tap_list];
+        NSDictionary::<NSString, AnyObject>::from_slices(&keys, &vals)
+    }
+
+    fn measure() -> Option<bool> {
+        // 1) Private global output tap (exclude no processes = tap everything).
+        let empty: objc2::rc::Retained<NSArray<NSNumber>> = NSArray::from_retained_slice(&[]);
+        let desc = unsafe {
+            CATapDescription::initStereoGlobalTapButExcludeProcesses(
+                CATapDescription::alloc(),
+                &empty,
+            )
+        };
         unsafe {
-            let mut device: AudioObjectID = 0;
-            if !get_u32(
-                kAudioObjectSystemObject as AudioObjectID,
-                kAudioHardwarePropertyDefaultOutputDevice,
-                &mut device,
-            ) || device == 0
-            {
-                return false;
+            desc.setName(&NSString::from_str("entracte-playing-probe"));
+            desc.setPrivate(true);
+            desc.setMuteBehavior(CATapMuteBehavior::Unmuted);
+        }
+        let mut tap: AudioObjectID = 0;
+        if unsafe { AudioHardwareCreateProcessTap(Some(&desc), &mut tap) } != 0 || tap == 0 {
+            return None;
+        }
+        let mut session = TapSession {
+            tap,
+            agg: 0,
+            proc_id: None,
+            started: false,
+        };
+
+        // 2) Aggregate device wrapping the tap so we can run an IOProc on it.
+        let tap_uid = read_uid(tap, kAudioTapPropertyUID)?;
+        let dict = aggregate_description(&tap_uid);
+        let cf_dict: &CFDictionary =
+            unsafe { &*(objc2::rc::Retained::as_ptr(&dict) as *const CFDictionary) };
+        let mut agg: AudioObjectID = 0;
+        if unsafe { AudioHardwareCreateAggregateDevice(cf_dict, NonNull::from(&mut agg)) } != 0
+            || agg == 0
+        {
+            return None;
+        }
+        session.agg = agg;
+
+        // 3) IOProc that flips a flag the moment it sees an audible sample.
+        let audible = Arc::new(AtomicBool::new(false));
+        let audible_cb = audible.clone();
+        let block = RcBlock::new(
+            move |_now: NonNull<AudioTimeStamp>,
+                  in_data: NonNull<AudioBufferList>,
+                  _in_time: NonNull<AudioTimeStamp>,
+                  _out: NonNull<AudioBufferList>,
+                  _out_time: NonNull<AudioTimeStamp>| {
+                if buffers_audible(in_data) {
+                    audible_cb.store(true, Ordering::Relaxed);
+                }
+            },
+        );
+        let mut proc_id: AudioDeviceIOProcID = None;
+        if unsafe {
+            AudioDeviceCreateIOProcIDWithBlock(
+                NonNull::from(&mut proc_id),
+                agg,
+                None,
+                RcBlock::as_ptr(&block) as _,
+            )
+        } != 0
+            || proc_id.is_none()
+        {
+            return None;
+        }
+        session.proc_id = proc_id;
+        if unsafe { AudioDeviceStart(agg, proc_id) } != 0 {
+            return None;
+        }
+        session.started = true;
+
+        // 4) Wait until we hear something or the window elapses.
+        let deadline = Instant::now() + PROBE_WINDOW;
+        while Instant::now() < deadline {
+            if audible.load(Ordering::Relaxed) {
+                break;
             }
-            let mut running: u32 = 0;
-            if !get_u32(
-                device,
-                kAudioDevicePropertyDeviceIsRunningSomewhere,
-                &mut running,
-            ) {
-                return false;
+            std::thread::sleep(POLL_STEP);
+        }
+        Some(audible.load(Ordering::Relaxed))
+        // `session` drops here, tearing the tap down.
+    }
+
+    /// True if any sample across the buffer list exceeds the silence floor.
+    fn buffers_audible(in_data: NonNull<AudioBufferList>) -> bool {
+        // SAFETY: CoreAudio hands us a valid AudioBufferList for the IO cycle;
+        // each buffer's `mData`/`mDataByteSize` describe a float32 sample run.
+        unsafe {
+            let list = in_data.as_ref();
+            let buffers =
+                std::slice::from_raw_parts(list.mBuffers.as_ptr(), list.mNumberBuffers as usize);
+            let mut peak: f32 = 0.0;
+            for buf in buffers {
+                if buf.mData.is_null() {
+                    continue;
+                }
+                let count = buf.mDataByteSize as usize / std::mem::size_of::<f32>();
+                let samples = std::slice::from_raw_parts(buf.mData as *const f32, count);
+                for &s in samples {
+                    let a = s.abs();
+                    if a > peak {
+                        peak = a;
+                    }
+                }
             }
-            running != 0
+            is_audible(peak)
         }
     }
 }
@@ -764,6 +964,30 @@ mod tests {
         assert!(!media_key_resume_allowed(&ResumeToken::Mpris(vec![
             "org.mpris.MediaPlayer2.vlc".to_string()
         ])));
+    }
+
+    // The macOS output tap's pure decision: digital silence is exactly 0.0, so
+    // only a positive peak past the small floor counts as real playback.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn audio_tap_is_audible_separates_silence_from_signal() {
+        assert!(!audio_tap::is_audible(0.0));
+        assert!(!audio_tap::is_audible(0.001));
+        assert!(audio_tap::is_audible(0.05));
+        assert!(audio_tap::is_audible(0.9));
+    }
+
+    // Smoke-test the macOS output-tap FFI end to end: create the global process
+    // tap + aggregate device + IOProc, sample, and tear it all down. The value
+    // is environment-dependent (false on a silent runner), so we only assert it
+    // returns within the probe window without panicking or leaking — that
+    // exercises the CoreAudio/objc2 wiring a mismatch would crash on. macOS
+    // only, where the module exists; absent from the Linux coverage build like
+    // the other platform FFI.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn output_active_probe_resolves_without_panicking() {
+        let _: bool = audio_tap::output_active();
     }
 
     #[test]

--- a/src-tauri/src/media.rs
+++ b/src-tauri/src/media.rs
@@ -445,9 +445,11 @@ mod audio_tap {
     // just ignores denormal/dither noise.
     const SILENCE_THRESHOLD: f32 = 0.003;
     // Upper bound on how long we wait for output before concluding it's silent.
-    // We early-exit the instant an audible sample arrives, so this only delays
-    // the "nothing playing" case (which has nothing to pause anyway).
-    const PROBE_WINDOW: Duration = Duration::from_millis(250);
+    // We early-exit the instant an audible sample arrives (real playback lands
+    // in the first buffer or two, ~10-20ms), so this bound is only paid on the
+    // silent case — which runs synchronously on the break-fire path before the
+    // overlay opens, so keep it tight to avoid janking every silent break.
+    const PROBE_WINDOW: Duration = Duration::from_millis(80);
     const POLL_STEP: Duration = Duration::from_millis(10);
 
     /// Pure decision: is a measured peak amplitude loud enough to be real
@@ -460,7 +462,25 @@ mod audio_tap {
     /// private global process tap, measures the live output signal for at most
     /// [`PROBE_WINDOW`], and tears the tap down. Any FFI failure degrades to
     /// `false` — never a blind Play/Pause toggle on a guess.
+    /// Process taps are macOS 14.2+. On older systems the tap symbols are
+    /// weak-linked (see `build.rs`) and resolve to null, so we must never call
+    /// them. Gating here degrades cleanly: `output_active` returns false, the
+    /// media key is not toggled, so a break neither pauses playing media nor
+    /// starts paused media on < 14.2 — the feature is simply inert there.
+    fn process_tap_supported() -> bool {
+        use objc2_foundation::{NSOperatingSystemVersion, NSProcessInfo};
+        let required = NSOperatingSystemVersion {
+            majorVersion: 14,
+            minorVersion: 2,
+            patchVersion: 0,
+        };
+        NSProcessInfo::processInfo().isOperatingSystemAtLeastVersion(required)
+    }
+
     pub(super) fn output_active() -> bool {
+        if !process_tap_supported() {
+            return false;
+        }
         measure().unwrap_or(false)
     }
 
@@ -519,10 +539,13 @@ mod audio_tap {
                 NonNull::from(&mut cf).cast::<c_void>(),
             )
         };
-        let cf = NonNull::new(cf as *mut CFString)?;
+        // Check the status before adopting the pointer: on a non-zero status we
+        // must not take ownership of whatever `cf` holds (it may be an
+        // uninitialised or non-owned value), so bail before `CFRetained`.
         if status != 0 {
             return None;
         }
+        let cf = NonNull::new(cf as *mut CFString)?;
         // `Get` returns a +1 reference we own; `CFRetained` releases it.
         let owned = unsafe { CFRetained::from_raw(cf) };
         Some(NSString::from_str(&owned.to_string()))
@@ -556,7 +579,33 @@ mod audio_tap {
     }
 
     fn measure() -> Option<bool> {
+        // The IOProc flag and its block are created first, so `block` is
+        // declared before `session`: locals drop in reverse declaration order,
+        // so `session` (whose Drop calls AudioDeviceDestroyIOProcID) tears down
+        // *before* our RcBlock reference is released, on every return path.
+        // CoreAudio Block_copy's the block too, but this makes the ordering
+        // correct by construction instead of relying on that.
+        let audible = Arc::new(AtomicBool::new(false));
+        let audible_cb = audible.clone();
+        let block = RcBlock::new(
+            move |_now: NonNull<AudioTimeStamp>,
+                  in_data: NonNull<AudioBufferList>,
+                  _in_time: NonNull<AudioTimeStamp>,
+                  _out: NonNull<AudioBufferList>,
+                  _out_time: NonNull<AudioTimeStamp>| {
+                if buffers_audible(in_data) {
+                    audible_cb.store(true, Ordering::Relaxed);
+                }
+            },
+        );
+
         // 1) Private global output tap (exclude no processes = tap everything).
+        //    KNOWN LIMITATION (#233 follow-up): a global tap answers "is *any*
+        //    audio playing", not "is the media player playing", so a stray
+        //    system/notification sound inside the probe window can read as
+        //    audible and let the blind Play/Pause key fire. The tight
+        //    PROBE_WINDOW keeps the exposure small; per-source attribution
+        //    isn't available from a global tap.
         let empty: objc2::rc::Retained<NSArray<NSNumber>> = NSArray::from_retained_slice(&[]);
         let desc = unsafe {
             CATapDescription::initStereoGlobalTapButExcludeProcesses(
@@ -593,20 +642,7 @@ mod audio_tap {
         }
         session.agg = agg;
 
-        // 3) IOProc that flips a flag the moment it sees an audible sample.
-        let audible = Arc::new(AtomicBool::new(false));
-        let audible_cb = audible.clone();
-        let block = RcBlock::new(
-            move |_now: NonNull<AudioTimeStamp>,
-                  in_data: NonNull<AudioBufferList>,
-                  _in_time: NonNull<AudioTimeStamp>,
-                  _out: NonNull<AudioBufferList>,
-                  _out_time: NonNull<AudioTimeStamp>| {
-                if buffers_audible(in_data) {
-                    audible_cb.store(true, Ordering::Relaxed);
-                }
-            },
-        );
+        // 3) Install the IOProc (built above) so it flips the flag on audio.
         let mut proc_id: AudioDeviceIOProcID = None;
         if unsafe {
             AudioDeviceCreateIOProcIDWithBlock(


### PR DESCRIPTION
## Summary

A break could **start** media you'd paused on macOS — the #233 regression, resurfaced. The #233 fix gated the blind Play/Pause media key on CoreAudio `kAudioDevicePropertyDeviceIsRunningSomewhere`, believing *"paused media does no device I/O."* That's false: Chrome, Spotify, and Apple Music keep the output device's IOProc alive while paused, so the flag reads "running" when media is paused → the gate passed → the toggle fired → the paused player started, played through the break, and got paused again at the end.

I went down the obvious paths first and ruled them out **empirically**:

- **MediaRemote now-playing** (the genuinely accurate signal) is restricted to **Apple platform binaries** on macOS 15.4+. Identical code under Apple-signed `/usr/bin/swift` returns real data; ad-hoc-compiled — CLI *and* hardened-runtime `.app` — returns empty (`isPlaying=false`, no title). No grantable entitlement; Developer-ID/notarization doesn't qualify. Both the read and `MRMediaRemoteSendCommand` are unusable.
- **Per-process CoreAudio `IsRunningOutput`** has the same over-reporting flaw — browsers route every tab through one always-running audio-service process.

### The fix

Gate on a **CoreAudio process tap** (macOS 14.2+) that measures the *actual output signal*. A paused player contributes digital silence (exactly `0.0`); active playback shows real peaks. It's public, **needs no permission prompt** (verified from CLI, `.app`, and hardened-runtime bundles), and is immune to the device-held-open problem. The probe early-exits the instant it hears audio and tears the tap / aggregate device / IOProc down via an RAII guard. Any FFI failure degrades to "not playing" — never a blind toggle on a guess.

The existing toggle/resume guards (`media_key_pause_allowed` / `media_key_resume_allowed`) are unchanged; only the macOS "is media playing?" signal feeding them changed.

## Test Plan

- [x] New unit test for the pure `is_audible` threshold decision (digital silence `0.0` → not audible).
- [x] New macOS FFI smoke test drives the full tap → aggregate device → IOProc → teardown path.
- [x] **Value verified against ground truth in the compiled Rust** with controlled `afplay` audio: `silent → false`, `playing → true`, `silent again → false`.
- [x] `cargo clippy --all-targets` clean (warnings denied); `cargo fmt --check` clean.
- [x] Full suite green — **1191 passed, 0 failed**.

The macOS FFI is `cfg`'d out of the ubuntu coverage build, so codecov/patch is unaffected (only the pure decision is instrumented, and it's macOS-gated like the other platform shims).

## Reviewer notes / follow-ups

- **Verify on a notarized build before release.** No prompt appeared from CLI / ad-hoc / hardened-runtime, but only a notarized Developer-ID build is the true release proxy. `NSAudioCaptureUsageDescription` is added to `Info.plist` defensively so a future OS that *does* gate the tap degrades to a prompt instead of a hard crash.
- **Latency:** the probe blocks break-start up to ~250ms in the *silent* case (early-exits on first audible sample) — comparable to the Linux gdbus path, tunable if desired.
- **Coverage gap by design:** browser/native media is now detected by real sound, but Windows still uses the display-wake proxy (parity tracked in #234).

Closes #233.

🤖 Generated with [Claude Code](https://claude.com/claude-code)