### PR TITLE
chore(deps): nightly security audit 2026-07-22

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5415,9 +5415,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "dev": true,
       "funding": [
         {
@@ -7125,9 +7125,9 @@
       "license": "MIT"
     },
     "node_modules/linkify-it": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
-      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Nightly Security Audit — 2026-07-22

Automated patch-level upgrades to resolve 2 HIGH-severity Node advisories. No Rust CVEs found. Frontend build verified (`tsc && vite build` passes).

### Node advisories resolved

| Advisory | Package | Before | After | Severity |
|----------|---------|--------|-------|----------|
| [GHSA-4c8g-83qw-93j6](https://github.com/advisories/GHSA-4c8g-83qw-93j6) | `fast-uri` | 3.1.2 | 3.1.4 | HIGH |
| [GHSA-v2hh-gcrm-f6hx](https://github.com/advisories/GHSA-v2hh-gcrm-f6hx) | `fast-uri` | 3.1.2 | 3.1.4 | HIGH |
| [GHSA-v245-v573-v5vm](https://github.com/advisories/GHSA-v245-v573-v5vm) | `linkify-it` | 5.0.1 | 5.0.2 | HIGH |

**fast-uri** is an indirect dev dependency (via `table` → `ajv`). The two advisories concern host confusion attacks via failed IDN canonicalization and via literal backslash as an authority delimiter; both are fixed at 3.1.4.

**linkify-it** is an indirect dev dependency (via `markdown-it`). The advisory concerns a quadratic-complexity DoS via the `mailto:` validator scan-loop on attacker-controlled text; fixed at 5.0.2.

### Rust

No CVE vulnerabilities found (`vulnerabilities.found: false`). Informational warnings (unmaintained GTK3 bindings, `mach`, `proc-macro-error`, `unic-*`) require upstream Tauri changes and are not auto-upgraded.

### Changes

- `package-lock.json`: fast-uri 3.1.2 → 3.1.4, linkify-it 5.0.1 → 5.0.2

---
_Generated by [Claude Code](https://claude.ai/code/session_01GMD1G3WN4NMHiWfV1Yjpox)_