### PR TITLE
chore(deps): nightly security audit 2026-07-03

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4333,9 +4333,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",


### PR DESCRIPTION
## Security audit — 2026-07-03

### Safe upgrades applied

| Advisory | Package | Before | After | Severity |
|---|---|---|---|---|
| RUSTSEC-2026-0185 | `quinn-proto` | 0.11.14 | 0.11.15 | HIGH |

**RUSTSEC-2026-0185** — Remote memory exhaustion in quinn-proto from unbounded out-of-order stream reassembly. A remote attacker can exhaust memory by sending a crafted QUIC stream. Fixed in 0.11.15 (patch bump, no API changes).

### Manual findings (separate issues opened)

| Advisory | Package | Current | Fix | Blocked by |
|---|---|---|---|---|
| RUSTSEC-2026-0194 + RUSTSEC-2026-0195 | `quick-xml` 0.37.5 | 0.37.5 | ≥ 0.41.0 | `tauri-winrt-notification` 0.7.2 pins `^0.37` |
| RUSTSEC-2026-0194 + RUSTSEC-2026-0195 | `quick-xml` 0.39.4 | 0.39.4 | ≥ 0.41.0 | `plist` 1.9.0 pins `^0.39` |

### Node audit
No vulnerabilities found (0 of 700 dependencies affected).

### Rust warnings (informational)
Unmaintained GTK3 bindings (`atk`, `gdk`, `gtk`, etc.) and `mach` — these are transitive Tauri dependencies; no security CVEs, upstream recommends waiting for Tauri to migrate to GTK4.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BBjHCmJpSy2pm3Uhr4mA1V)_