### PR TITLE
fix(chores): only nudge users who actually use chores

### DIFF
--- a/src-tauri/src/chores_store.rs
+++ b/src-tauri/src/chores_store.rs
@@ -32,6 +32,13 @@ pub struct ChoresSnapshot {
     /// a value `!= date` means we haven't prompted today yet. Defaults empty
     /// on older stores that predate the field.
     pub prompted_date: String,
+    /// True once the user has ever saved a non-empty chore list. Unlike
+    /// `items` (which reset each morning), this persists across days, so the
+    /// morning prompt only nudges people who actually use chores — a
+    /// permanently-empty list no longer pops Preferences every work-day
+    /// (#251-adjacent annoyance). Defaults false on older stores; a store that
+    /// already has items is migrated to true on load.
+    pub ever_used_chores: bool,
 }
 
 pub fn load(path: &Path) -> ChoresSnapshot {
@@ -105,6 +112,7 @@ mod tests {
             ],
             rotation: 3,
             prompted_date: "2026-06-11".to_string(),
+            ever_used_chores: true,
         };
         save(&path, &snap).unwrap();
         assert_eq!(load(&path), snap);

--- a/src-tauri/src/scheduler/chores.rs
+++ b/src-tauri/src/scheduler/chores.rs
@@ -22,6 +22,10 @@ pub struct ChoresState {
     /// [`ChoresSnapshot::prompted_date`]). `!= date` means "not prompted yet
     /// today".
     pub prompted_date: String,
+    /// True once the user has ever saved a non-empty list. Persists across the
+    /// daily rollover (unlike `items`), so the morning prompt only nudges
+    /// people who actually use chores — see [`should_prompt_morning_chores`].
+    pub ever_used_chores: bool,
 }
 
 impl ChoresState {
@@ -29,12 +33,18 @@ impl ChoresState {
     /// is discarded — a chore post-it is a fresh thing each morning, so we
     /// never carry yesterday's list into today.
     pub fn from_snapshot(snap: ChoresSnapshot, today: &str) -> Self {
+        // Migrate stores that predate `ever_used_chores`: a snapshot that
+        // already carries items (today's or yesterday's) is clearly a
+        // chore-user, so treat it as having used chores even if the flag
+        // was default-false.
+        let ever_used_chores = snap.ever_used_chores || !snap.items.is_empty();
         if snap.date == today {
             Self {
                 date: snap.date,
                 items: snap.items,
                 rotation: snap.rotation,
                 prompted_date: snap.prompted_date,
+                ever_used_chores,
             }
         } else {
             Self {
@@ -42,6 +52,7 @@ impl ChoresState {
                 items: Vec::new(),
                 rotation: 0,
                 prompted_date: String::new(),
+                ever_used_chores,
             }
         }
     }
@@ -54,6 +65,7 @@ impl ChoresState {
             items: self.items.clone(),
             rotation: self.rotation,
             prompted_date: self.prompted_date.clone(),
+            ever_used_chores: self.ever_used_chores,
         }
     }
 }
@@ -81,8 +93,11 @@ const MORNING_PROMPT_FLOOR_MIN: u32 = 5 * 60;
 /// Whether to surface the morning chore prompt this tick. Fires once per
 /// local day — the first time the user is inside their work window (past an
 /// early-morning floor), while today's list is still empty and we haven't
-/// already prompted today. Pure so the gating is unit-testable without a
-/// scheduler or clock.
+/// already prompted today. Only nudges users who have *ever* used chores:
+/// the list resets empty every morning, so without this a user who never
+/// touches chores would have Preferences popped open every single work-day
+/// on a permanently-empty list. Pure so the gating is unit-testable without
+/// a scheduler or clock.
 pub fn should_prompt_morning_chores(
     enabled: bool,
     in_work_window: bool,
@@ -91,6 +106,7 @@ pub fn should_prompt_morning_chores(
     today: &str,
 ) -> bool {
     enabled
+        && state.ever_used_chores
         && in_work_window
         && now_min >= MORNING_PROMPT_FLOOR_MIN
         && state.items.is_empty()
@@ -139,6 +155,19 @@ mod tests {
             items: items.iter().map(|s| s.to_string()).collect(),
             rotation,
             prompted_date: String::new(),
+            // A state built with items is a chore-user; keep the flag in sync
+            // so the rotation / "already has chores" tests act like real use.
+            ever_used_chores: !items.is_empty(),
+        }
+    }
+
+    /// A returning chore-user whose daily list has reset to empty this
+    /// morning: empty today, but `ever_used_chores` is set, so the morning
+    /// prompt should still nudge them. This is the case the gate allows.
+    fn returning_user_empty() -> ChoresState {
+        ChoresState {
+            ever_used_chores: true,
+            ..state_with(&[], 0)
         }
     }
 
@@ -149,11 +178,14 @@ mod tests {
             items: vec!["Water the plants".to_string()],
             rotation: 2,
             prompted_date: "2026-06-11".to_string(),
+            ever_used_chores: false,
         };
         let st = ChoresState::from_snapshot(snap, "2026-06-11");
         assert_eq!(st.items, vec!["Water the plants".to_string()]);
         assert_eq!(st.rotation, 2);
         assert_eq!(st.prompted_date, "2026-06-11");
+        // Migration: a store with items predates the flag but is a chore-user.
+        assert!(st.ever_used_chores);
     }
 
     #[test]
@@ -163,6 +195,7 @@ mod tests {
             items: vec!["Yesterday's chore".to_string()],
             rotation: 5,
             prompted_date: "2026-06-10".to_string(),
+            ever_used_chores: false,
         };
         let st = ChoresState::from_snapshot(snap, "2026-06-11");
         assert_eq!(st.date, "2026-06-11");
@@ -171,6 +204,27 @@ mod tests {
         // A stale day's "already prompted" marker must not suppress today's
         // prompt.
         assert_eq!(st.prompted_date, "");
+        // ...but "has ever used chores" persists across the day boundary
+        // (migrated here from yesterday's non-empty list), so a returning
+        // user still gets this morning's nudge.
+        assert!(st.ever_used_chores);
+    }
+
+    #[test]
+    fn from_snapshot_preserves_ever_used_across_days() {
+        // A chore-user who cleared their list: empty items, but the flag was
+        // already set. Rolling into a new day keeps the flag even though the
+        // (empty) list is discarded.
+        let snap = ChoresSnapshot {
+            date: "2026-06-10".to_string(),
+            items: vec![],
+            rotation: 0,
+            prompted_date: "2026-06-10".to_string(),
+            ever_used_chores: true,
+        };
+        let st = ChoresState::from_snapshot(snap, "2026-06-11");
+        assert!(st.items.is_empty());
+        assert!(st.ever_used_chores);
     }
 
     #[test]
@@ -182,11 +236,15 @@ mod tests {
         assert_eq!(st.rotation, 0);
         assert_eq!(st.date, "2026-06-12");
         assert_eq!(st.prompted_date, "");
+        // The daily rollover must NOT wipe the chore-user flag, or a user with
+        // the app running across midnight would stop getting the morning
+        // nudge every day.
+        assert!(st.ever_used_chores);
     }
 
     #[test]
-    fn morning_prompt_fires_in_window_with_empty_list() {
-        let st = state_with(&[], 0);
+    fn morning_prompt_fires_for_returning_user_with_empty_list() {
+        let st = returning_user_empty();
         assert!(should_prompt_morning_chores(
             true,
             true,
@@ -197,8 +255,24 @@ mod tests {
     }
 
     #[test]
-    fn morning_prompt_skips_when_disabled() {
+    fn morning_prompt_skips_when_user_never_used_chores() {
+        // Empty list + never used chores: every other condition is met, but a
+        // user who doesn't use chores must not have Preferences popped open
+        // every morning on a permanently-empty list.
         let st = state_with(&[], 0);
+        assert!(!st.ever_used_chores);
+        assert!(!should_prompt_morning_chores(
+            true,
+            true,
+            9 * 60,
+            &st,
+            "2026-06-11"
+        ));
+    }
+
+    #[test]
+    fn morning_prompt_skips_when_disabled() {
+        let st = returning_user_empty();
         assert!(!should_prompt_morning_chores(
             false,
             true,
@@ -210,7 +284,7 @@ mod tests {
 
     #[test]
     fn morning_prompt_skips_outside_work_window() {
-        let st = state_with(&[], 0);
+        let st = returning_user_empty();
         assert!(!should_prompt_morning_chores(
             true,
             false,
@@ -224,7 +298,7 @@ mod tests {
     fn morning_prompt_skips_before_the_morning_floor() {
         // All-day work window: in_window is true even at 02:00, but the floor
         // keeps the prompt from firing at the post-midnight rollover.
-        let st = state_with(&[], 0);
+        let st = returning_user_empty();
         assert!(!should_prompt_morning_chores(
             true,
             true,
@@ -255,7 +329,7 @@ mod tests {
 
     #[test]
     fn morning_prompt_skips_when_already_prompted_today() {
-        let mut st = state_with(&[], 0);
+        let mut st = returning_user_empty();
         st.prompted_date = "2026-06-11".to_string();
         assert!(!should_prompt_morning_chores(
             true,

--- a/src-tauri/src/scheduler/commands/chores.rs
+++ b/src-tauri/src/scheduler/commands/chores.rs
@@ -42,6 +42,12 @@ pub(crate) async fn set_chores_impl(scheduler: &Scheduler, items: Vec<String>) -
     let mut c = scheduler.chores.lock().await;
     rollover_if_new_day(&mut c, &today);
     c.items = cleaned;
+    // Saving any real chore marks the user as a chore-user for good, so the
+    // morning prompt keeps nudging them on future (empty) mornings. Never
+    // cleared — clearing today's list doesn't mean they've stopped using it.
+    if !c.items.is_empty() {
+        c.ever_used_chores = true;
+    }
     persist_chores(&scheduler.chores_path, &c);
     c.clone()
 }
@@ -72,6 +78,23 @@ mod tests {
         // A fresh read sees the same sanitized list (persisted + in memory).
         let read = get_chores_impl(&sched).await;
         assert_eq!(read.items, stored.items);
+    }
+
+    #[tokio::test]
+    async fn set_chores_marks_and_keeps_the_chore_user_flag() {
+        let (_dir, sched) = test_scheduler(Settings::default());
+        // Saving an all-blank (→ empty) list does not flip the flag.
+        let empty = set_chores_impl(&sched, vec!["   ".to_string()]).await;
+        assert!(empty.items.is_empty());
+        assert!(!empty.ever_used_chores);
+        // Saving a real chore marks the user as a chore-user...
+        let used = set_chores_impl(&sched, vec!["Water the plants".to_string()]).await;
+        assert!(used.ever_used_chores);
+        // ...and clearing the list again keeps it set — they still use chores,
+        // so the morning prompt should keep nudging them.
+        let cleared = set_chores_impl(&sched, vec![]).await;
+        assert!(cleared.items.is_empty());
+        assert!(cleared.ever_used_chores);
     }
 
     #[tokio::test]

--- a/src/views/settings/hooks/use-chores.test.ts
+++ b/src/views/settings/hooks/use-chores.test.ts
@@ -12,6 +12,7 @@ describe("useChores", () => {
       items: ["Water the plants"],
       rotation: 0,
       prompted_date: "",
+      ever_used_chores: false,
     });
     const { result } = renderHook(() => useChores({ invoke }));
     expect(result.current.chores).toBeNull();
@@ -46,12 +47,14 @@ describe("useChores", () => {
         items: [],
         rotation: 0,
         prompted_date: "",
+        ever_used_chores: false,
       })
       .mockResolvedValueOnce({
         date: TODAY,
         items: ["Tidy desk"],
         rotation: 0,
         prompted_date: "",
+        ever_used_chores: false,
       });
     const { result } = renderHook(() => useChores({ invoke }));
     await waitFor(() => expect(result.current.chores).not.toBeNull());
@@ -72,6 +75,7 @@ describe("useChores", () => {
         items: ["Keep me"],
         rotation: 0,
         prompted_date: "",
+        ever_used_chores: false,
       })
       .mockResolvedValueOnce({ bogus: true });
     const { result } = renderHook(() => useChores({ invoke }));

--- a/src/views/settings/hooks/use-chores.ts
+++ b/src/views/settings/hooks/use-chores.ts
@@ -8,6 +8,7 @@ const choresSchema = z.object({
   items: z.array(z.string()),
   rotation: z.number(),
   prompted_date: z.string(),
+  ever_used_chores: z.boolean(),
 }) satisfies z.ZodType<ChoresState>;
 
 export type UseChoresDeps = {

--- a/src/views/settings/tabs/breaks-tab.test.tsx
+++ b/src/views/settings/tabs/breaks-tab.test.tsx
@@ -234,6 +234,7 @@ describe("BreaksTab break ideas", () => {
       items: [] as string[],
       rotation: 0,
       prompted_date: "",
+      ever_used_chores: false,
     };
     invokeMock.mockImplementation(async (cmd: string) => {
       if (cmd === "get_chores") return emptyToday;
@@ -261,6 +262,7 @@ describe("BreaksTab break ideas", () => {
       items: ["Water the plants"],
       rotation: 0,
       prompted_date: "",
+      ever_used_chores: false,
     };
     invokeMock.mockImplementation(async (cmd: string) => {
       if (cmd === "get_chores") return today;

--- a/src/views/settings/types.ts
+++ b/src/views/settings/types.ts
@@ -233,6 +233,10 @@ export type ChoresState = {
   /** Backend-internal: the day the morning prompt last fired. On the wire
    * (get_chores returns the full state) but unused by the UI. */
   prompted_date: string;
+  /** Backend-internal: whether the user has ever saved a non-empty list, so
+   * the morning prompt only nudges people who actually use chores. On the
+   * wire but unused by the UI. */
+  ever_used_chores: boolean;
 };
 
 export type PauseInfo = {


### PR DESCRIPTION
## Summary

Fixes the intermittent "the settings window opens after a break" annoyance.

**Root cause (confirmed from a real install's `settings.json` + `chores.json`):** the morning chore prompt (`run_loop.rs`) auto-opens Preferences once per work-day when the chore list is empty. But the list is a daily post-it that **resets empty every morning by design** — so a user who never uses chores (`items: []` forever) had Preferences popped open *every* work-day. It reads as "settings randomly opens after a break" because it fires at the first work-window scheduler tick after the app resumes ticking (often right after you step away for a break and come back), and the path logs nothing.

**Fix:** gate the prompt on a new persisted `ever_used_chores` flag:
- set the first time a non-empty list is saved (`set_chores_impl`)
- persists across the daily rollover (unlike `items`) and on restart (`from_snapshot`)
- never cleared — clearing today's list doesn't mean you've stopped using chores
- existing stores migrate: a snapshot that already carries items is treated as a chore-user

Real chore-users still get their morning nudge; a permanently-empty list never triggers it.

## Test Plan

- `cargo test --lib chores` → **30 pass**, incl. new cases:
  - `morning_prompt_fires_for_returning_user_with_empty_list` (empty today + ever-used → fires)
  - `morning_prompt_skips_when_user_never_used_chores` (empty + never-used → no prompt)
  - `from_snapshot_preserves_ever_used_across_days` + migration asserts in the existing `from_snapshot_*` tests
  - `rollover_clears_on_new_day` now asserts the flag survives midnight
  - `set_chores_marks_and_keeps_the_chore_user_flag` (empty→false, real→true, cleared→stays true)
- `cargo clippy --bin entracte` clean; `cargo fmt` applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)