### PR TITLE
feat(breaks): take a long break now, restarting the rotation (#258)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Versions on the `0.0.X` line are public beta releases; `0.1.X` and onwards will 
 
 ## [Unreleased]
 
+### Added
+
+- **Take a long break now.** A new **Take a long break now** action — in the menu-bar menu and on the Breaks tab (next to _Test long_) — starts your long break immediately and restarts the rotation from that moment, so if you step away early (the washing machine's done, a call wrapped up) you get your proper long break when you want it and aren't broken again a few minutes later. ([#258](https://github.com/drmowinckels/entracte/issues/258))
+
 ## [0.0.10] — 2026-07-23
 
 ### Fixed

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -163,6 +163,7 @@ pub fn run() {
             scheduler::get_postpone_state,
             scheduler::get_last_break_info,
             scheduler::resume_last_break,
+            scheduler::start_long_break_now,
             scheduler::get_break_stats,
             scheduler::get_current_break,
             scheduler::get_routines,

--- a/src-tauri/src/scheduler/commands/breaks.rs
+++ b/src-tauri/src/scheduler/commands/breaks.rs
@@ -642,6 +642,29 @@ pub async fn resume_last_break<R: Runtime>(
     resume_last_break_impl(&app, scheduler.inner()).await
 }
 
+/// Fire a long break right now and restart the rotation, exactly as if the
+/// scheduled long break had come due (#258). Lets a user take their long
+/// break early — a chore timer went off, the washing machine finished —
+/// without waiting for it and without it doubling up later:
+/// `fire_scheduled_break` re-anchors *both* interval clocks (a long break
+/// swallows the pending micro). Bypasses suppression, matching the other
+/// explicit manual triggers. Shared by the renderer command and the tray.
+pub async fn start_long_break_now_impl<R: Runtime>(app: &AppHandle<R>, scheduler: &Scheduler) {
+    let s = scheduler.settings.lock().await.clone();
+    super::super::run_loop::fire_scheduled_break(app, scheduler, &s, BreakKind::Long, None).await;
+}
+
+/// Renderer-facing "take a long break now". Thin wrapper over
+/// `start_long_break_now_impl`.
+#[tauri::command]
+pub async fn start_long_break_now<R: Runtime>(
+    app: AppHandle<R>,
+    scheduler: tauri::State<'_, Scheduler>,
+) -> Result<(), String> {
+    start_long_break_now_impl(&app, scheduler.inner()).await;
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1671,6 +1694,86 @@ mod rig_smoke_tests {
         trigger_break_from_cli(app.handle(), &sched, BreakKind::Long, 42).await;
         // Notification delivery does not stash an overlay break.
         assert!(sched.current_break.lock().unwrap().is_none());
+    }
+
+    #[tokio::test]
+    #[allow(clippy::field_reassign_with_default)]
+    async fn start_long_break_now_reanchors_both_interval_clocks() {
+        // #258: "take a long break now" fires a real long break AND restarts
+        // the rotation, so a break already overdue on the clock is no longer
+        // due the instant after — no doubled-up break later. Notification mode
+        // keeps delivery windowless (the mock runtime can't open an overlay);
+        // the re-anchor is `fire_scheduled_break`'s job regardless of channel.
+        use super::super::super::settings::BreakMode;
+        let mut settings = Settings::default();
+        settings.long_break_mode = BreakMode::Notification;
+        settings.long_interval_secs = 1_800;
+        settings.micro_interval_secs = 1_200;
+        let (_dir, app, sched) = mock_app_with_scheduler(settings);
+
+        // A genuine past sample (never `now() - offset`, which can underflow
+        // the monotonic clock on a fresh runner) standing in for stale anchors
+        // left overdue by a long stretch of work.
+        let stale = Instant::now();
+        {
+            let mut t = sched.timers.lock().await;
+            t.last_micro = stale;
+            t.last_long = stale;
+            t.long_warned = true;
+            t.micro_warned = true;
+        }
+
+        start_long_break_now_impl(app.handle(), &sched).await;
+
+        let t = sched.timers.lock().await;
+        assert!(
+            t.last_long > stale,
+            "long anchor must move forward to the fire instant"
+        );
+        assert!(
+            t.last_micro > stale,
+            "a long break swallows the pending micro, so its clock re-anchors too"
+        );
+        assert!(!t.long_warned, "the long warn flag resets on fire");
+        assert!(!t.micro_warned, "the micro warn flag resets on fire");
+        assert!(
+            !crate::scheduler::timers::interval_break_due(
+                true,
+                true,
+                t.last_long,
+                1_800,
+                false,
+                t.last_long
+            ),
+            "no long break may be due the instant after taking one"
+        );
+    }
+
+    #[tokio::test]
+    #[allow(clippy::field_reassign_with_default)]
+    async fn start_long_break_now_command_via_rig_fires_and_reanchors() {
+        // Covers the `#[tauri::command]` wrapper (State/AppHandle threading),
+        // separate from the impl-level test above. Notification mode keeps
+        // delivery windowless under the mock runtime; a moved long anchor
+        // proves the wrapper reached the impl and the fire path ran.
+        use super::super::super::settings::BreakMode;
+        let mut settings = Settings::default();
+        settings.long_break_mode = BreakMode::Notification;
+        let (_dir, app, sched) = mock_app_with_scheduler(settings);
+        let stale = Instant::now();
+        {
+            let mut t = sched.timers.lock().await;
+            t.last_long = stale;
+        }
+
+        start_long_break_now(app.handle().clone(), app.state::<Scheduler>())
+            .await
+            .expect("start_long_break_now command succeeds");
+
+        assert!(
+            sched.timers.lock().await.last_long > stale,
+            "the wrapper drove the fire path and re-anchored the long clock"
+        );
     }
 
     #[test]

--- a/src-tauri/src/scheduler/run_loop.rs
+++ b/src-tauri/src/scheduler/run_loop.rs
@@ -519,7 +519,12 @@ pub(super) async fn run_loop(app: AppHandle, sched: Scheduler) {
 /// under the timers lock (see [`record_scheduled_fire`]). `fixed_key` is
 /// `Some((today, minute))` for a fixed-time fire (recording the dedupe
 /// key) or `None` for an interval fire; the fire `Instant` is stamped here.
-async fn fire_scheduled_break<R: Runtime>(
+///
+/// Also the on-demand entry for "take a long break now" (#258): the
+/// `start_long_break_now` command calls this with `Long`/`None` so a
+/// user-initiated long break behaves exactly like a due one — same delivery,
+/// same re-anchor of both interval clocks — and never doubles up later.
+pub(super) async fn fire_scheduled_break<R: Runtime>(
     app: &AppHandle<R>,
     sched: &Scheduler,
     s: &Settings,

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -125,6 +125,13 @@ pub fn setup(app: &AppHandle) -> tauri::Result<()> {
         false,
         None::<&str>,
     )?;
+    let long_break_now = MenuItem::with_id(
+        app,
+        "long_break_now",
+        "Take a long break now",
+        true,
+        None::<&str>,
+    )?;
 
     let pause_15m = MenuItem::with_id(app, "pause_15m", "15 minutes", true, None::<&str>)?;
     let pause_30m = MenuItem::with_id(app, "pause_30m", "30 minutes", true, None::<&str>)?;
@@ -179,6 +186,7 @@ pub fn setup(app: &AppHandle) -> tauri::Result<()> {
             &profile_submenu,
             &sep3,
             &resume_break,
+            &long_break_now,
             &sep4,
             &quit,
         ],
@@ -249,6 +257,14 @@ pub fn setup(app: &AppHandle) -> tauri::Result<()> {
                     });
                     return;
                 }
+                "long_break_now" => {
+                    let app_handle = app.clone();
+                    tauri::async_runtime::spawn(async move {
+                        let scheduler = app_handle.state::<Scheduler>().inner().clone();
+                        crate::scheduler::start_long_break_now_impl(&app_handle, &scheduler).await;
+                    });
+                    return;
+                }
                 _ => {}
             }
 
@@ -309,6 +325,7 @@ pub fn setup(app: &AppHandle) -> tauri::Result<()> {
     let resume_for_rebuild = resume.clone();
     let pause_submenu_for_rebuild = pause_submenu.clone();
     let resume_break_for_rebuild = resume_break.clone();
+    let long_break_now_for_rebuild = long_break_now.clone();
     let sep1_for_rebuild = sep1.clone();
     let sep2_for_rebuild = sep2.clone();
     let sep3_for_rebuild = sep3.clone();
@@ -323,6 +340,7 @@ pub fn setup(app: &AppHandle) -> tauri::Result<()> {
         let resume = resume_for_rebuild.clone();
         let pause_submenu = pause_submenu_for_rebuild.clone();
         let resume_break = resume_break_for_rebuild.clone();
+        let long_break_now = long_break_now_for_rebuild.clone();
         let sep1 = sep1_for_rebuild.clone();
         let sep2 = sep2_for_rebuild.clone();
         let sep3 = sep3_for_rebuild.clone();
@@ -352,6 +370,7 @@ pub fn setup(app: &AppHandle) -> tauri::Result<()> {
                     &new_submenu,
                     &sep3,
                     &resume_break,
+                    &long_break_now,
                     &sep4,
                     &quit,
                 ],

--- a/src/views/settings/tabs/breaks-tab.test.tsx
+++ b/src/views/settings/tabs/breaks-tab.test.tsx
@@ -461,6 +461,27 @@ describe("BreaksTab delivery", () => {
       durationSecs: 15,
     });
   });
+
+  it("clicking Take a long break now invokes start_long_break_now", () => {
+    renderTab(false, () => {}, { micro_enabled: true, long_enabled: true });
+    fireEvent.click(
+      screen.getByRole("button", { name: "Take a long break now" }),
+    );
+    expect(invokeMock).toHaveBeenCalledWith("start_long_break_now");
+  });
+
+  it("keeps Take a long break now enabled even when long breaks are off", () => {
+    // Deliberately not gated on long_enabled (unlike Test long): taking a long
+    // break on demand is a valid manual override independent of the schedule.
+    renderTab(false, () => {}, { micro_enabled: true, long_enabled: false });
+    expect(
+      (
+        screen.getByRole("button", {
+          name: "Take a long break now",
+        }) as HTMLButtonElement
+      ).disabled,
+    ).toBe(false);
+  });
 });
 
 describe("BreaksTab sound", () => {

--- a/src/views/settings/tabs/breaks-tab.tsx
+++ b/src/views/settings/tabs/breaks-tab.tsx
@@ -187,6 +187,9 @@ export function BreaksTab({
           >
             Test long
           </button>
+          <button onClick={() => invoke("start_long_break_now")}>
+            Take a long break now
+          </button>
         </div>
       </section>
 


### PR DESCRIPTION
## Summary

Adds a **Take a long break now** action — in the menu-bar menu and on the Breaks tab (next to _Test long_) — that fires a real long break immediately **and restarts the rotation** from that moment. So if you step away early (washing machine's done, a call wrapped up) you get your proper long break on demand, and aren't broken again a few minutes later. Closes #258.

Design: the command composes the existing canonical scheduled-fire path (`fire_scheduled_break`, widened from private to `pub(super)`) rather than duplicating fire logic. That path both delivers the break and calls `record_scheduled_fire(Long)`, which re-anchors *both* interval clocks (`last_long` + `last_micro` — a long break swallows the pending micro). It bypasses suppression like the other explicit manual triggers.

- new `start_long_break_now` command + `_impl`, registered in `lib.rs`, re-exported via the existing glob
- tray item wired into the initial menu **and** the profile-change rebuild (mirrors the `resume_break` pattern)
- Breaks-tab button — always enabled (a manual long break is valid regardless of whether scheduled long breaks are on, unlike the config-preview _Test long_)

## Test Plan

- `start_long_break_now_reanchors_both_interval_clocks` — asserts both clocks re-anchor so no long break is due the instant after (rig test, Notification-mode delivery)
- `start_long_break_now_command_via_rig_fires_and_reanchors` — drives the command wrapper's State/AppHandle threading
- frontend: clicking the button invokes `start_long_break_now`; the button stays enabled with `long_enabled: false`
- `cargo clippy --all-targets -D warnings` + `cargo fmt --check` clean; full Rust suite green; frontend 33/33; `prettier`/`eslint` clean

## ⚠️ codecov/patch — needs admin-merge (deliberate)

`codecov/patch` is red at 78.9%. All **16** uncovered lines are framework glue that no unit test can reach — the sanctioned admin-bypass case per `.github/AGENTS.md` ("lines unreachable in CI by construction"):

- **15 in `tray.rs`** — the new menu item, its `on_menu_event` handler arm, and the profile-rebuild clone, all inside `setup()` and its event closures. The mock runtime has no tray, so every existing tray handler (`resume_break`, `pause`, …) is uncovered for the same reason (tray.rs sits at ~49%). Verified via local `cargo llvm-cov --show-missing-lines`.
- **1 in `breaks.rs:659`** — the `#[tauri::command]` macro's generated IPC-dispatch wrapper. Rig tests call the command fn directly (not through `invoke`), so this line is uncovered for **every** command in the crate (`end_break`, `trigger_test_break`, etc. are all uncovered here too); it's only flagged now because it's a *new* line in the patch.

Neither is reachable from a test (`cargo-llvm-cov` doesn't honor `LCOV_EXCL`, and CI runs coverage on stable so `#[coverage(off)]` is inert). `codecov/project` passes; all other checks (rust mac/ubuntu/windows, frontend, both smokes) are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)