### PR TITLE
chore(deps): nightly security audit 2026-07-25

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7407,9 +7407,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -7793,9 +7793,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "dev": true,
       "funding": [
         {
@@ -7813,7 +7813,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },


### PR DESCRIPTION
## Nightly security audit — 2026-07-25

Automated dependency-advisory sweep (`cargo audit` on `src-tauri/`, `npm audit` at root).

### SAFE upgrade applied (this PR)

| Advisory | Package | Change | Tier |
|---|---|---|---|
| [GHSA-r28c-9q8g-f849](https://github.com/advisories/GHSA-r28c-9q8g-f849) — PostCSS path traversal via source-map (`sourceMappingURL`) auto-loading | `postcss` (transitive, dev, via vite) | `8.5.15 → 8.5.23` | patch |
| — (forced transitive of the above) | `nanoid` (transitive, dev) | `3.3.12 → 3.3.16` | patch |

- **Lockfile-only**: only `package-lock.json` changes. `postcss` stays within vite's existing `^8` range, so `package.json` is untouched.
- `npm audit` after the bump: the `postcss` advisory is **absent**; no new advisory introduced (high count 7 → 6).
- `npm run build` (`tsc && vite build`) passes on this head. Rust is not touched by this change; its build/tests are confirmed by CI's `rust` matrix (macOS/Ubuntu/Windows).

### Not addressed here (MANUAL — left for human review)

The remaining 6 npm advisories all cluster in the **ESLint dev-toolchain** and each requires a **major** bump (out of scope for auto-merge):

- `eslint` → fix path `eslint@10` (semver-major)
- `eslint-plugin-jsx-a11y`, `@eslint/config-array`, `@eslint/eslintrc`, `minimatch`, `brace-expansion` ([GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg)) — resolved only via major/breaking bumps of the ESLint chain.

`cargo audit` reported **0 vulnerabilities** — only `unmaintained`/`unsound` informational warnings on the GTK/Tauri native stack (no patched versions available), which are not actionable here.

---

Supersedes any prior open `chore/sec-audit-*` PR (there were none tonight). This PR **auto-merges** (squash) only if CI is fully green **and** the adversarial merge-review gate passes 5/5; otherwise it stays open for a human.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014792dMsJt27VG5HcxSBgDe

---
_Generated by [Claude Code](https://claude.ai/code/session_014792dMsJt27VG5HcxSBgDe)_