### PR TITLE
fix(autostart): don't let a build-tree copy hijack launch-at-login (macOS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Versions on the `0.0.X` line are public beta releases; `0.1.X` and onwards will 
 
 ## [Unreleased]
 
+### Fixed
+
+- **A leftover build of Entracte can no longer hijack "launch at login" from the one you installed (macOS).** If a copy of Entracte was ever run from a build folder (a `target/…` directory left over from building it locally), it would quietly point "launch at login" at itself and re-claim that spot every login — so the app that actually started each day was the old build, not the version in your Applications folder. If that build predated a fix, you'd keep seeing the already-fixed bug (e.g. the invisible break overlay of [#196](https://github.com/drmowinckels/entracte/issues/196)). A build running from a `target/…` folder now leaves "launch at login" alone, so the installed app stays the one that runs.
+
 ### Added
 
 - **Take a long break now.** A new **Take a long break now** action — in the menu-bar menu and on the Breaks tab (next to _Test long_) — starts your long break immediately and restarts the rotation from that moment, so if you step away early (the washing machine's done, a call wrapped up) you get your proper long break when you want it and aren't broken again a few minutes later. ([#258](https://github.com/drmowinckels/entracte/issues/258))

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -60,9 +60,23 @@ fn autostart_agent_is_stale(plist: &str, current_exe: &str) -> bool {
     launch_agent_program_path(plist).is_some_and(|p| p != current_exe)
 }
 
+/// True when the running executable lives inside a Cargo build tree
+/// (`.../target/debug/...` or `.../target/release/...`). Such a binary is a
+/// transient dev or CI build, never an installed app, so it must not claim
+/// the autostart LaunchAgent. Without this guard a locally-built bundle that
+/// repoints autostart to itself hijacks it from the installed app and
+/// re-asserts every login — the user then keeps launching the stale build
+/// (e.g. the pre-fix invisible overlay of #196/#226) instead of the release
+/// they installed.
+#[cfg(any(target_os = "macos", test))]
+fn is_dev_build_path(exe: &str) -> bool {
+    exe.contains("/target/debug/") || exe.contains("/target/release/")
+}
+
 /// Repoint the autostart LaunchAgent at the running executable when it was
-/// written by a different build. Only the path-mismatch decision carries
-/// logic ([`autostart_agent_is_stale`]); the rest is filesystem/plugin glue.
+/// written by a different build. Only the path decisions carry logic
+/// ([`autostart_agent_is_stale`], [`is_dev_build_path`]); the rest is
+/// filesystem/plugin glue.
 #[cfg(target_os = "macos")]
 fn repoint_stale_autostart_agent(app: &tauri::App) {
     use tauri_plugin_autostart::ManagerExt;
@@ -82,7 +96,16 @@ fn repoint_stale_autostart_agent(app: &tauri::App) {
     let Ok(exe) = std::env::current_exe().and_then(|p| p.canonicalize()) else {
         return;
     };
-    if autostart_agent_is_stale(&contents, &exe.display().to_string()) {
+    let exe = exe.display().to_string();
+    // A build running from a Cargo target tree is never the installed app, so
+    // leave autostart alone: a locally-built bundle that claimed it would
+    // hijack the LaunchAgent from the real install and re-assert every login.
+    // The installed app repoints correctly when it next runs.
+    if is_dev_build_path(&exe) {
+        log::debug!("autostart: running from a build tree; leaving the LaunchAgent untouched");
+        return;
+    }
+    if autostart_agent_is_stale(&contents, &exe) {
         log::warn!(
             "autostart: LaunchAgent points at a stale executable; repointing to current binary"
         );
@@ -445,5 +468,24 @@ mod tests {
     #[test]
     fn agent_is_not_stale_without_program_arguments() {
         assert!(!super::autostart_agent_is_stale("<plist/>", EXE));
+    }
+
+    #[test]
+    fn dev_build_path_detects_cargo_target_tree() {
+        assert!(super::is_dev_build_path(
+            "/Users/dev/workspace/entracte/src-tauri/target/release/bundle/macos/\
+             Entracte.app/Contents/MacOS/entracte"
+        ));
+        assert!(super::is_dev_build_path(
+            "/Users/dev/entracte/src-tauri/target/debug/entracte"
+        ));
+    }
+
+    #[test]
+    fn dev_build_path_false_for_installed_app() {
+        assert!(!super::is_dev_build_path(EXE));
+        assert!(!super::is_dev_build_path(
+            "/Users/me/Applications/Entracte.app/Contents/MacOS/entracte"
+        ));
     }
 }


### PR DESCRIPTION
## Summary

A user reported the **invisible break overlay "regression" in v0.0.10** — but 0.0.10's overlay code is byte-identical to the fixed 0.0.9. The real cause was environmental: their autostart LaunchAgent pointed at a **locally-built v0.0.6 bundle** under `~/workspace/.../target/release/bundle/macos/Entracte.app` (built 8 days *before* the de-zod overlay fix #227). Every login relaunched that stale pre-fix binary; the installed 0.0.10 never ran.

Why it perpetuated: [`repoint_stale_autostart_agent`](src-tauri/src/lib.rs) repoints the LaunchAgent to `current_exe()` — *whichever build ran last wins*. Once a `target/…` dev build ran, it claimed launch-at-login and re-asserted itself every login. This is the same "stale binary re-blocks every login" trap noted for the sibling app.

## Change

Add a pure, tested predicate `is_dev_build_path` and guard the repoint: a binary running from a Cargo `target/{debug,release}/` tree now **leaves the LaunchAgent untouched**, so only a real install manages autostart. The installed app still repoints correctly when it runs.

## Test plan

- `cargo test --lib` — new `dev_build_path_detects_cargo_target_tree` / `dev_build_path_false_for_installed_app` cover both `||` branches and the installed-app negatives; existing `agent_is_stale_*` tests unchanged (7/7 pass).
- `cargo clippy --all-targets` clean; `cargo fmt` applied.
- Pre-merge trio run: critical-code-reviewer (approve), security-review (no findings), simplify (nothing to change).

## Known limitation

Covers the default `target/debug` / `target/release` layout (the documented trap). A custom `CARGO_TARGET_DIR` or named profile (`target/dist/…`) isn't matched; if that recurs, flip to an install-location allowlist (`/Applications`, `~/Applications`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)