### PR TITLE
chore(deps): nightly security audit 2026-07-04

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4333,9 +4333,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",


### PR DESCRIPTION
## Nightly security audit — 2026-07-04

### Advisories addressed (SAFE upgrades applied)

| Advisory | Package | Before | After | CVSS | Category |
|---|---|---|---|---|---|
| [RUSTSEC-2026-0185](https://rustsec.org/advisories/RUSTSEC-2026-0185) | `quinn-proto` | 0.11.14 | 0.11.15 | HIGH | denial-of-service |

**RUSTSEC-2026-0185** — Remote memory exhaustion in `quinn-proto` from unbounded out-of-order stream reassembly. An attacker can exhaust process memory by sending crafted QUIC stream frames with gaps, since the reassembly buffer has no upper bound before 0.11.15.

### Advisories requiring manual action (tracked in issues)

| Advisory | Package | Issue | Reason |
|---|---|---|---|
| RUSTSEC-2026-0194 | `quick-xml` 0.37.5, 0.39.4 | #256 | Upstream crates (`tauri-winrt-notification`, `plist`) pin incompatible minor versions |
| RUSTSEC-2026-0195 | `quick-xml` 0.37.5, 0.39.4 | #257 | Same — fix requires upstream releases first |

### Node.js

npm audit: **0 vulnerabilities**

### Changes

- `src-tauri/Cargo.lock`: `quinn-proto` 0.11.14 → 0.11.15 (Cargo.lock only, no source changes)


---
_Generated by [Claude Code](https://claude.ai/code/session_01LHjRz7CdQJHYZKJx3iWe29)_