### PR TITLE
chore(deps): nightly security audit 2026-07-10

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -135,9 +135,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arbitrary"
@@ -1106,9 +1106,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -4333,9 +4333,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",


### PR DESCRIPTION
## Nightly Security Audit — 2026-07-10

Automated patch-level upgrades resolving 3 RustSec advisories. All are patch-version bumps within the same minor series (no breaking changes).

| Advisory | Package | Before | After | Severity |
|---|---|---|---|---|
| RUSTSEC-2026-0204 | `crossbeam-epoch` | 0.9.18 | 0.9.20 | — (memory safety) |
| RUSTSEC-2026-0185 | `quinn-proto` | 0.11.14 | 0.11.15 | CVSS HIGH 9.8 (remote mem exhaustion) |
| RUSTSEC-2026-0190 | `anyhow` | 1.0.102 | 1.0.103 | Unsound (UB in `downcast_mut`) |

### Advisory details

**RUSTSEC-2026-0204 — crossbeam-epoch**
Invalid pointer dereference in `fmt::Pointer` impl for `Atomic` and `Shared` when the underlying pointer is null (e.g. created with `Atomic::null()`). Patched in ≥ 0.9.20.
https://github.com/crossbeam-rs/crossbeam/pull/1276

**RUSTSEC-2026-0185 — quinn-proto** (GHSA-4w2j-m93h-cj5j)
Remote peer can send out-of-order QUIC stream fragments with many gaps, causing unbounded buffer growth and memory exhaustion. CVSS 9.8 (AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H). Patched in ≥ 0.11.15.
https://github.com/quinn-rs/quinn/pull/2694

**RUSTSEC-2026-0190 — anyhow**
`Error::downcast_mut()` violates borrow rules when context has been added to an error, resulting in undefined behaviour (confirmed by Miri). Patched in ≥ 1.0.103.
https://github.com/dtolnay/anyhow/issues/451

---

### Still open (pre-existing issues, manual action needed)

- `quick-xml` 0.37.5 / 0.39.4 — RUSTSEC-2026-0194, RUSTSEC-2026-0195 (tracked in #256, #257; blocked by parent crate constraints)
- `glib` 0.18.5 — RUSTSEC-2024-0429 (tracked in #84; no patched version available)


---
_Generated by [Claude Code](https://claude.ai/code/session_016oA7xmubiCrgv3foo7sVaf)_