### PR TITLE
chore(deps): nightly security audit 2026-07-06

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -135,9 +135,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arbitrary"
@@ -4333,9 +4333,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",


### PR DESCRIPTION
## Nightly security audit — 2026-07-06

Automated patch-level upgrades for two Rust advisories resolved by a simple `cargo update --precise`.

### Advisories addressed

| Advisory | Package | From | To | Severity | Description |
|---|---|---|---|---|---|
| [RUSTSEC-2026-0185](https://github.com/quinn-rs/quinn/pull/2694) | `quinn-proto` | 0.11.14 | 0.11.15 | HIGH (AV:N/AC:L/PR:N) | Remote memory exhaustion via unbounded out-of-order stream reassembly |
| [RUSTSEC-2026-0190](https://github.com/dtolnay/anyhow/issues/451) | `anyhow` | 1.0.102 | 1.0.103 | Unsound | `Error::downcast_mut()` violates borrow rules → undefined behaviour |

### Changes

- `src-tauri/Cargo.lock`: two patch-version bumps, no other changes.

### MANUAL findings (not in this PR — existing issues)

| Advisory | Package | Issue | Reason |
|---|---|---|---|
| RUSTSEC-2026-0194 | `quick-xml` 0.37.5 / 0.39.4 | #256 | Fix requires >=0.41.0; parent crates pin incompatible minor range |
| RUSTSEC-2026-0195 | `quick-xml` 0.37.5 / 0.39.4 | #257 | Same as above |
| RUSTSEC-2024-0429 | `glib` 0.18.5 | #84 | No patched version; requires coordinated Tauri upgrade |

### Node

`npm audit` — **0 vulnerabilities** across 700 dependencies. ✅

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uqkd1QcfeBRLQ1SJvFQG95)_