### PR TITLE
chore(deps): nightly security audit 2026-08-01

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1262,9 +1262,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1343,9 +1343,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3922,16 +3922,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -5110,9 +5110,9 @@
       "license": "MIT"
     },
     "node_modules/eslint-plugin-jsx-a11y/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5198,9 +5198,9 @@
       "license": "MIT"
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Nightly security audit — 2026-08-01

Automated dependency audit. This PR carries **lockfile-only** changes and addresses the one SAFE (patch-level) advisory found tonight.

### Node — resolved (SAFE)
| Advisory | Package | Change | Tier |
|----------|---------|--------|------|
| [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg) | `brace-expansion` | `1.1.16 → 1.1.18` (×4, ESLint dev toolchain) and `5.0.7 → 5.0.9` (top-level dev tree) | patch |

`brace-expansion` is a **dev-only** transitive dependency (pulled in via `eslint`, `@eslint/config-array`, `@eslint/eslintrc`, `eslint-plugin-jsx-a11y`). Both bumps are patch-level and resolve the DoS advisory. `npm audit` reports **0 vulnerabilities** after the change.

Only `package-lock.json` is touched — no `package.json`, source, workflow, or config changes.

### Rust — not actionable tonight (left for manual review, no issue per policy)
- `wasmtime 43.0.2` — [RUSTSEC-2026-0222](https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-hgjw-h833-99q9) (stores can mix up type indices between engines). Patched only at `>=46.0.2` / `>=47.0.3`, i.e. a **major** bump (43→46/47) with no in-major patch → classified MANUAL. Severity is **LOW** (`CVSS AV:L/AC:H/PR:H/UI:R/S:U/C:L/I:L/A:L`), below the HIGH threshold that would warrant an issue, so no issue was opened and no automatic major bump was applied.
- Remaining `cargo audit` output is `unmaintained`/`unsound` informational warnings (gtk-rs GTK3 bindings, `mach`, `proc-macro-error`, `unic-*`, `event-listener`, `glib`) with no patched releases available → no action.

### Local verification
- `npm run build` (tsc && vite build) ✅
- `cargo build` ✅
- `cargo test --no-run` ✅
- `npm audit` → 0 vulnerabilities ✅

### Auto-merge
No prior `chore/sec-audit-*` PR was open, so nothing was superseded. This PR **auto-merges (squash)** only if CI is fully green **and** the adversarial merge review passes 5/5. On any red check, rejection, or uncertainty it is left open for a human.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HVcr1YMYuwRUfc4FEDXZ61)_