### PR TITLE
chore(deps): nightly security audit 2026-07-08

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -135,9 +135,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arbitrary"
@@ -1106,9 +1106,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -4333,9 +4333,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",


### PR DESCRIPTION
## Advisories addressed

| Advisory | Package | Before | After | Severity |
|---|---|---|---|---|
| [RUSTSEC-2026-0204](https://github.com/crossbeam-rs/crossbeam/pull/1276) | `crossbeam-epoch` | 0.9.18 | 0.9.20 | — (invalid pointer deref in `fmt::Pointer`) |
| [RUSTSEC-2026-0185](https://github.com/quinn-rs/quinn/pull/2694) | `quinn-proto` | 0.11.14 | 0.11.15 | HIGH (remote memory exhaustion) |
| [RUSTSEC-2026-0190](https://rustsec.org/advisories/RUSTSEC-2026-0190.html) | `anyhow` | 1.0.102 | 1.0.103 | unsound |

All three are patch-level bumps resolved via `cargo update -p <crate> --precise <ver>`. Build (`cargo build`) and test compilation (`cargo test --no-run`) both pass.

## Remaining open advisories (manual review required)

- **RUSTSEC-2026-0194 / RUSTSEC-2026-0195** (`quick-xml`) — tracked in #256 and #257. Requires `quick-xml >= 0.41.0`; blocked by parent crates `tauri-winrt-notification` and `plist` pinning incompatible minor ranges.
- **RUSTSEC-2024-0429** (`glib 0.18.5`, unsound) — fix requires `>= 0.20.0` (minor bump, breaking changes expected).
- Unmaintained GTK3 bindings (18 advisories) — transitive Tauri dependencies, no patched versions available.

## Node dependencies

`npm audit` reports 0 vulnerabilities.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NacdeuYXwF5kK8HykwNJRB)_