### PR TITLE
perf(build): code-split vendor chunks to decouple entry bundle from size-limit ceiling

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,19 @@
     {
       "name": "JS bundle (entry chunk)",
       "path": "dist/assets/index-*.js",
-      "limit": "120 KB",
+      "limit": "70 KB",
+      "gzip": true
+    },
+    {
+      "name": "vendor: react + react-dom",
+      "path": "dist/assets/react-vendor-*.js",
+      "limit": "65 KB",
+      "gzip": true
+    },
+    {
+      "name": "vendor: zod",
+      "path": "dist/assets/zod-vendor-*.js",
+      "limit": "20 KB",
       "gzip": true
     },
     {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,6 +8,27 @@ const host = process.env.TAURI_DEV_HOST;
 export default defineConfig(async () => ({
   plugins: [react()],
 
+  // size-limit gates only the entry chunk, so vendor code is split into
+  // sibling chunks to keep the entry budget decoupled from app growth.
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          if (
+            id.includes("node_modules/react-dom") ||
+            id.includes("node_modules/react/") ||
+            id.includes("node_modules/scheduler")
+          ) {
+            return "react-vendor";
+          }
+          if (id.includes("node_modules/zod")) {
+            return "zod-vendor";
+          }
+        },
+      },
+    },
+  },
+
   // Vite options tailored for Tauri development and only applied in `tauri dev` or `tauri build`
   //
   // 1. prevent Vite from obscuring rust errors


### PR DESCRIPTION
## Summary

The JS **entry chunk** was at **118.33 / 120 KB gzip** against the `audit:size` gate ([package.json](../blob/main/package.json) `size-limit`) — ~1.7 KB headroom. Because everything bundled into one chunk, the gate was coupled to *app* growth: an unrelated feature PR could trip it on a size regression that had nothing to do with its change.

`size-limit` measures **only the entry chunk**, so this splits the static vendor code into sibling chunks via `build.rollupOptions.output.manualChunks`:

| Chunk | gzip | budget |
|---|---|---|
| `index-*.js` (entry, gated) | **42.22 KB** ← was 118.33 | 70 KB |
| `react-vendor-*.js` (react + react-dom + scheduler) | 58.83 KB | 65 KB |
| `zod-vendor-*.js` | 17.23 KB | 20 KB |

For a Tauri app all chunks load from local disk (no network round-trips), so parallel chunk loading has **no runtime cost**; Vite injects `modulepreload` automatically. The entry budget is now decoupled from app growth, and the vendor chunks get their own `size-limit` budgets so vendor bloat stays monitored rather than becoming an unwatched blind spot.

React and react-dom are kept in one chunk on purpose: Rolldown (Vite 8) co-locates react core with react-dom anyway, so a separate react chunk was a pointless 300 B — one React-runtime chunk is simpler and avoids a too-tight per-chunk limit.

## Test plan

Ran the full CI gate suite locally, all green:

- `npm run audit:size` — every budget passes (entry 42.22/70, react 58.83/65, zod 17.23/20, CSS 6.88/8)
- `npm run test` — **840 passed** (79 files)
- `npx tsc --noEmit`, `npm run format:check`, `npm run lint:css` — clean
- `npm run audit:knip` (exit 0), `npm run audit:spell` (0 issues)
- `npm run build` + the a11y audit exercises the multi-chunk build headless across every tab × light/dark, so the split is functionally smoke-tested by CI

`vite.config.ts` is build config with no mockable surface (eslint-ignored `*.config.{js,ts}`); the `audit:size` budgets serve as the regression test for the split.

Closes #297

🤖 Generated with [Claude Code](https://claude.com/claude-code)