### PR TITLE
chore(deps): nightly security audit 2026-07-17

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1106,9 +1106,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -4333,9 +4333,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",


### PR DESCRIPTION
## Summary

Two patch-level Rust dependency upgrades that resolve previously-filed security advisories. No Node vulnerabilities found today.

| Advisory | Package | Before | After | Severity |
|---|---|---|---|---|
| RUSTSEC-2026-0204 | `crossbeam-epoch` | 0.9.18 | 0.9.20 | Invalid pointer dereference in `fmt::Pointer` impl |
| RUSTSEC-2026-0185 | `quinn-proto` | 0.11.14 | 0.11.15 | Remote memory exhaustion via unbounded stream reassembly (CVSS HIGH) |

Both upgrades are within the `^0.9` / `^0.11` semver constraint of their parent crates (`crossbeam-deque`, `quinn`). Only `src-tauri/Cargo.lock` changed — no `Cargo.toml` edits required.

## Remaining open advisories (not addressed here)

These remain blocked on upstream ecosystem updates and are already tracked as issues:

- **RUSTSEC-2026-0194** (quick-xml quadratic DoS) — #256, #275 — blocked on `plist`/`tauri-winrt-notification` adopting quick-xml ≥ 0.41
- **RUSTSEC-2026-0195** (quick-xml memory exhaustion) — #257, #276 — same blocker
- **RUSTSEC-2026-0122** (rkyv unsoundness) — #125 — blocked on `tauri-plugin-log` → `byte-unit` → `rust_decimal` chain

## Verification

- `cargo update -p crossbeam-epoch --precise 0.9.20` and `cargo update -p quinn-proto --precise 0.11.15` applied cleanly
- `cargo build` / `cargo check` environment fails on missing `gdk-3.0` system lib — confirmed identical failure on `main` before these changes, not a regression
- npm audit: 0 vulnerabilities

🤖 Generated by nightly security audit routine

---
_Generated by [Claude Code](https://claude.ai/code/session_01UdZqkXDjfewiYKjtUkwTSK)_