### PR TITLE
chore(deps): nightly security audit 2026-07-20

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -135,9 +135,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arbitrary"
@@ -1106,9 +1106,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -4333,9 +4333,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",


### PR DESCRIPTION
## Nightly Security Audit — 2026-07-20

Automated patch-level dependency upgrades resolving 3 Rust advisories. Only `src-tauri/Cargo.lock` was modified.

### Advisories resolved

| Advisory | Package | Before | After | Severity |
|---|---|---|---|---|
| [RUSTSEC-2026-0204](https://github.com/crossbeam-rs/crossbeam/pull/1276) | `crossbeam-epoch` | 0.9.18 | 0.9.20 | — (no CVSS yet) |
| [RUSTSEC-2026-0185](https://github.com/quinn-rs/quinn/pull/2694) | `quinn-proto` | 0.11.14 | 0.11.15 | High (CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H) |
| [RUSTSEC-2026-0190](https://github.com/dtolnay/anyhow/issues/451) | `anyhow` | 1.0.102 | 1.0.103 | Unsound (UB in `Error::downcast_mut`) |

All three are pure patch bumps (`cargo update -p <crate> --precise <ver>`). No API changes.

### Still open (manual — cannot auto-fix)

| Advisory | Package | Reason |
|---|---|---|
| RUSTSEC-2026-0194 | `quick-xml` 0.37.5, 0.39.4 | Fix requires ≥0.41.0; `tauri-winrt-notification` and `plist` pin incompatible minor ranges — tracked in #275 and #256 |
| RUSTSEC-2026-0195 | `quick-xml` 0.37.5, 0.39.4 | Same root cause — tracked in #276 and #257 |

### Node.js

`npm audit` — 0 vulnerabilities.

### Build note

`cargo build` and `npm run build` both fail in this CI container due to pre-existing environment constraints (missing `gdk-3.0` system library; TypeScript errors in `system-tab.tsx` unrelated to these deps). The upgrades touch only `Cargo.lock` with no source changes; the failures are identical to the unmodified branch.

🤖 Generated by nightly security audit

---
_Generated by [Claude Code](https://claude.ai/code/session_01PeaAsx48ketZtx7RcBECge)_