### PR TITLE
chore(deps): nightly security audit 2026-07-09

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1106,9 +1106,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -4333,9 +4333,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",


### PR DESCRIPTION
## Advisories addressed

| Advisory | Package | Old version | New version | Severity | Description |
|---|---|---|---|---|---|
| [RUSTSEC-2026-0204](https://github.com/crossbeam-rs/crossbeam/pull/1276) | `crossbeam-epoch` | 0.9.18 | 0.9.20 | — | Invalid pointer dereference in `fmt::Pointer` impl for `Atomic`/`Shared` when the underlying pointer is null |
| [RUSTSEC-2026-0185](https://rustsec.org/advisories/RUSTSEC-2026-0185) | `quinn-proto` | 0.11.14 | 0.11.15 | HIGH (CVSS 9.8) | Remote memory exhaustion via unbounded out-of-order stream reassembly |

Both are patch-level bumps within the same minor series. `cargo build` and `cargo test --no-run` pass after the upgrades.

## Skipped (MANUAL — existing issues)

- **RUSTSEC-2026-0194** + **RUSTSEC-2026-0195** (`quick-xml` 0.37.5 and 0.39.4 → ≥0.41.0): tracked in #256 and #257. Blocked on upstream crates (`tauri-winrt-notification`, `plist`) pinning incompatible minor ranges.

## Node advisories

`npm audit` found **0 vulnerabilities** across 700 dependencies.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MkGoWjRcVussEBqKJDTxLP)_