### PR TITLE
feat(download): auto-detecting download button on site and in-app

### DIFF
--- a/.github/audit/cspell/project-words.txt
+++ b/.github/audit/cspell/project-words.txt
@@ -53,6 +53,7 @@ proscenium
 Lemon
 appimage
 AppImage
+riscv
 gsettings
 gdbus
 WebKit

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -65,6 +65,7 @@ jobs:
         working-directory: docs
         run: |
           npm ci || npm install
+          npm test
           npm run build
       - name: Install desktop app dependencies
         run: npm ci || npm install

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -48,6 +48,7 @@ jobs:
         working-directory: docs
         run: |
           npm ci || npm install
+          npm test
           npm run build
       - name: Install desktop app dependencies
         run: npm ci || npm install

--- a/docs/.vitepress/theme/components/SmartDownload.vue
+++ b/docs/.vitepress/theme/components/SmartDownload.vue
@@ -1,0 +1,231 @@
+<script setup lang="ts">
+import { computed, onMounted, ref } from "vue";
+import {
+  classify,
+  detectOs,
+  groupByOs,
+  OS_LABELS,
+  selectPrimary,
+  selectSecondary,
+  type Installer,
+  type Os,
+} from "./download-detect";
+
+// Auto-detecting download control for the landing + install pages. It
+// asks the GitHub API for the latest release, detects the visitor's OS
+// (and arch where the browser exposes it), and offers a one-click
+// download of the matching installer — with every other build one
+// "All downloads" toggle away. On any failure it degrades to a plain
+// link to the Releases page. The pure detection/matching logic lives in
+// ./download-detect.ts (unit-tested); this file is DOM + fetch glue.
+
+const RELEASES_PAGE = "https://github.com/drmowinckels/entracte/releases";
+const LATEST_API =
+  "https://api.github.com/repos/drmowinckels/entracte/releases/latest";
+
+async function detectArch(): Promise<"aarch64" | "x64" | null> {
+  // Only Chromium exposes CPU architecture (via UA-CH). Safari/Firefox
+  // mask it, so macOS visitors there see both builds instead.
+  const uaData = (
+    navigator as Navigator & {
+      userAgentData?: {
+        getHighEntropyValues?: (h: string[]) => Promise<{ architecture?: string }>;
+      };
+    }
+  ).userAgentData;
+  if (!uaData?.getHighEntropyValues) return null;
+  try {
+    const { architecture } = await uaData.getHighEntropyValues(["architecture"]);
+    if (architecture === "arm") return "aarch64";
+    if (architecture === "x86") return "x64";
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+// Module-level cache so navigating between the landing and install pages
+// doesn't re-hit the API (and its unauthenticated rate limit).
+let releaseCache: Promise<{ tag: string; installers: Installer[] }> | null = null;
+
+function loadRelease() {
+  if (!releaseCache) {
+    releaseCache = fetch(LATEST_API, {
+      headers: { Accept: "application/vnd.github+json" },
+    })
+      .then((r) => {
+        if (!r.ok) throw new Error(`GitHub API ${r.status}`);
+        return r.json();
+      })
+      .then(
+        (data: {
+          tag_name?: string;
+          assets?: { name: string; browser_download_url: string }[];
+        }) => ({
+          tag: data.tag_name ?? "",
+          installers: classify(
+            (data.assets ?? []).map((a) => ({ name: a.name, url: a.browser_download_url })),
+          ),
+        }),
+      )
+      .catch((e) => {
+        releaseCache = null; // let a later mount retry
+        throw e;
+      });
+  }
+  return releaseCache;
+}
+
+const status = ref<"loading" | "ready" | "error">("loading");
+const tag = ref("");
+const installers = ref<Installer[]>([]);
+const os = ref<Os>("other");
+const arch = ref<"aarch64" | "x64" | null>(null);
+
+onMounted(async () => {
+  os.value = detectOs(navigator.userAgent);
+  arch.value = await detectArch();
+  try {
+    const rel = await loadRelease();
+    tag.value = rel.tag;
+    installers.value = rel.installers;
+    status.value = "ready";
+  } catch {
+    status.value = "error";
+  }
+});
+
+const primary = computed(() => selectPrimary(installers.value, os.value, arch.value));
+const secondary = computed(() =>
+  selectSecondary(installers.value, os.value, primary.value),
+);
+const grouped = computed(() => groupByOs(installers.value));
+const osLabel = computed(() => OS_LABELS[os.value]);
+</script>
+
+<template>
+  <div class="smart-download">
+    <div v-if="status === 'loading'" class="sd-line">
+      <a class="sd-btn" :href="RELEASES_PAGE" target="_blank" rel="noreferrer">
+        Download Entracte
+      </a>
+      <span class="sd-note">Detecting your system…</span>
+    </div>
+
+    <template v-else-if="status === 'ready'">
+      <div class="sd-primary">
+        <a v-for="i in primary" :key="i.name" class="sd-btn" :href="i.url">
+          Download for {{ osLabel
+          }}<template v-if="os === 'macos'"> · {{ i.label }}</template>
+        </a>
+        <a
+          v-if="!primary.length"
+          class="sd-btn"
+          :href="RELEASES_PAGE"
+          target="_blank"
+          rel="noreferrer"
+        >
+          Download Entracte
+        </a>
+      </div>
+
+      <p class="sd-meta">
+        <template v-if="tag">Latest release <strong>{{ tag }}</strong>.</template>
+        <template v-if="primary.length && secondary.length">
+          Other {{ osLabel }} builds:
+          <template v-for="(i, idx) in secondary" :key="i.name"
+            ><a :href="i.url">{{ i.label }}</a
+            ><template v-if="idx < secondary.length - 1"> · </template></template
+          >.
+        </template>
+      </p>
+
+      <details v-if="grouped.length" class="sd-details">
+        <summary>All platforms &amp; formats</summary>
+        <div class="sd-groups">
+          <div v-for="g in grouped" :key="g.os" class="sd-group">
+            <span class="sd-group-title">{{ g.label }}</span>
+            <ul>
+              <li v-for="i in g.items" :key="i.name">
+                <a :href="i.url">{{ i.label }}</a>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </details>
+    </template>
+
+    <div v-else class="sd-line">
+      <a class="sd-btn" :href="RELEASES_PAGE" target="_blank" rel="noreferrer">
+        Download from Releases
+      </a>
+      <span class="sd-note">
+        Couldn't reach GitHub just now — pick your build on the
+        <a :href="RELEASES_PAGE" target="_blank" rel="noreferrer">Releases page</a>.
+      </span>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.smart-download {
+  margin: 1.5rem 0;
+}
+.sd-primary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+.sd-btn {
+  display: inline-block;
+  padding: 0.5rem 1.25rem;
+  border-radius: 8px;
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: var(--vp-button-brand-text);
+  background: var(--vp-button-brand-bg);
+  border: 1px solid var(--vp-button-brand-border);
+  transition:
+    background-color 0.2s,
+    border-color 0.2s;
+}
+.sd-btn:hover {
+  text-decoration: none;
+  color: var(--vp-button-brand-hover-text);
+  background: var(--vp-button-brand-hover-bg);
+  border-color: var(--vp-button-brand-hover-border);
+}
+.sd-line {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+}
+.sd-note,
+.sd-meta {
+  font-size: 0.85rem;
+  color: var(--vp-c-text-2);
+}
+.sd-meta {
+  margin-top: 0.75rem;
+}
+.sd-details summary {
+  cursor: pointer;
+  color: var(--vp-c-brand-1);
+  font-size: 0.85rem;
+}
+.sd-groups {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  margin-top: 0.75rem;
+}
+.sd-group-title {
+  font-weight: 600;
+  color: var(--vp-c-text-1);
+}
+.sd-group ul {
+  margin: 0.25rem 0 0;
+  padding-left: 1rem;
+}
+</style>

--- a/docs/.vitepress/theme/components/download-detect.test.ts
+++ b/docs/.vitepress/theme/components/download-detect.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  classify,
+  detectOs,
+  groupByOs,
+  selectPrimary,
+  selectSecondary,
+  type Asset,
+} from "./download-detect";
+
+const BASE = "https://github.com/drmowinckels/entracte/releases/download/v0.0.10";
+
+// A realistic v0.0.10 asset listing (installers + the noise the classifier
+// must ignore: signatures, updater tarballs, checksums, manifest).
+const assets: Asset[] = [
+  { name: "Entracte_0.0.10_aarch64.dmg", url: `${BASE}/Entracte_0.0.10_aarch64.dmg` },
+  { name: "Entracte_0.0.10_x64.dmg", url: `${BASE}/Entracte_0.0.10_x64.dmg` },
+  { name: "Entracte_0.0.10_x64-setup.exe", url: `${BASE}/Entracte_0.0.10_x64-setup.exe` },
+  { name: "Entracte_0.0.10_x64_en-US.msi", url: `${BASE}/Entracte_0.0.10_x64_en-US.msi` },
+  { name: "Entracte_0.0.10_amd64.AppImage", url: `${BASE}/Entracte_0.0.10_amd64.AppImage` },
+  { name: "Entracte_0.0.10_amd64.deb", url: `${BASE}/Entracte_0.0.10_amd64.deb` },
+  { name: "Entracte-0.0.10-1.x86_64.rpm", url: `${BASE}/Entracte-0.0.10-1.x86_64.rpm` },
+  { name: "Entracte_0.0.10_aarch64.app.tar.gz", url: `${BASE}/Entracte_0.0.10_aarch64.app.tar.gz` },
+  { name: "Entracte_0.0.10_amd64.AppImage.sig", url: `${BASE}/Entracte_0.0.10_amd64.AppImage.sig` },
+  { name: "latest.json", url: `${BASE}/latest.json` },
+  { name: "SHA256SUMS.txt", url: `${BASE}/SHA256SUMS.txt` },
+];
+
+describe("classify", () => {
+  it("recognises exactly the seven installer artefacts", () => {
+    const got = classify(assets);
+    expect(got.map((i) => i.name).sort()).toEqual(
+      [
+        "Entracte-0.0.10-1.x86_64.rpm",
+        "Entracte_0.0.10_aarch64.dmg",
+        "Entracte_0.0.10_amd64.AppImage",
+        "Entracte_0.0.10_amd64.deb",
+        "Entracte_0.0.10_x64-setup.exe",
+        "Entracte_0.0.10_x64.dmg",
+        "Entracte_0.0.10_x64_en-US.msi",
+      ].sort(),
+    );
+  });
+
+  it("drops signatures, updater tarballs, checksums, and the manifest", () => {
+    const names = classify(assets).map((i) => i.name);
+    expect(names.some((n) => n.endsWith(".sig"))).toBe(false);
+    expect(names.some((n) => n.endsWith(".app.tar.gz"))).toBe(false);
+    expect(names).not.toContain("latest.json");
+    expect(names).not.toContain("SHA256SUMS.txt");
+  });
+
+  it("tags the two macOS builds with their arch", () => {
+    const macs = classify(assets).filter((i) => i.os === "macos");
+    expect(macs.find((i) => i.arch === "aarch64")?.name).toBe(
+      "Entracte_0.0.10_aarch64.dmg",
+    );
+    expect(macs.find((i) => i.arch === "x64")?.name).toBe(
+      "Entracte_0.0.10_x64.dmg",
+    );
+  });
+
+  it("rejects an installer served from an untrusted host (defence in depth)", () => {
+    const spoofed: Asset[] = [
+      {
+        name: "Entracte_0.0.10_aarch64.dmg",
+        url: "https://evil.example.com/Entracte_0.0.10_aarch64.dmg",
+      },
+      { name: "javascript-uri.dmg", url: "javascript:alert(1)" },
+    ];
+    expect(classify(spoofed)).toEqual([]);
+  });
+
+  it("sorts within an OS by preferred rank", () => {
+    const linux = classify(assets).filter((i) => i.os === "linux");
+    expect(linux.map((i) => i.label)).toEqual([
+      "AppImage",
+      "Debian / Ubuntu (.deb)",
+      "Fedora / openSUSE (.rpm)",
+    ]);
+  });
+});
+
+describe("detectOs", () => {
+  it("identifies the three desktop platforms", () => {
+    expect(detectOs("Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0)")).toBe("macos");
+    expect(detectOs("Mozilla/5.0 (Windows NT 10.0; Win64; x64)")).toBe("windows");
+    expect(detectOs("Mozilla/5.0 (X11; Linux x86_64)")).toBe("linux");
+  });
+
+  it("maps mobile and unknown UAs to other (no desktop build for them)", () => {
+    expect(detectOs("Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X)")).toBe(
+      "other",
+    );
+    expect(detectOs("Mozilla/5.0 (Linux; Android 14)")).toBe("other");
+    expect(detectOs("SomeWeirdBot/1.0")).toBe("other");
+  });
+});
+
+describe("selectPrimary", () => {
+  const installers = classify(assets);
+
+  it("picks the matching arch build on macOS when the arch is known", () => {
+    expect(selectPrimary(installers, "macos", "aarch64").map((i) => i.name)).toEqual([
+      "Entracte_0.0.10_aarch64.dmg",
+    ]);
+    expect(selectPrimary(installers, "macos", "x64").map((i) => i.name)).toEqual([
+      "Entracte_0.0.10_x64.dmg",
+    ]);
+  });
+
+  it("offers both macOS builds when the arch is undetermined", () => {
+    const both = selectPrimary(installers, "macos", null);
+    expect(both.map((i) => i.arch)).toEqual(["aarch64", "x64"]);
+  });
+
+  it("picks the rank-0 build for Windows and Linux", () => {
+    expect(selectPrimary(installers, "windows", null)[0].label).toBe("Installer (.exe)");
+    expect(selectPrimary(installers, "linux", null)[0].label).toBe("AppImage");
+  });
+
+  it("returns nothing for an OS with no build", () => {
+    expect(selectPrimary(installers, "other", null)).toEqual([]);
+  });
+});
+
+describe("selectSecondary", () => {
+  const installers = classify(assets);
+
+  it("lists the other builds for the OS, excluding the primary", () => {
+    const primary = selectPrimary(installers, "linux", null);
+    expect(selectSecondary(installers, "linux", primary).map((i) => i.label)).toEqual([
+      "Debian / Ubuntu (.deb)",
+      "Fedora / openSUSE (.rpm)",
+    ]);
+  });
+
+  it("surfaces the other-arch dmg as the macOS secondary", () => {
+    const primary = selectPrimary(installers, "macos", "aarch64");
+    expect(selectSecondary(installers, "macos", primary).map((i) => i.arch)).toEqual([
+      "x64",
+    ]);
+  });
+});
+
+describe("groupByOs", () => {
+  it("groups installers in display order, skipping empty groups", () => {
+    const groups = groupByOs(classify(assets));
+    expect(groups.map((g) => g.os)).toEqual(["macos", "windows", "linux"]);
+    expect(groups.every((g) => g.items.length > 0)).toBe(true);
+  });
+
+  it("omits an OS with no installers", () => {
+    const macOnly = classify([
+      { name: "Entracte_0.0.10_aarch64.dmg", url: `${BASE}/Entracte_0.0.10_aarch64.dmg` },
+    ]);
+    expect(groupByOs(macOnly).map((g) => g.os)).toEqual(["macos"]);
+  });
+});

--- a/docs/.vitepress/theme/components/download-detect.ts
+++ b/docs/.vitepress/theme/components/download-detect.ts
@@ -1,0 +1,123 @@
+// Pure, framework-free detection + asset-matching logic for the
+// SmartDownload component. Kept out of the .vue so it's unit-testable
+// without a DOM. Asset patterns mirror the tauri-bundler output in
+// `.github/workflows/release.yml` and the app-side builder in
+// `src/lib/download.ts`; keep the three in lockstep if names change.
+
+export type Os = "macos" | "windows" | "linux" | "other";
+export type Asset = { name: string; url: string };
+
+export interface Installer {
+  os: Os;
+  /** Order within an OS group; lower is the preferred default. */
+  rank: number;
+  /** Button/row label, e.g. "Apple Silicon" or "AppImage". */
+  label: string;
+  /** Only set for macOS, where the arch splits the build. */
+  arch?: "aarch64" | "x64";
+  name: string;
+  url: string;
+}
+
+export const OS_LABELS: Record<Os, string> = {
+  macos: "macOS",
+  windows: "Windows",
+  linux: "Linux",
+  other: "your system",
+};
+
+// Defence in depth: asset URLs come from a remote API and are rendered
+// straight into `href`s, so only accept genuine GitHub release download
+// links — never a `javascript:` URL or an off-host redirect a
+// spoofed/compromised response might smuggle in.
+export const TRUSTED_ASSET_PREFIX =
+  "https://github.com/drmowinckels/entracte/releases/download/";
+
+// Ordered so the first match wins; `.sig`, `latest.json`, checksums and
+// the `.app.tar.gz` updater artefacts match nothing and are ignored.
+const RULES: {
+  test: RegExp;
+  os: Os;
+  rank: number;
+  label: string;
+  arch?: "aarch64" | "x64";
+}[] = [
+  { test: /_aarch64\.dmg$/, os: "macos", rank: 0, label: "Apple Silicon", arch: "aarch64" },
+  { test: /_x64\.dmg$/, os: "macos", rank: 1, label: "Intel", arch: "x64" },
+  { test: /-setup\.exe$/, os: "windows", rank: 0, label: "Installer (.exe)" },
+  { test: /\.msi$/, os: "windows", rank: 1, label: "MSI" },
+  { test: /\.AppImage$/, os: "linux", rank: 0, label: "AppImage" },
+  { test: /\.deb$/, os: "linux", rank: 1, label: "Debian / Ubuntu (.deb)" },
+  { test: /\.rpm$/, os: "linux", rank: 2, label: "Fedora / openSUSE (.rpm)" },
+];
+
+/** Turn a release's raw assets into recognised installers, sorted by OS
+ * then preferred rank. Anything that isn't a trusted GitHub download URL,
+ * or doesn't match a known installer pattern, is dropped. */
+export function classify(assets: Asset[]): Installer[] {
+  const out: Installer[] = [];
+  for (const a of assets) {
+    if (a.name.endsWith(".sig")) continue;
+    if (!a.url.startsWith(TRUSTED_ASSET_PREFIX)) continue;
+    const rule = RULES.find((r) => r.test.test(a.name));
+    if (rule) {
+      out.push({
+        os: rule.os,
+        rank: rule.rank,
+        label: rule.label,
+        arch: rule.arch,
+        name: a.name,
+        url: a.url,
+      });
+    }
+  }
+  return out.sort((x, y) => x.os.localeCompare(y.os) || x.rank - y.rank);
+}
+
+/** Best-guess host OS from a user-agent string. Mobile UAs (which we have
+ * no desktop build for) map to `"other"`. */
+export function detectOs(ua: string): Os {
+  const s = ua.toLowerCase();
+  if (/(iphone|ipad|android)/.test(s)) return "other";
+  if (s.includes("mac")) return "macos";
+  if (s.includes("win")) return "windows";
+  if (s.includes("linux")) return "linux";
+  return "other";
+}
+
+/** The recommended primary download(s) for the detected host. macOS with
+ * an undetermined arch yields both builds (the caller shows two buttons);
+ * every other case yields the single rank-0 build. Empty when we have no
+ * installer for the OS — the caller then points at the Releases page. */
+export function selectPrimary(
+  installers: Installer[],
+  os: Os,
+  arch: "aarch64" | "x64" | null,
+): Installer[] {
+  const mine = installers.filter((i) => i.os === os);
+  if (!mine.length) return [];
+  if (os === "macos" && arch) return mine.filter((i) => i.arch === arch);
+  if (os === "macos") return mine.filter((i) => i.arch);
+  return [mine[0]];
+}
+
+/** Other builds for the detected OS (e.g. .msi, .deb, .rpm, or the
+ * other-arch .dmg), excluding whatever's already shown as primary. */
+export function selectSecondary(
+  installers: Installer[],
+  os: Os,
+  primary: Installer[],
+): Installer[] {
+  const shown = new Set(primary.map((i) => i.name));
+  return installers.filter((i) => i.os === os && !shown.has(i.name));
+}
+
+/** All installers grouped by OS in display order, skipping empty groups. */
+export function groupByOs(
+  installers: Installer[],
+): { os: Os; label: string; items: Installer[] }[] {
+  const order: Os[] = ["macos", "windows", "linux"];
+  return order
+    .map((o) => ({ os: o, label: OS_LABELS[o], items: installers.filter((i) => i.os === o) }))
+    .filter((g) => g.items.length);
+}

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,4 +1,11 @@
 import DefaultTheme from "vitepress/theme";
+import type { EnhanceAppContext } from "vitepress";
 import "./custom.css";
+import SmartDownload from "./components/SmartDownload.vue";
 
-export default DefaultTheme;
+export default {
+  extends: DefaultTheme,
+  enhanceApp({ app }: EnhanceAppContext) {
+    app.component("SmartDownload", SmartDownload);
+  },
+};

--- a/docs/guide/install.md
+++ b/docs/guide/install.md
@@ -6,7 +6,9 @@ Entracte is in its public beta line (`0.0.X`). Bundles ship from the same releas
 
 ## Download official builds
 
-Tagged releases appear on the [Releases page](https://github.com/drmowinckels/entracte/releases) with signed installers for every supported platform. Pick the artefact that matches your OS and architecture. Beta releases (`0.0.X`) are flagged as pre-releases on GitHub, so `releases/latest` won't surface them — open the Releases page directly until the stable line begins.
+<SmartDownload />
+
+The button above auto-detects your OS — and your Mac's chip, where the browser reveals it — and links straight to the matching installer for the latest release; **All platforms & formats** expands the full list. Every release is published as a normal (non-prerelease) release, so `releases/latest` and the [Releases page](https://github.com/drmowinckels/entracte/releases) always point at the newest `0.0.X` beta. Prefer to pick by hand? The platform-by-platform breakdown below names every artefact.
 
 ### macOS
 
@@ -55,11 +57,11 @@ Once we have evidence to satisfy SignPath's criteria, we'll reapply. The CI sign
 
 ### Linux
 
-- `entracte_<version>_amd64.AppImage` — portable, single binary
-- `entracte_<version>_amd64.deb` — Debian, Ubuntu, and derivatives
-- `entracte-<version>-1.x86_64.rpm` — Fedora, openSUSE, and derivatives
+- `Entracte_<version>_amd64.AppImage` — portable, single binary
+- `Entracte_<version>_amd64.deb` — Debian, Ubuntu, and derivatives
+- `Entracte-<version>-1.x86_64.rpm` — Fedora, openSUSE, and derivatives
 
-AppImage: `chmod +x entracte_*.AppImage && ./entracte_*.AppImage`. For `.deb` / `.rpm`, install via your package manager (e.g. `sudo apt install ./entracte_*.deb`). Linux builds aren't per-binary code-signed — the ecosystem relies on repository signatures instead.
+AppImage: `chmod +x Entracte_*.AppImage && ./Entracte_*.AppImage`. For `.deb` / `.rpm`, install via your package manager (e.g. `sudo apt install ./Entracte_*.deb`). Linux builds aren't per-binary code-signed — the ecosystem relies on repository signatures instead.
 
 ## Build from source
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -62,8 +62,12 @@ features:
   </video>
 </div>
 
-::: warning Pre-release
-No tagged binaries yet — installing currently means [building from source](/guide/install). The release pipeline is in place; the first `v0.1.0` will land on the [Releases page](https://github.com/drmowinckels/entracte/releases) once it's cut.
+<div style="text-align: center; margin: 2.5rem 0 1rem;">
+  <SmartDownload />
+</div>
+
+::: tip Public beta
+Entracte is in its public beta line (`0.0.X`). Builds are published for macOS, Windows, and Linux from the [release pipeline](https://github.com/drmowinckels/entracte/releases) — see the [install guide](/guide/install) for signing status and package-manager options.
 :::
 
 <div style="text-align: center; margin-top: 2rem;">

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -8,7 +8,8 @@
       "devDependencies": {
         "mermaid": "^11.15.0",
         "vitepress": "^1.5.0",
-        "vitepress-plugin-mermaid": "^2.0.17"
+        "vitepress-plugin-mermaid": "^2.0.17",
+        "vitest": "^4.1.6"
       }
     },
     "node_modules/@algolia/abtesting": {
@@ -396,6 +397,40 @@
         "search-insights": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -859,6 +894,317 @@
       "dependencies": {
         "@chevrotain/types": "~11.1.1"
       }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.60.4",
@@ -1336,6 +1682,35 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/d3": {
       "version": "7.4.3",
       "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
@@ -1620,6 +1995,13 @@
         "@types/d3-selection": "*"
       }
     },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1731,6 +2113,92 @@
       "peerDependencies": {
         "vite": "^5.0.0 || ^6.0.0",
         "vue": "^3.2.25"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vue/compiler-core": {
@@ -2010,6 +2478,16 @@
         "node": ">= 14.0.0"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/birpc": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/birpc/-/birpc-2.9.0.tgz",
@@ -2029,6 +2507,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/character-entities-html4": {
@@ -2073,6 +2561,13 @@
       "engines": {
         "node": ">= 10"
       }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/copy-anything": {
       "version": "4.0.5",
@@ -2675,6 +3170,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/devlop": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
@@ -2718,6 +3223,13 @@
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-toolkit": {
       "version": "1.46.1",
@@ -2775,6 +3287,34 @@
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
     },
     "node_modules/focus-trap": {
       "version": "7.8.0",
@@ -2950,6 +3490,279 @@
       "integrity": "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
     },
     "node_modules/lodash-es": {
       "version": "4.18.1",
@@ -3149,9 +3962,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -3174,6 +3987,20 @@
       "dev": true,
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
     },
     "node_modules/oniguruma-to-es": {
       "version": "3.1.1",
@@ -3201,6 +4028,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/perfect-debounce": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
@@ -3214,6 +4048,19 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/points-on-curve": {
       "version": "0.2.0",
@@ -3234,9 +4081,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.14",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
-      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "dev": true,
       "funding": [
         {
@@ -3254,7 +4101,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -3324,6 +4171,40 @@
       "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
       "dev": true,
       "license": "Unlicense"
+    },
+    "node_modules/rolldown": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.139.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
+      }
     },
     "node_modules/rollup": {
       "version": "4.60.4",
@@ -3422,6 +4303,13 @@
         "@types/hast": "^3.0.4"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -3452,6 +4340,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stringify-entities": {
       "version": "4.0.4",
@@ -3495,6 +4397,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
@@ -3503,6 +4412,33 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/trim-lines": {
@@ -3525,6 +4461,14 @@
       "engines": {
         "node": ">=6.10"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/unist-util-is": {
       "version": "6.0.1",
@@ -3759,6 +4703,211 @@
         "vitepress": "^1.0.0 || ^1.0.0-alpha"
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/vitest/node_modules/vite": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/vue": {
       "version": "3.5.34",
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.34.tgz",
@@ -3779,6 +4928,23 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/zwitch": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -5,11 +5,13 @@
   "scripts": {
     "dev": "vitepress dev",
     "build": "vitepress build",
-    "preview": "vitepress preview"
+    "preview": "vitepress preview",
+    "test": "vitest run"
   },
   "devDependencies": {
     "mermaid": "^11.15.0",
     "vitepress": "^1.5.0",
-    "vitepress-plugin-mermaid": "^2.0.17"
+    "vitepress-plugin-mermaid": "^2.0.17",
+    "vitest": "^4.1.6"
   }
 }

--- a/docs/vitest.config.ts
+++ b/docs/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: [".vitepress/**/*.{test,spec}.ts"],
+  },
+});

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -187,6 +187,7 @@ pub fn run() {
             updater::check_for_update,
             diagnostics::build_diagnostics_report,
             platform::get_platform,
+            platform::get_arch,
             platform::get_platform_capabilities,
             platform::get_locale,
             window::close_pause_window,

--- a/src-tauri/src/platform.rs
+++ b/src-tauri/src/platform.rs
@@ -17,6 +17,18 @@ pub fn get_platform() -> &'static str {
     std::env::consts::OS
 }
 
+/// Return the host CPU architecture as the value of
+/// `std::env::consts::ARCH` (`"aarch64"`, `"x86_64"`, …). Compiled into
+/// the binary, so it reflects the build target the user is running —
+/// exactly the build the Download button should offer them. The browser
+/// can't see this reliably (WKWebView masks Apple Silicon as Intel), so
+/// the renderer asks Rust and normalises the answer through
+/// `normaliseArch` in `lib/platform.ts`.
+#[tauri::command]
+pub fn get_arch() -> &'static str {
+    std::env::consts::ARCH
+}
+
 /// Normalise an optional OS locale into a BCP-47 tag the renderer can hand
 /// to `Intl`. Falls back to `"en-US"` when the OS reports nothing usable.
 /// Pure so the fallback is unit-testable without the platform locale source.
@@ -137,6 +149,18 @@ mod tests {
         assert!(
             matches!(p, "macos" | "linux" | "windows"),
             "unexpected std::env::consts::OS = {p:?}",
+        );
+    }
+
+    #[test]
+    fn get_arch_returns_a_known_value() {
+        let a = get_arch();
+        // The CI matrix builds x86_64 and aarch64; reject anything else so a
+        // new target arch gets a deliberate mapping in the renderer rather
+        // than silently falling through to the "other" download bucket.
+        assert!(
+            matches!(a, "x86_64" | "aarch64"),
+            "unexpected std::env::consts::ARCH = {a:?}",
         );
     }
 

--- a/src/lib/download.test.ts
+++ b/src/lib/download.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import { primaryInstaller } from "./download";
+
+describe("primaryInstaller", () => {
+  it("offers the Apple Silicon .dmg for macOS aarch64", () => {
+    const i = primaryInstaller("macos", "aarch64", "0.0.10");
+    expect(i).toEqual({
+      label: "macOS (Apple Silicon)",
+      fileName: "Entracte_0.0.10_aarch64.dmg",
+      url: "https://github.com/drmowinckels/entracte/releases/download/v0.0.10/Entracte_0.0.10_aarch64.dmg",
+    });
+  });
+
+  it("offers the Intel .dmg for macOS x64", () => {
+    const i = primaryInstaller("macos", "x64", "0.0.10");
+    expect(i?.fileName).toBe("Entracte_0.0.10_x64.dmg");
+    expect(i?.label).toBe("macOS (Intel)");
+  });
+
+  it("returns null for macOS when the arch is unknown", () => {
+    // WKWebView masks Apple Silicon as Intel; when Rust hasn't answered
+    // yet the arch is "other" and we must not guess the wrong .dmg.
+    expect(primaryInstaller("macos", "other", "0.0.10")).toBeNull();
+  });
+
+  it("offers the NSIS installer for Windows regardless of reported arch", () => {
+    const i = primaryInstaller("windows", "other", "0.0.10");
+    expect(i?.fileName).toBe("Entracte_0.0.10_x64-setup.exe");
+    expect(i?.label).toBe("Windows");
+  });
+
+  it("offers the AppImage for Linux", () => {
+    const i = primaryInstaller("linux", "x64", "0.0.10");
+    expect(i?.fileName).toBe("Entracte_0.0.10_amd64.AppImage");
+    expect(i?.label).toBe("Linux (AppImage)");
+  });
+
+  it("returns null for an unsupported OS", () => {
+    expect(primaryInstaller("other", "x64", "0.0.10")).toBeNull();
+  });
+
+  it("normalises a v-prefixed version so the tag isn't doubled up", () => {
+    const i = primaryInstaller("macos", "aarch64", "v0.1.0");
+    expect(i?.fileName).toBe("Entracte_0.1.0_aarch64.dmg");
+    expect(i?.url).toBe(
+      "https://github.com/drmowinckels/entracte/releases/download/v0.1.0/Entracte_0.1.0_aarch64.dmg",
+    );
+  });
+});

--- a/src/lib/download.ts
+++ b/src/lib/download.ts
@@ -1,0 +1,60 @@
+import type { Arch, Platform } from "./platform";
+
+const RELEASE_BASE =
+  "https://github.com/drmowinckels/entracte/releases/download";
+
+/** Strip a leading `v` so callers can pass either the app's bare
+ * `package_info().version` (`"0.0.10"`) or a release tag (`"v0.0.10"`). */
+function bareVersion(version: string): string {
+  return version.replace(/^v/, "");
+}
+
+/** A downloadable installer artefact for a specific release. */
+export interface Installer {
+  /** Short label for the Download button, e.g. `"macOS (Apple Silicon)"`. */
+  label: string;
+  /** The asset file name exactly as published on the GitHub release. */
+  fileName: string;
+  /** Absolute download URL on the GitHub release. */
+  url: string;
+}
+
+/** The single best installer to offer for a running host, or `null` when
+ * we can't confidently pick one (unknown OS, or macOS with an
+ * undetermined arch) — the caller then falls back to the Releases page
+ * rather than hand the user a binary that won't run.
+ *
+ * File names mirror the tauri-bundler output wired up in
+ * `.github/workflows/release.yml`, and the `v`-prefixed release tag
+ * matches the convention `updater.rs` deep-links to; keep all three in
+ * lockstep if the naming ever changes. macOS is the only OS with an arch
+ * split — Windows and Linux ship x64 only. */
+export function primaryInstaller(
+  os: Platform,
+  arch: Arch,
+  version: string,
+): Installer | null {
+  const v = bareVersion(version);
+  const asset = (label: string, fileName: string): Installer => ({
+    label,
+    fileName,
+    url: `${RELEASE_BASE}/v${v}/${fileName}`,
+  });
+
+  switch (os) {
+    case "macos":
+      if (arch === "aarch64") {
+        return asset("macOS (Apple Silicon)", `Entracte_${v}_aarch64.dmg`);
+      }
+      if (arch === "x64") {
+        return asset("macOS (Intel)", `Entracte_${v}_x64.dmg`);
+      }
+      return null;
+    case "windows":
+      return asset("Windows", `Entracte_${v}_x64-setup.exe`);
+    case "linux":
+      return asset("Linux (AppImage)", `Entracte_${v}_amd64.AppImage`);
+    default:
+      return null;
+  }
+}

--- a/src/lib/platform.test.ts
+++ b/src/lib/platform.test.ts
@@ -1,7 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { act, renderHook, waitFor } from "@testing-library/react";
 
-import { detectPlatform, normalisePlatform, PLATFORM_LABELS } from "./platform";
+import {
+  detectPlatform,
+  normaliseArch,
+  normalisePlatform,
+  PLATFORM_LABELS,
+} from "./platform";
 
 describe("detectPlatform", () => {
   it("identifies macOS", () => {
@@ -44,6 +49,31 @@ describe("normalisePlatform", () => {
   it("falls back to other for unknown values", () => {
     expect(normalisePlatform("freebsd")).toBe("other");
     expect(normalisePlatform("")).toBe("other");
+  });
+});
+
+describe("normaliseArch", () => {
+  it("maps Apple Silicon arch strings to aarch64", () => {
+    expect(normaliseArch("aarch64")).toBe("aarch64");
+    expect(normaliseArch("arm64")).toBe("aarch64");
+    expect(normaliseArch("arm")).toBe("aarch64");
+  });
+
+  it("maps Intel/AMD arch strings to x64", () => {
+    expect(normaliseArch("x86_64")).toBe("x64");
+    expect(normaliseArch("x64")).toBe("x64");
+    expect(normaliseArch("amd64")).toBe("x64");
+    expect(normaliseArch("x86")).toBe("x64");
+  });
+
+  it("is case-insensitive", () => {
+    expect(normaliseArch("AArch64")).toBe("aarch64");
+    expect(normaliseArch("X86_64")).toBe("x64");
+  });
+
+  it("falls back to other for unknown or empty values", () => {
+    expect(normaliseArch("riscv64")).toBe("other");
+    expect(normaliseArch("")).toBe("other");
   });
 });
 
@@ -154,6 +184,88 @@ describe("usePlatform", () => {
 
     expect(result.current).toBe("linux"); // UA guess first
     await waitFor(() => expect(result.current).toBe("other"));
+  });
+});
+
+// useArch mirrors usePlatform but has no UA fallback: it renders "other"
+// synchronously, then upgrades to the authoritative `get_arch` answer.
+// Module-level cache, so each test resets modules + the invoke mock.
+
+describe("useArch", () => {
+  const invokeMock = vi.fn();
+
+  beforeEach(() => {
+    vi.resetModules();
+    invokeMock.mockReset();
+    vi.doMock("@tauri-apps/api/core", () => ({
+      invoke: (cmd: string) => invokeMock(cmd),
+    }));
+  });
+
+  afterEach(() => {
+    vi.doUnmock("@tauri-apps/api/core");
+  });
+
+  it("returns 'other' synchronously, then upgrades to the Rust answer", async () => {
+    invokeMock.mockResolvedValueOnce("aarch64");
+
+    const { useArch } = await import("./platform");
+    const { result } = renderHook(() => useArch());
+
+    expect(result.current).toBe("other");
+    await waitFor(() => expect(result.current).toBe("aarch64"));
+    expect(invokeMock).toHaveBeenCalledWith("get_arch");
+  });
+
+  it("settles on 'other' when the Tauri invoke fails (plain browser)", async () => {
+    invokeMock.mockRejectedValueOnce(new Error("tauri unavailable"));
+
+    const { useArch } = await import("./platform");
+    const { result } = renderHook(() => useArch());
+
+    expect(result.current).toBe("other");
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(result.current).toBe("other");
+  });
+
+  it("normalises an unknown Rust arch into 'other'", async () => {
+    invokeMock.mockResolvedValueOnce("riscv64");
+
+    const { useArch } = await import("./platform");
+    const { result } = renderHook(() => useArch());
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(result.current).toBe("other");
+  });
+
+  it("invokes get_arch only once even when many components subscribe", async () => {
+    invokeMock.mockResolvedValueOnce("x86_64");
+    const { useArch } = await import("./platform");
+
+    renderHook(() => useArch());
+    renderHook(() => useArch());
+    renderHook(() => useArch());
+
+    await waitFor(() => {
+      expect(invokeMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("re-renders pick up the cached arch without re-invoking", async () => {
+    invokeMock.mockResolvedValueOnce("aarch64");
+    const { useArch } = await import("./platform");
+
+    const first = renderHook(() => useArch());
+    await waitFor(() => expect(first.result.current).toBe("aarch64"));
+    expect(invokeMock).toHaveBeenCalledTimes(1);
+
+    const second = renderHook(() => useArch());
+    expect(second.result.current).toBe("aarch64"); // synchronous, from cache
+    expect(invokeMock).toHaveBeenCalledTimes(1); // not invoked again
   });
 });
 

--- a/src/lib/platform.ts
+++ b/src/lib/platform.ts
@@ -86,6 +86,80 @@ export function usePlatform(): Platform {
   return platform;
 }
 
+/** Host CPU architectures the Download button distinguishes. Only the two
+ * the release pipeline actually builds (`aarch64`, `x64`) map to a real
+ * installer; `"other"` is the fallback bucket for any target the pipeline
+ * doesn't publish, so callers point at the Releases page rather than
+ * offer a binary that won't run. */
+export type Arch = "aarch64" | "x64" | "other";
+
+/** Map Rust's `std::env::consts::ARCH` — or a browser arch hint such as
+ * `navigator.userAgentData.getHighEntropyValues(["architecture"])` — to
+ * the renderer's `Arch` enum. Apple Silicon reports
+ * `"aarch64"`/`"arm64"`/`"arm"`; Intel/AMD desktops report
+ * `"x86_64"`/`"x64"`/`"amd64"`/`"x86"`. Anything else → `"other"`. */
+export function normaliseArch(raw: string): Arch {
+  const lower = raw.toLowerCase();
+  if (lower === "aarch64" || lower === "arm64" || lower === "arm") {
+    return "aarch64";
+  }
+  if (
+    lower === "x86_64" ||
+    lower === "x64" ||
+    lower === "amd64" ||
+    lower === "x86"
+  ) {
+    return "x64";
+  }
+  return "other";
+}
+
+// Same single-flight cache shape as the platform string above: exactly
+// one in-flight `get_arch` request, shared across every `useArch()`
+// consumer.
+let cachedArch: Arch | null = null;
+let pendingArch: Promise<Arch> | null = null;
+
+/** Resolve the authoritative architecture from the Rust `get_arch`
+ * command. Unlike the platform string there's no trustworthy UA fallback
+ * — WKWebView masks Apple Silicon as Intel — so when Tauri is
+ * unavailable (tests, a plain browser) this resolves to `"other"` and the
+ * caller degrades to the Releases page. */
+function getArch(): Promise<Arch> {
+  if (cachedArch) return Promise.resolve(cachedArch);
+  if (!pendingArch) {
+    pendingArch = invoke<string>("get_arch")
+      .then((raw) => {
+        const a = normaliseArch(raw);
+        cachedArch = a;
+        return a;
+      })
+      .catch(() => {
+        cachedArch = "other";
+        return "other" as Arch;
+      });
+  }
+  return pendingArch;
+}
+
+/** React hook: returns `"other"` synchronously (arch is unknowable until
+ * Rust answers), then upgrades to the authoritative `get_arch` result.
+ * Safe to call from any component. */
+export function useArch(): Arch {
+  const [arch, setArch] = useState<Arch>(() => cachedArch ?? "other");
+  useEffect(() => {
+    if (cachedArch) return;
+    let cancelled = false;
+    getArch().then((a) => {
+      if (!cancelled) setArch(a);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+  return arch;
+}
+
 /** Behavioural capability flags surfaced from the Rust
  * `get_platform_capabilities` command. Components branch on these rather
  * than on the raw {@link Platform} string, so a platform gaining a

--- a/src/views/settings/tabs/about-tab.test.tsx
+++ b/src/views/settings/tabs/about-tab.test.tsx
@@ -2,7 +2,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-import type { PlatformCapabilities } from "../../../lib/platform";
+import type {
+  Arch,
+  Platform,
+  PlatformCapabilities,
+} from "../../../lib/platform";
 import type { UseSupporter } from "../hooks/use-supporter";
 import type { UseUpdateCheck } from "../hooks/use-update-check";
 import type { UpdateInfo, SupporterStatus, SchedulerSettings } from "../types";
@@ -35,6 +39,11 @@ let currentCaps: PlatformCapabilities = {
   installerUnsignedWarning: false,
   videoPauseReliable: true,
 };
+// Default to an undetectable host (both "other") so `primaryInstaller`
+// returns null and the update banner keeps its plain "Open release page"
+// button — the download-specific tests opt into a concrete OS/arch.
+let currentPlatform: Platform = "other";
+let currentArch: Arch = "other";
 vi.mock("../../../lib/platform", async () => {
   const actual = await vi.importActual<typeof import("../../../lib/platform")>(
     "../../../lib/platform",
@@ -42,6 +51,8 @@ vi.mock("../../../lib/platform", async () => {
   return {
     ...actual,
     usePlatformCapabilities: () => currentCaps,
+    usePlatform: () => currentPlatform,
+    useArch: () => currentArch,
   };
 });
 
@@ -91,6 +102,8 @@ afterEach(() => {
     installerUnsignedWarning: false,
     videoPauseReliable: true,
   };
+  currentPlatform = "other";
+  currentArch = "other";
   mockUpdate = {
     info: null,
     checking: false,
@@ -163,6 +176,46 @@ describe("AboutTab — update banner", () => {
     const btn = screen.getByRole("button", { name: /open release page/i });
     await user.click(btn);
     expect(openUrlMock).toHaveBeenCalledWith(updateAvailable.release_url);
+  });
+
+  it("offers a direct download for the detected OS/arch and opens the matching installer", async () => {
+    const user = userEvent.setup();
+    currentPlatform = "macos";
+    currentArch = "aarch64";
+    mockUpdate = { ...mockUpdate, info: updateAvailable };
+    render(
+      <AboutTab
+        supporter={supporterStub()}
+        settings={null}
+        updateSetting={vi.fn()}
+      />,
+    );
+    const download = screen.getByRole("button", {
+      name: /download for macOS \(Apple Silicon\)/i,
+    });
+    await user.click(download);
+    expect(openUrlMock).toHaveBeenCalledWith(
+      "https://github.com/drmowinckels/entracte/releases/download/v0.0.2/Entracte_0.0.2_aarch64.dmg",
+    );
+    // The release-page link demotes to an "All downloads" secondary action.
+    expect(screen.getByRole("button", { name: /all downloads/i })).toBeTruthy();
+  });
+
+  it("falls back to a plain 'Open release page' button when the arch is undetermined", () => {
+    currentPlatform = "macos";
+    currentArch = "other";
+    mockUpdate = { ...mockUpdate, info: updateAvailable };
+    render(
+      <AboutTab
+        supporter={supporterStub()}
+        settings={null}
+        updateSetting={vi.fn()}
+      />,
+    );
+    expect(screen.queryByRole("button", { name: /download for/i })).toBeNull();
+    expect(
+      screen.getByRole("button", { name: /open release page/i }),
+    ).toBeTruthy();
   });
 
   it("suppresses the update banner when release_url is null even if has_update is true", () => {

--- a/src/views/settings/tabs/about-tab.tsx
+++ b/src/views/settings/tabs/about-tab.tsx
@@ -6,7 +6,12 @@ import { useUpdateCheck } from "../hooks/use-update-check";
 import type { UseSupporter } from "../hooks/use-supporter";
 import type { UseSettings } from "../hooks/use-settings";
 import type { SchedulerSettings } from "../types";
-import { usePlatformCapabilities } from "../../../lib/platform";
+import {
+  useArch,
+  usePlatform,
+  usePlatformCapabilities,
+} from "../../../lib/platform";
+import { primaryInstaller } from "../../../lib/download";
 import { writeToClipboard } from "../utils";
 
 const TOAST_MS = 3000;
@@ -27,6 +32,13 @@ export function AboutTab({
   const [licenseInput, setLicenseInput] = useState("");
   const update = useUpdateCheck();
   const caps = usePlatformCapabilities();
+  const platform = usePlatform();
+  const arch = useArch();
+
+  const downloadInstaller =
+    update.info && update.info.has_update
+      ? primaryInstaller(platform, arch, update.info.latest)
+      : null;
 
   const onVerify = async () => {
     const trimmed = licenseInput.trim();
@@ -94,14 +106,21 @@ export function AboutTab({
           <>
             <p className="about-meta">
               Update available: <strong>{update.info.latest}</strong> (you have{" "}
-              {update.info.current}).{" "}
+              {update.info.current}).
+            </p>
+            <div className="actions inline">
+              {downloadInstaller && (
+                <button onClick={() => openUrl(downloadInstaller.url)}>
+                  Download for {downloadInstaller.label}
+                </button>
+              )}
               <button
-                className="link"
+                className={downloadInstaller ? "secondary" : undefined}
                 onClick={() => openUrl(update.info!.release_url!)}
               >
-                Open release page
+                {downloadInstaller ? "All downloads" : "Open release page"}
               </button>
-            </p>
+            </div>
             {caps.installerUnsignedWarning && (
               <p className="about-meta">
                 The Windows installer isn't Authenticode-signed yet, so


### PR DESCRIPTION
## Summary

Adds a one-click, system-detecting download path so users don't have to hand-pick an artefact off the Releases page — on **both** the website and inside Entracte.

**Website** ([`SmartDownload.vue`](docs/.vitepress/theme/components/SmartDownload.vue)): fetches the latest release from the GitHub API (version-agnostic, matches assets by pattern), detects the visitor's OS, and detects Mac arch via UA-CH where the browser exposes it — on Safari/Firefox it offers **both** Apple Silicon and Intel. Primary "Download for X" button(s) + inline alternates + an **All platforms & formats** disclosure. Degrades to the Releases page on any API failure. Embedded on the home and install pages.

**In-app** ([`about-tab.tsx`](src/views/settings/tabs/about-tab.tsx)): when an update is available, a primary **"Download for macOS (Apple Silicon)"**-style button opens the exact installer for the running platform/arch via `openUrl`; the old release-page link demotes to **All downloads**. A new `get_arch` Rust command gives the authoritative architecture (WKWebView masks Apple Silicon), consumed via a `useArch` hook + pure [`primaryInstaller`](src/lib/download.ts) builder.

**Docs corrections:** retires the stale *"no tagged binaries yet"* home warning, fixes the install guide's now-false pre-release note (releases publish `prerelease: false`), and corrects the Linux asset-name casing.

## Design notes

- **macOS arch is undetectable in Safari/Firefox** (arch is masked) and in the in-app WKWebView — so the web path shows both builds when unknown, and the app path uses Rust's `std::env::consts::ARCH` (authoritative for the running binary).
- **Two strategies, one naming convention:** the web *matches* live API assets (resilient to renames); the app *constructs* the URL from version+os+arch (avoids an extra network call, keeping the local-only stance). Both cross-reference `.github/workflows/release.yml`.
- **Security (defence in depth):** only URLs beginning with the GitHub release-download prefix are rendered into `href`s, so a spoofed/compromised API response can't smuggle a `javascript:`/off-host link. Covered by a regression test.

## Test plan

- **New unit tests:** `download.ts` (7), `platform.ts` `normaliseArch`/`useArch` (10), About-tab download button (2), `get_arch` Rust test, and `download-detect.ts` web matcher (15, wired into the docs CI build).
- **Gates run locally, all green:** eslint, prettier `--check`, stylelint, `tsc`, **840** frontend tests + coverage (new lines fully covered), a11y audit, size-limit; `cargo fmt`/`clippy -D warnings`/**1197** Rust tests/`cargo doc`; knip, cspell, VitePress build.
- Pre-merge review trio (critical-code-reviewer → security-review → simplify) run; the one Required finding (untested web matcher) was fixed by extracting + testing the pure logic.

## Note

The JS entry bundle sits at **118.3 KB against the 120 KB gzip limit** — pre-existing tightness this change didn't meaningfully move, worth a code-split follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)