### PR TITLE
chore(deps): nightly security audit 2026-08-04

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5415,9 +5415,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Nightly security audit — 2026-08-04

Automated dependency audit (`cargo audit` + `npm audit`). This PR ships only the SAFE, non-breaking fix found tonight.

### Advisory resolved
| Advisory | Package | Change | Severity | Type |
|----------|---------|--------|----------|------|
| [GHSA-7p8r-x3mc-p8w7](https://github.com/advisories/GHSA-7p8r-x3mc-p8w7) (CVE-2026-18446) | `fast-uri` | 3.1.4 → **3.1.5** | High | Node, transitive (eslint › table › ajv, `^3.0.1`) |

**fast-uri**: host confusion via backslash authority introducer — the library failed to treat `\\`, `/\`, `\/` as authority introducers, parsing URLs differently from Node's WHATWG parser. Fixed in 3.1.5 (patch bump, satisfies the existing `^3.0.1` range; package is dependency-free).

### Changes
- `package-lock.json` only — `fast-uri` version, resolved URL, and integrity hash. No `package.json` change (transitive, updated in place via `npm update fast-uri`).

### Verification
- `npm audit` → **0 vulnerabilities** on this head
- `npm run build` (tsc && vite build) ✓
- `cargo build` ✓
- `cargo test --no-run` ✓

### Not shipped (left for humans)
- **RUSTSEC-2026-0222** (`wasmtime` 43.0.2, transitive via tauri): patched only in ≥46/≥47 — a **major** bump, not auto-applied. Severity low (CVSS AV:L/AC:H/PR:H); no issue opened.
- Unmaintained/unsound advisories on gtk-rs bindings, `mach`, `unic-*`, `glib` — informational warnings with no fixed release available.

---
Supersedes any prior open `chore/sec-audit-*` PR (none were open tonight). Will **auto-merge** only if CI is fully green **and** the adversarial merge review passes 5/5; otherwise it stays open for a human.

---
_Generated by [Claude Code](https://claude.ai/code/session_011U63VFhSHgqK2qvjxTWR7p)_