### PR TITLE
chore(build): give react-vendor size-limit budget headroom parity

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     {
       "name": "vendor: react + react-dom",
       "path": "dist/assets/react-vendor-*.js",
-      "limit": "65 KB",
+      "limit": "70 KB",
       "gzip": true
     },
     {


### PR DESCRIPTION
## Summary

Follow-up to #298. The `react-vendor` `size-limit` budget was the tight one: **58.83 KB actual against a 65 KB limit (~10% headroom)**, while the entry chunk carries ~40% and zod ~16%. A React 19.x patch bump could trip it prematurely — noise rather than signal.

Bumps the limit to **70 KB** so a tripped budget means a real regression, not normal patch drift. No code change; `manualChunks` and the actual bundle are untouched.

## Test plan

- `npm run audit:size` — `vendor: react + react-dom` passes at 58.83 / 70 KB; all other budgets unchanged and passing.

Config-only change to the `size-limit` array; `audit:size` is the only affected gate.