### PR TITLE
chore(deps): nightly security audit 2026-07-12

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1106,9 +1106,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -4333,9 +4333,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",


### PR DESCRIPTION
## Nightly Security Audit — 2026-07-12

### Advisories resolved (Cargo.lock only)

| Advisory | Package | Old version | New version | Severity |
|---|---|---|---|---|
| [RUSTSEC-2026-0204](https://github.com/crossbeam-rs/crossbeam/pull/1276) | `crossbeam-epoch` | 0.9.18 | 0.9.20 | (no CVSS) — invalid pointer dereference in `fmt::Pointer` |
| [RUSTSEC-2026-0185](https://rustsec.org/advisories/RUSTSEC-2026-0185) | `quinn-proto` | 0.11.14 | 0.11.15 | HIGH — remote memory exhaustion via unbounded out-of-order stream reassembly |

Both are patch bumps within the same semver-compatible minor range and applied with `cargo update --precise`.

### Manual findings (existing issues, no change)

| Advisory | Issue | Status |
|---|---|---|
| RUSTSEC-2026-0194 (`quick-xml` quadratic DoS) | #256 | open — awaiting upstream |
| RUSTSEC-2026-0195 (`quick-xml` memory exhaustion DoS) | #257 | open — awaiting upstream |

### Node audit

0 vulnerabilities found.

### Audit summary

- Rust advisories: 6 instances across 4 advisories (Safe: 2, Manual: 4 across 2 upstream crates)
- Node advisories: 0


---
_Generated by [Claude Code](https://claude.ai/code/session_015oDFsTXQZgLsb1hnpoVoUj)_