### PR TITLE
chore(deps): nightly security audit 2026-07-01

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -135,9 +135,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arbitrary"
@@ -4333,9 +4333,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",


### PR DESCRIPTION
## Nightly Security Audit — 2026-07-01

### Rust advisories fixed (2 SAFE patch upgrades)

| Advisory | Package | From → To | Severity | Description |
|---|---|---|---|---|
| [RUSTSEC-2026-0185](https://github.com/quinn-rs/quinn/pull/2694) | `quinn-proto` | 0.11.14 → 0.11.15 | HIGH (CVSS 7.5, A:H) | Remote memory exhaustion via unbounded out-of-order stream reassembly |
| [RUSTSEC-2026-0190](https://rustsec.org/advisories/RUSTSEC-2026-0190) | `anyhow` | 1.0.102 → 1.0.103 | Unsound | Soundness advisory resolved by patch release |

Both are patch-level bumps with no breaking changes.

### Node advisories

None — `npm audit` returned zero vulnerabilities.

### MANUAL findings (no action needed — already tracked)

| Advisory | Package | Reason | Issue |
|---|---|---|---|
| RUSTSEC-2024-0429 | `glib@0.18.5` (unsound) | No patch; requires GTK4 migration via Tauri. | [#84](https://github.com/drmowinckels/entracte/issues/84) |
| RUSTSEC-2026-0122 | `rkyv@0.7.46` (unsound) | Requires rkyv ≥0.8.16 — breaking major bump via tauri-plugin-log chain. | [#125](https://github.com/drmowinckels/entracte/issues/125) |

### Note on cargo-audit

The RustSec advisory database (hosted on GitHub) is blocked by the session's network egress policy (HTTP 403). This is a recurring limitation in the CI container — see also PR #249, #250, #253. The two advisories fixed here are known from prior runs and confirmed still present in main's `Cargo.lock`. No new advisories published after 2026-06-30 could be detected in this run.

### Note on accumulating open PRs

PRs #241, #249, #250, and #253 address the same advisories and remain open. This PR is freshly rebased onto the current main HEAD (`f08a66f`). Once merged, the older PRs should be closed.

### Changes

Only `src-tauri/Cargo.lock` changed (4 lines: version + checksum for `quinn-proto` and `anyhow`).

### Build note

`cargo build` fails in this container due to missing GTK3 system headers (`gdk-3.0`) — a pre-existing environment constraint unrelated to these changes, documented in all prior audit PRs.

---
🤖 Generated by nightly dep-audit routine

---
_Generated by [Claude Code](https://claude.ai/code/session_0149ryMunzCUepvsSrxXtPy1)_