### PR TITLE
feat(i18n): translation framework with auto-discovering catalogs

### DIFF
--- a/.github/audit/cspell.json
+++ b/.github/audit/cspell.json
@@ -13,6 +13,7 @@
     "**/package-lock.json",
     "**/.vitepress/cache/**",
     "**/.claude/**",
+    "**/src/i18n/locales/**",
     "**/icons/**",
     "**/public/**",
     "**/*.svg",

--- a/.github/audit/cspell/project-words.txt
+++ b/.github/audit/cspell/project-words.txt
@@ -194,3 +194,6 @@ ungranted
 unsandboxed
 acks
 unacked
+CLDR
+endonym
+Norsk

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Versions on the `0.0.X` line are public beta releases; `0.1.X` and onwards will 
 
 ### Added
 
-- **Groundwork for translating Entracte into other languages.** Introduces an internationalisation (i18n) framework: every piece of interface text lives in a per-language catalog (`src/i18n/locales/<code>/`), and the app picks your language from the operating system automatically. The **Pause until** picker is the first surface translated, shipping in English and Norwegian (Bokmål); the rest of the interface follows. Adding a new language is a matter of dropping in a folder of translated text — no code changes — so contributions are welcome.
+- **Groundwork for translating Entracte into other languages.** Introduces an internationalisation (i18n) framework: every piece of interface text lives in a per-language catalog (`src/i18n/locales/<code>/`), and the app picks your language from the operating system automatically. The **Pause until** picker is the first surface translated, shipping in English and Norwegian (Bokmål); the rest of the interface follows. Adding a new language is a matter of dropping in a folder of translated text — no code changes — so contributions are welcome. ([#252](https://github.com/drmowinckels/entracte/pull/252))
 
 ## [0.0.9] — 2026-06-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Versions on the `0.0.X` line are public beta releases; `0.1.X` and onwards will 
 
 ## [Unreleased]
 
+### Added
+
+- **Groundwork for translating Entracte into other languages.** Introduces an internationalisation (i18n) framework: every piece of interface text lives in a per-language catalog (`src/i18n/locales/<code>/`), and the app picks your language from the operating system automatically. The **Pause until** picker is the first surface translated, shipping in English and Norwegian (Bokmål); the rest of the interface follows. Adding a new language is a matter of dropping in a folder of translated text — no code changes — so contributions are welcome.
+
 ## [0.0.9] — 2026-06-22
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,13 +49,43 @@ The first `cargo` build takes a couple of minutes. After that, hot reload is ins
 - Bug reports — particularly with the diagnostics bundle from **Settings → About → Copy diagnostics report** attached.
 - Per-OS implementations that close gaps in [Per-OS detection](.github/AGENTS.md#per-os-detection) — Linux DnD, Wayland-friendly idle detection, etc.
 - Accessibility improvements (axe-clean output is a hard CI gate; if you see real-world AT issues that axe doesn't catch, please open an issue).
-- Translations / internationalisation if you're interested — none yet, but the renderer is structured to make it tractable.
+- Translations / internationalisation — the framework is in place and English + Norwegian ship today. See [Translations](#translations) below; adding a language needs no code changes.
 
 **Out of scope for now:**
 
 - Plugin / extension systems. Considered, decided against.
 - Cloud sync, telemetry, account systems. Entracte is local-only by design.
 - Forks of the scheduler logic for very specific personal workflows — those are better as your own fork than as core features.
+
+## Translations
+
+Interface text lives in per-language catalogs under [`src/i18n/locales/`](src/i18n/locales). Each language is a folder of small JSON files, one per UI surface — the filename is the key's namespace, so `pause.json`'s `cancel` is looked up as `pause.cancel`:
+
+```
+src/i18n/locales/
+  en/                 # English — the source of truth for the key set
+    _meta.json        # { "label": "English", "order": 0 }
+    pause.json
+  nb/                 # Norwegian Bokmål
+    _meta.json        # { "label": "Norsk", "order": 20 }
+    pause.json
+```
+
+English defines every key; the TypeScript `Catalog` type is derived straight from `en/`, so calling `t("pause.cancel")` is checked at compile time, and a test asserts every other language carries exactly the English key set (no missing or stray keys).
+
+**Add a language** — no code changes, nothing to register:
+
+1. **Copy the folder.** Duplicate `src/i18n/locales/en/` to `src/i18n/locales/<code>/`, where `<code>` is the [ISO 639-1 code](https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes) (e.g. `de`, `fr`, `nn`).
+2. **Set `_meta.json`.** `label` is the language's own name (its endonym, e.g. `Deutsch`); `order` is its place in the language picker (English is `0`).
+3. **Translate the values.** Keep every key exactly as in `en/`; change only the values. `{name}` placeholders are filled in at runtime — keep them — and a plural entry stays an object: `{ "one": "{count} break", "other": "{count} breaks" }`.
+4. **Check it.** The registry auto-discovers the folder; browser/OS language detection, the parity test, and the fallback chain all pick it up automatically.
+
+   ```sh
+   npm run typecheck   # flags any structural mistakes
+   npm test            # the registry test lists any missing/extra keys
+   ```
+
+Locale files are excluded from the spell-checker, so translated prose won't trip `audit:spell`.
 
 ## Cross-platform parity
 

--- a/src/i18n/LangProvider.test.tsx
+++ b/src/i18n/LangProvider.test.tsx
@@ -1,0 +1,124 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+
+vi.mock("@tauri-apps/api/core", () => ({ invoke: vi.fn() }));
+import { invoke } from "@tauri-apps/api/core";
+const invokeMock = vi.mocked(invoke);
+
+const { LangProvider, useT, useLocale, useLang } = await import("./index");
+const { default: nbPause } = await import("./locales/nb/pause.json");
+const { default: enPause } = await import("./locales/en/pause.json");
+
+function Probe() {
+  const t = useT();
+  const [locale, setLocale] = useLocale();
+  const lang = useLang();
+  return (
+    <div>
+      <span data-testid="locale">{locale}</span>
+      <span data-testid="hook-locale">{lang.locale}</span>
+      <span data-testid="cancel">{t("pause.cancel")}</span>
+      <button type="button" onClick={() => setLocale("nb")}>
+        to-nb
+      </button>
+    </div>
+  );
+}
+
+const locale = () => screen.getByTestId("locale").textContent;
+const cancel = () => screen.getByTestId("cancel").textContent;
+
+afterEach(() => {
+  cleanup();
+  invokeMock.mockReset();
+  localStorage.clear();
+  document.documentElement.removeAttribute("lang");
+});
+
+describe("LangProvider", () => {
+  it("resolves the OS locale when nothing is saved", async () => {
+    invokeMock.mockResolvedValue("nb-NO");
+    render(
+      <LangProvider>
+        <Probe />
+      </LangProvider>,
+    );
+    await waitFor(() => expect(locale()).toBe("nb"));
+    expect(cancel()).toBe(nbPause.cancel);
+    expect(document.documentElement.lang).toBe("nb");
+    expect(localStorage.getItem("entracte-lang")).toBe("nb");
+  });
+
+  it("honours a saved choice and skips the OS probe", async () => {
+    localStorage.setItem("entracte-lang", "nb");
+    invokeMock.mockResolvedValue("en-US");
+    render(
+      <LangProvider>
+        <Probe />
+      </LangProvider>,
+    );
+    expect(locale()).toBe("nb");
+    expect(cancel()).toBe(nbPause.cancel);
+    expect(invokeMock).not.toHaveBeenCalled();
+  });
+
+  it("degrades to English when the OS probe fails", async () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    invokeMock.mockRejectedValue(new Error("no backend"));
+    render(
+      <LangProvider>
+        <Probe />
+      </LangProvider>,
+    );
+    await waitFor(() => expect(error).toHaveBeenCalled());
+    expect(locale()).toBe("en");
+    expect(cancel()).toBe(enPause.cancel);
+    error.mockRestore();
+  });
+
+  it("persists and reflects a language chosen at runtime", async () => {
+    invokeMock.mockResolvedValue("en-US");
+    render(
+      <LangProvider>
+        <Probe />
+      </LangProvider>,
+    );
+    await waitFor(() => expect(locale()).toBe("en"));
+    fireEvent.click(screen.getByRole("button", { name: "to-nb" }));
+    await waitFor(() => expect(locale()).toBe("nb"));
+    expect(localStorage.getItem("entracte-lang")).toBe("nb");
+    expect(document.documentElement.lang).toBe("nb");
+  });
+
+  it("falls back to the default locale outside a provider", () => {
+    render(<Probe />);
+    expect(locale()).toBe("en");
+    expect(screen.getByTestId("hook-locale").textContent).toBe("en");
+    expect(cancel()).toBe(enPause.cancel);
+    fireEvent.click(screen.getByRole("button", { name: "to-nb" }));
+    expect(locale()).toBe("en");
+  });
+
+  it("tolerates storage that throws (private mode) and still detects the OS", async () => {
+    const getItem = vi
+      .spyOn(globalThis.localStorage, "getItem")
+      .mockImplementation(() => {
+        throw new Error("storage blocked");
+      });
+    invokeMock.mockResolvedValue("nb-NO");
+    render(
+      <LangProvider>
+        <Probe />
+      </LangProvider>,
+    );
+    await waitFor(() => expect(locale()).toBe("nb"));
+    getItem.mockRestore();
+  });
+});

--- a/src/i18n/LangProvider.tsx
+++ b/src/i18n/LangProvider.tsx
@@ -1,0 +1,99 @@
+import { createContext, useContext, useEffect, useMemo, useState } from "react";
+import type { ReactNode } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { DEFAULT_LOCALE, isLocale, resolveLocale } from "./registry";
+import type { Locale } from "./registry";
+import { makeT } from "./translate";
+import type { TFunc } from "./translate";
+
+const LANG_KEY = "entracte-lang";
+
+interface LangContextValue {
+  locale: Locale;
+  setLocale: (locale: Locale) => void;
+  t: TFunc;
+}
+
+const LangContext = createContext<LangContextValue | null>(null);
+
+function readSaved(): Locale | null {
+  try {
+    const saved = localStorage.getItem(LANG_KEY);
+    return saved && isLocale(saved) ? saved : null;
+  } catch {
+    // storage unavailable (private mode / disabled) — fall through
+    return null;
+  }
+}
+
+export function LangProvider({ children }: { children: ReactNode }) {
+  const [locale, setLocale] = useState<Locale>(
+    () => readSaved() ?? DEFAULT_LOCALE,
+  );
+
+  // A saved choice wins; otherwise resolve from the OS locale. The WebView's
+  // navigator/Intl report en-US regardless of the OS region in this
+  // non-localised app, so the backend's `get_locale` is the only reliable
+  // source. Runs once, after the first paint (which uses the saved value or
+  // English) — so a missing backend degrades to English rather than blocking.
+  useEffect(() => {
+    if (readSaved()) return;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const tag = await invoke<string>("get_locale");
+        if (!cancelled && tag) setLocale(resolveLocale(tag));
+      } catch (e) {
+        console.error("get_locale failed", e);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    document.documentElement.lang = locale;
+    try {
+      localStorage.setItem(LANG_KEY, locale);
+    } catch {
+      // storage unavailable — degrades gracefully
+    }
+  }, [locale]);
+
+  const t = useMemo(() => makeT(locale), [locale]);
+  const value = useMemo<LangContextValue>(
+    () => ({ locale, setLocale, t }),
+    [locale, t],
+  );
+
+  return <LangContext.Provider value={value}>{children}</LangContext.Provider>;
+}
+
+// Outside a provider, resolve against the default locale instead of throwing,
+// so a component can render in isolation (e.g. unit tests) without ceremony.
+function useLangContext(): LangContextValue {
+  const ctx = useContext(LangContext);
+  const fallback = useMemo<LangContextValue>(
+    () => ({
+      locale: DEFAULT_LOCALE,
+      setLocale: () => {},
+      t: makeT(DEFAULT_LOCALE),
+    }),
+    [],
+  );
+  return ctx ?? fallback;
+}
+
+export function useLang(): LangContextValue {
+  return useLangContext();
+}
+
+export function useT(): TFunc {
+  return useLangContext().t;
+}
+
+export function useLocale(): [Locale, (locale: Locale) => void] {
+  const { locale, setLocale } = useLangContext();
+  return [locale, setLocale];
+}

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -1,0 +1,18 @@
+// The catalog's type is derived directly from the English JSON — English is the
+// source of truth for the key set, and `import type` means this carries no
+// runtime cost and nothing to regenerate. Each namespace file contributes its
+// keys under a `<filename>.` prefix (matching how `registry.ts` merges them at
+// runtime), so `pause.json`'s `cancel` becomes the key `pause.cancel`.
+//
+// Adding a UI surface = drop a `locales/en/<surface>.json`, then add one
+// `import type` and one `& Prefixed<…>` line below. Adding a *language* needs
+// no change here — see CONTRIBUTING.md.
+import enPause from "./locales/en/pause.json";
+
+type Prefixed<NS extends string, T> = {
+  [K in keyof T as `${NS}.${string & K}`]: T[K];
+};
+
+export type Catalog = Prefixed<"pause", typeof enPause>;
+
+export type TKey = keyof Catalog;

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,0 +1,19 @@
+// Public surface for the i18n module. Internal files import each other directly
+// (catalog/locales → registry → translate → LangProvider); only consumers
+// import from here, so there is no cycle through this barrel.
+
+export type { Catalog, TKey } from "./catalog";
+export type { Plural, Entry, LocaleMeta } from "./types";
+export {
+  LOCALES,
+  DEFAULT_LOCALE,
+  LOCALE_LABELS,
+  LOCALE_ORDER,
+  LOCALE_ALIASES,
+  isLocale,
+  resolveLocale,
+} from "./registry";
+export type { Locale } from "./registry";
+export { makeT, translate, interpolate, resolveEntry } from "./translate";
+export type { TFunc, Vars } from "./translate";
+export { LangProvider, useT, useLocale, useLang } from "./LangProvider";

--- a/src/i18n/locales/en/_meta.json
+++ b/src/i18n/locales/en/_meta.json
@@ -1,0 +1,4 @@
+{
+  "label": "English",
+  "order": 0
+}

--- a/src/i18n/locales/en/pause.json
+++ b/src/i18n/locales/en/pause.json
@@ -1,0 +1,10 @@
+{
+  "title": "Pause until",
+  "hint": "Suppress all breaks until the chosen date and time, shown in your region's format.",
+  "day": "Day",
+  "month": "Month",
+  "year": "Year",
+  "time": "Time",
+  "cancel": "Cancel",
+  "pause": "Pause"
+}

--- a/src/i18n/locales/nb/_meta.json
+++ b/src/i18n/locales/nb/_meta.json
@@ -1,0 +1,4 @@
+{
+  "label": "Norsk",
+  "order": 20
+}

--- a/src/i18n/locales/nb/pause.json
+++ b/src/i18n/locales/nb/pause.json
@@ -1,0 +1,10 @@
+{
+  "title": "Sett på pause til",
+  "hint": "Demp alle pauser fram til valgt dato og tid, vist i din regions format.",
+  "day": "Dag",
+  "month": "Måned",
+  "year": "År",
+  "time": "Tid",
+  "cancel": "Avbryt",
+  "pause": "Pause"
+}

--- a/src/i18n/registry.test.ts
+++ b/src/i18n/registry.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import {
+  LOCALES,
+  LOCALE_LABELS,
+  LOCALE_ORDER,
+  LOCALE_ALIASES,
+  DEFAULT_LOCALE,
+  isLocale,
+  resolveLocale,
+} from "./index";
+
+const codes = Object.keys(LOCALES);
+const enKeys = Object.keys(LOCALES[DEFAULT_LOCALE]).sort();
+
+describe("locale registry", () => {
+  it("discovers more than just English", () => {
+    expect(codes.length).toBeGreaterThan(1);
+    expect(codes).toContain("nb");
+  });
+
+  it("every locale translates exactly the English key set", () => {
+    for (const code of codes) {
+      expect(Object.keys(LOCALES[code]).sort()).toEqual(enKeys);
+    }
+  });
+
+  it("namespaces every key by its source file", () => {
+    expect(enKeys.every((k) => k.includes("."))).toBe(true);
+    expect(LOCALES[DEFAULT_LOCALE]["pause.title"]).toBe("Pause until");
+  });
+
+  it("plural keys stay plural in every locale", () => {
+    for (const key of enKeys) {
+      const isPlural =
+        typeof (LOCALES[DEFAULT_LOCALE] as Record<string, unknown>)[key] ===
+        "object";
+      for (const code of codes) {
+        const entry = (LOCALES[code] as Record<string, unknown>)[key];
+        expect(typeof entry === "object").toBe(isPlural);
+      }
+    }
+  });
+
+  it("every locale has a label and a slot in the picker order", () => {
+    for (const code of codes) {
+      expect(LOCALE_LABELS[code]).toBeTruthy();
+      expect(LOCALE_ORDER).toContain(code);
+    }
+    expect(LOCALE_ORDER).toHaveLength(codes.length);
+  });
+
+  it("orders the picker by each locale's declared order (English first)", () => {
+    expect(LOCALE_ORDER[0]).toBe("en");
+  });
+
+  it("the default locale is registered", () => {
+    expect(isLocale(DEFAULT_LOCALE)).toBe(true);
+    expect(isLocale("definitely-not-a-locale")).toBe(false);
+  });
+
+  it("resolves OS tags to a supported locale", () => {
+    expect(resolveLocale("nb-NO")).toBe("nb");
+    expect(resolveLocale("en-US")).toBe("en");
+    expect(resolveLocale("NB")).toBe("nb");
+    expect(resolveLocale("de-DE")).toBe(DEFAULT_LOCALE);
+  });
+
+  it("maps aliased language codes onto a supported locale", () => {
+    expect(LOCALE_ALIASES.nn).toBe("nb");
+    expect(resolveLocale("nn")).toBe("nb");
+    expect(resolveLocale("no")).toBe("nb");
+  });
+});

--- a/src/i18n/registry.ts
+++ b/src/i18n/registry.ts
@@ -1,0 +1,94 @@
+import type { Entry, LocaleMeta } from "./types";
+
+// The locale registry auto-discovers every folder under `locales/`. To add a
+// language, drop a `locales/<code>/` directory holding a `_meta.json` (its name
+// + picker position) and one JSON file per UI surface — nothing here needs
+// editing. The surface filename is the key namespace, so `pause.json`'s
+// `cancel` is looked up as `pause.cancel`. See CONTRIBUTING.md.
+
+const namespaceFiles = import.meta.glob<Record<string, Entry>>(
+  "./locales/*/*.json",
+  { eager: true, import: "default" },
+);
+
+const metaFiles = import.meta.glob<LocaleMeta>("./locales/*/_meta.json", {
+  eager: true,
+  import: "default",
+});
+
+interface RegisteredLocale {
+  code: string;
+  catalog: Record<string, Entry>;
+  meta: LocaleMeta;
+}
+
+const byCode = new Map<string, { catalog: Record<string, Entry> }>();
+
+// `./locales/<code>/<file>.json` — the glob guarantees this shape, so the last
+// two path segments are the locale code and the namespace (the filename).
+function segments(path: string): { code: string; file: string } {
+  const parts = path.split("/");
+  return {
+    code: parts[parts.length - 2],
+    file: parts[parts.length - 1].replace(/\.json$/, ""),
+  };
+}
+
+for (const [path, mod] of Object.entries(namespaceFiles)) {
+  const { code, file } = segments(path);
+  if (file === "_meta") continue;
+  const entry = byCode.get(code) ?? { catalog: {} };
+  for (const [key, value] of Object.entries(mod)) {
+    entry.catalog[`${file}.${key}`] = value;
+  }
+  byCode.set(code, entry);
+}
+
+const registered: RegisteredLocale[] = Object.entries(metaFiles)
+  .map(([path, meta]) => {
+    const { code } = segments(path);
+    return { code, catalog: byCode.get(code)?.catalog ?? {}, meta };
+  })
+  .sort(
+    (a, b) =>
+      (a.meta.order ?? 0) - (b.meta.order ?? 0) || a.code.localeCompare(b.code),
+  );
+
+// Locale codes are discovered at build time, so this is a string rather than a
+// literal union. Per-key completeness is still enforced — see registry.test.ts,
+// which asserts every locale carries exactly the English key set.
+export type Locale = string;
+
+export const LOCALES: Record<
+  Locale,
+  Record<string, Entry>
+> = Object.fromEntries(registered.map((r) => [r.code, r.catalog]));
+
+export const LOCALE_LABELS: Record<Locale, string> = Object.fromEntries(
+  registered.map((r) => [r.code, r.meta.label]),
+);
+
+// Picker order, as discovered (sorted by each folder's `_meta.order`).
+export const LOCALE_ORDER: Locale[] = registered.map((r) => r.code);
+
+export const DEFAULT_LOCALE: Locale = "en";
+
+// Browser/OS language codes that map to a supported locale beyond an exact base
+// match (e.g. Nynorsk/legacy "no" → Bokmål). Keep this small and explicit.
+export const LOCALE_ALIASES: Record<string, Locale> = {
+  no: "nb",
+  nn: "nb",
+};
+
+export function isLocale(value: string): boolean {
+  return value in LOCALES;
+}
+
+// Resolve a browser/OS tag (e.g. "nb-NO", "en-US") to a supported locale:
+// exact base match, then an alias, otherwise the default.
+export function resolveLocale(tag: string): Locale {
+  const base = tag.toLowerCase().split("-")[0];
+  if (isLocale(base)) return base;
+  if (base in LOCALE_ALIASES) return LOCALE_ALIASES[base];
+  return DEFAULT_LOCALE;
+}

--- a/src/i18n/translate.test.ts
+++ b/src/i18n/translate.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { translate, interpolate, resolveEntry, makeT } from "./index";
+import type { TKey } from "./index";
+import nbPause from "./locales/nb/pause.json";
+
+describe("interpolate", () => {
+  it("fills named placeholders", () => {
+    expect(interpolate("Pause until {when}", { when: "noon" })).toBe(
+      "Pause until noon",
+    );
+  });
+
+  it("coerces numbers and leaves unknown placeholders verbatim", () => {
+    expect(interpolate("{count} of {missing}", { count: 3 })).toBe(
+      "3 of {missing}",
+    );
+  });
+
+  it("returns the template untouched when no vars are given", () => {
+    expect(interpolate("{count} breaks")).toBe("{count} breaks");
+  });
+});
+
+describe("resolveEntry", () => {
+  it("interpolates a string entry", () => {
+    expect(resolveEntry("Hi {name}", "en", { name: "Ada" })).toBe("Hi Ada");
+  });
+
+  it("selects the plural form per the locale's CLDR rule", () => {
+    const entry = { one: "{count} break", other: "{count} breaks" };
+    expect(resolveEntry(entry, "en", { count: 1 })).toBe("1 break");
+    expect(resolveEntry(entry, "en", { count: 4 })).toBe("4 breaks");
+    expect(resolveEntry(entry, "en", { count: 0 })).toBe("0 breaks");
+  });
+
+  it("uses the locale's own plural rules", () => {
+    const entry = { one: "{count} pause", other: "{count} pauser" };
+    expect(resolveEntry(entry, "nb", { count: 1 })).toBe("1 pause");
+    expect(resolveEntry(entry, "nb", { count: 2 })).toBe("2 pauser");
+  });
+});
+
+describe("translate", () => {
+  it("resolves a key in the requested locale", () => {
+    expect(translate("en", "pause.title")).toBe("Pause until");
+    expect(translate("nb", "pause.cancel")).toBe(nbPause.cancel);
+  });
+
+  it("falls back to English for an unregistered locale", () => {
+    expect(translate("de", "pause.title")).toBe("Pause until");
+  });
+
+  it("falls back to the key itself for an unknown key", () => {
+    expect(translate("en", "does.not.exist" as TKey)).toBe("does.not.exist");
+  });
+
+  it("makeT binds a locale", () => {
+    expect(makeT("nb")("pause.pause")).toBe("Pause");
+    expect(makeT("en")("pause.day")).toBe("Day");
+  });
+});

--- a/src/i18n/translate.ts
+++ b/src/i18n/translate.ts
@@ -1,0 +1,44 @@
+import type { TKey } from "./catalog";
+import { DEFAULT_LOCALE, LOCALES } from "./registry";
+import type { Locale } from "./registry";
+import type { Entry } from "./types";
+
+export type Vars = Record<string, string | number>;
+export type TFunc = (key: TKey, vars?: Vars) => string;
+
+// Replace `{name}` placeholders; an unknown placeholder is left verbatim so a
+// typo surfaces in the UI rather than vanishing.
+export function interpolate(template: string, vars?: Vars): string {
+  if (!vars) return template;
+  return template.replace(/\{(\w+)\}/g, (match, name: string) =>
+    name in vars ? String(vars[name]) : match,
+  );
+}
+
+// Render a single catalog entry: a string is interpolated directly; a plural
+// group selects its form via the locale's CLDR rule (Intl.PluralRules), keyed
+// off `vars.count`. Pure and catalog-independent, so it's the unit under test
+// for both shapes.
+export function resolveEntry(
+  entry: Entry,
+  locale: Locale,
+  vars?: Vars,
+): string {
+  if (typeof entry === "string") return interpolate(entry, vars);
+  const count = Number(vars?.count ?? 0);
+  const rule = new Intl.PluralRules(locale).select(count);
+  return interpolate(rule === "one" ? entry.one : entry.other, vars);
+}
+
+// Resolve a key for a locale, falling back active locale → English → the key
+// itself, so a gap never blanks the UI. `TKey` plus English completeness make
+// the key-itself fallback unreachable in typed use; it only guards a cast.
+export function translate(locale: Locale, key: TKey, vars?: Vars): string {
+  const entry: Entry | undefined =
+    LOCALES[locale]?.[key] ?? LOCALES[DEFAULT_LOCALE]?.[key];
+  return entry == null ? String(key) : resolveEntry(entry, locale, vars);
+}
+
+export function makeT(locale: Locale): TFunc {
+  return (key, vars) => translate(locale, key, vars);
+}

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -1,0 +1,17 @@
+// Shared shapes for the translation catalogs. A catalog entry is either a
+// plain string or a plural group; `{name}` placeholders are filled at call
+// time. The catalogs themselves live as JSON under `locales/<code>/`, one file
+// per UI surface (the filename is the key namespace, e.g. `pause.json` →
+// `pause.*`). See CONTRIBUTING.md for how to add a language.
+export type Plural = { one: string; other: string };
+export type Entry = string | Plural;
+
+// Per-language metadata, stored as `locales/<code>/_meta.json`, so the registry
+// can discover everything about a language from its folder alone.
+export interface LocaleMeta {
+  // The language's name in its own language (endonym), e.g. "Norsk".
+  label: string;
+  // Position in the language picker; lower comes first. English stays first
+  // at 0.
+  order?: number;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,12 +2,15 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
 import { installGlobalRendererErrorReporters } from "./error-boundary";
+import { LangProvider } from "./i18n";
 import "./brand.css";
 
 installGlobalRendererErrorReporters();
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>
-    <App />
+    <LangProvider>
+      <App />
+    </LangProvider>
   </React.StrictMode>,
 );

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -1,6 +1,34 @@
 import { afterEach } from "vitest";
 import { cleanup } from "@testing-library/react";
 
+// happy-dom doesn't expose a `localStorage`, but the WebView the app runs in
+// does. Install a minimal in-memory stand-in so code that persists to it (e.g.
+// the language choice) behaves as it does in the real app. Defined rather than
+// read-then-assigned, so it never trips Node's experimental-localStorage probe.
+const localStorageStore = new Map<string, string>();
+Object.defineProperty(globalThis, "localStorage", {
+  configurable: true,
+  value: {
+    getItem: (key: string) =>
+      localStorageStore.has(key)
+        ? (localStorageStore.get(key) as string)
+        : null,
+    setItem: (key: string, value: string) => {
+      localStorageStore.set(key, String(value));
+    },
+    removeItem: (key: string) => {
+      localStorageStore.delete(key);
+    },
+    clear: () => {
+      localStorageStore.clear();
+    },
+    key: (index: number) => Array.from(localStorageStore.keys())[index] ?? null,
+    get length() {
+      return localStorageStore.size;
+    },
+  } as Storage,
+});
+
 afterEach(() => {
   cleanup();
 });

--- a/src/views/pause-picker.test.tsx
+++ b/src/views/pause-picker.test.tsx
@@ -13,6 +13,8 @@ import { invoke } from "@tauri-apps/api/core";
 const invokeMock = vi.mocked(invoke);
 
 const { PausePicker } = await import("./pause-picker");
+const { LangProvider } = await import("../i18n");
+const { default: nbPause } = await import("../i18n/locales/nb/pause.json");
 
 function mockBackend(opts: { locale?: string; clock?: string } = {}) {
   invokeMock.mockImplementation(async (cmd: string) => {
@@ -25,6 +27,7 @@ function mockBackend(opts: { locale?: string; clock?: string } = {}) {
 afterEach(() => {
   cleanup();
   invokeMock.mockReset();
+  localStorage.clear();
 });
 
 const combo = (name: string) =>
@@ -89,5 +92,19 @@ describe("PausePicker", () => {
     fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
     expect(invokeMock).toHaveBeenCalledWith("close_pause_window");
     expect(invokeMock).not.toHaveBeenCalledWith("pause", expect.anything());
+  });
+
+  it("renders its labels in the active language", async () => {
+    localStorage.setItem("entracte-lang", "nb");
+    mockBackend({ locale: "nb-NO" });
+    render(
+      <LangProvider>
+        <PausePicker />
+      </LangProvider>,
+    );
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { name: nbPause.title })).toBeTruthy(),
+    );
+    expect(screen.getByRole("button", { name: nbPause.cancel })).toBeTruthy();
   });
 });

--- a/src/views/pause-picker.tsx
+++ b/src/views/pause-picker.tsx
@@ -10,6 +10,7 @@ import {
   monthNames,
   type DateField,
 } from "../lib/locale-format";
+import { useT } from "../i18n";
 import type { ClockFormat } from "./settings/types";
 import "./pause-picker.css";
 
@@ -25,6 +26,7 @@ function clampDay(year: number, month: number, day: number): number {
  * WebView locks to its own locale (en-US in a non-localised app) regardless
  * of the OS region. Pauses all breaks until the chosen moment, then closes. */
 export function PausePicker() {
+  const t = useT();
   const now = useMemo(() => new Date(), []);
   const [locale, setLocale] = useState("en-US");
   const [clockFormat, setClockFormat] = useState<ClockFormat>("24h");
@@ -94,7 +96,7 @@ export function PausePicker() {
       return (
         <select
           key="day"
-          aria-label="Day"
+          aria-label={t("pause.day")}
           value={day}
           onChange={(e) => setDay(Number(e.target.value))}
         >
@@ -110,7 +112,7 @@ export function PausePicker() {
       return (
         <select
           key="month"
-          aria-label="Month"
+          aria-label={t("pause.month")}
           value={month}
           onChange={(e) => setMonth(Number(e.target.value))}
         >
@@ -125,7 +127,7 @@ export function PausePicker() {
     return (
       <select
         key="year"
-        aria-label="Year"
+        aria-label={t("pause.year")}
         value={year}
         onChange={(e) => setYear(Number(e.target.value))}
       >
@@ -140,18 +142,15 @@ export function PausePicker() {
 
   return (
     <main className="pause-picker">
-      <h1 className="pause-picker-title">Pause until</h1>
-      <p className="pause-picker-hint">
-        Suppress all breaks until the chosen date and time, shown in your
-        region&apos;s format.
-      </p>
+      <h1 className="pause-picker-title">{t("pause.title")}</h1>
+      <p className="pause-picker-hint">{t("pause.hint")}</p>
       <div className="pause-picker-date">{order.map(fieldFor)}</div>
       <label className="pause-picker-time">
-        <span>Time</span>
+        <span>{t("pause.time")}</span>
         <input
           type="text"
           className="pause-picker-input"
-          aria-label="Time"
+          aria-label={t("pause.time")}
           inputMode="numeric"
           spellCheck={false}
           placeholder={clockFormat === "12h" ? "h:mm AM/PM" : "HH:MM"}
@@ -173,14 +172,14 @@ export function PausePicker() {
       </label>
       <div className="pause-picker-actions">
         <button type="button" className="secondary" onClick={close}>
-          Cancel
+          {t("pause.cancel")}
         </button>
         <button
           type="button"
           disabled={secs === null}
           onClick={() => void submit()}
         >
-          Pause
+          {t("pause.pause")}
         </button>
       </div>
     </main>


### PR DESCRIPTION
## Summary

Sets up an internationalisation (i18n) system for Entracte, so the interface can be translated — the first slice of the multi-PR effort discussed for full localisation.

**JSON is the single source of truth** (not TS), chosen deliberately: Entracte is two runtimes — the React WebView *and* the native Rust side (tray menu, window titles, notifications). JSON is the one format both can read, so a later PR can have the Rust side read the very same catalogs (`serde_json` is already a dependency) without a TS→Rust codegen. This is the Hugo-style "one catalog, consumed everywhere" model.

We keep TypeScript safety on top: the `Catalog` type and the `TKey` union that type-checks every `t("…")` call are derived **directly** from the English JSON via `import type` — no generated file to drift — and a registry test asserts every other language carries exactly the English key set.

### How it works
- **Catalogs:** `src/i18n/locales/<code>/` — one JSON file per UI surface (the filename is the key namespace, e.g. `pause.json` → `pause.*`) plus a `_meta.json` (the language's own name + picker order).
- **Auto-discovery:** a registry globs the folders via `import.meta.glob`, so **adding a language is a drop-in folder — nothing to register**.
- **Resolution:** `translate` does `{var}` interpolation, `Intl.PluralRules` plural groups, and active-locale → English → key fallback.
- **Provider:** `LangProvider`/`useT`/`useLocale` — a saved choice wins, otherwise the language is resolved from the OS via the existing `get_locale` backend (the WebView's own `navigator`/`Intl` report `en-US` regardless of region, so the backend is the only reliable source).
- **First surface:** the **Pause until** picker is fully translated in **English** and **Norwegian (Bokmål)** as the end-to-end proof. The rest of the UI follows in subsequent PRs.

### Notable
- Adds a minimal `localStorage` stand-in to the shared test setup (happy-dom exposes none), so the language-persistence path is exercised as it is in the real WebView.
- Excludes `src/i18n/locales/**` from cspell, so translated prose (in any language) never trips the spell-checker — keeping "add a language" zero-config.
- Documents the registration-free "add a language" flow in CONTRIBUTING.

### Heads-up for the next PRs
The entry JS bundle is now **118.87 kB gzipped against the 120 kB `size-limit` budget**. The Settings (~1.5k strings) and overlay catalogs in PR2/PR3 will exceed it bundled into one chunk — those PRs will need per-window code-splitting (the overlay is cold-start-sensitive) or a budget bump. Flagging now.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm test` — **846 passing** (new: registry parity, interpolation/plural/fallback, `LangProvider` detect/persist/storage-throws, pause-picker renders in the active language)
- [x] `npm run lint` — 0 errors (1 pre-existing warning, unrelated)
- [x] `npm run format:check` — clean
- [x] `npm run audit:knip` — exit 0
- [x] `npm run audit:spell` — 0 issues
- [x] `npm run audit:size` — within budget (118.87/120 kB JS, 6.88/8 kB CSS)
- [x] `npm run audit:a11y` — axe + renderer-console clean across 16 audits
- [x] Coverage — `src/i18n` 100% lines/statements/functions; pause-picker patch lines covered

🤖 Generated with [Claude Code](https://claude.com/claude-code)