### PR TITLE
chore(release): 0.0.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Versions on the `0.0.X` line are public beta releases; `0.1.X` and onwards will 
 
 ## [Unreleased]
 
+## [0.0.11] — 2026-08-04
+
 ### Fixed
 
 - **A break no longer starts media you'd paused (Windows).** To pause your music or video for a break, Entracte taps the system Play/Pause key — a blind toggle, so it only taps when it believes something is playing. On Windows it judged that from whether anything was keeping the display awake, which a paused video tab or a call app can do on its own — so if you'd paused your media before a break, Entracte could **start** it, play it through the break, then pause it again at the end. It now checks whether audio is actually coming out of your speakers right now (the same real-output approach the macOS fix uses), so paused media stays paused. ([#234](https://github.com/drmowinckels/entracte/issues/234))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "entracte-desktop",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "entracte-desktop",
-      "version": "0.0.10",
+      "version": "0.0.11",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-autostart": "^2.5.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "entracte-desktop",
   "private": true,
-  "version": "0.0.10",
+  "version": "0.0.11",
   "type": "module",
   "engines": {
     "node": "^20.19.0 || >=22.12.0"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1581,7 +1581,7 @@ checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
 
 [[package]]
 name = "entracte"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "base64 0.22.1",
  "block2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "entracte"
-version = "0.0.10"
+version = "0.0.11"
 description = "Cross-platform break reminder"
 authors = ["Athanasia Mowinckel"]
 license = "Apache-2.0"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Entracte",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "identifier": "io.drmowinckels.entracte",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary

Version bump for the 0.0.11 release, cutting everything merged since [v0.0.10](https://github.com/drmowinckels/entracte/releases/tag/v0.0.10).

Bumps `0.0.10` → `0.0.11` across the six files the 0.0.10 release touched, keeping the three version sources in lockstep (`package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`) plus both lockfiles, and promotes `[Unreleased]` to `## [0.0.11] — 2026-08-04`.

### Shipping in this release

**Fixed**

- A break no longer starts media you'd paused (Windows) — gates on real audio output rather than a display-wake request ([#234](https://github.com/drmowinckels/entracte/issues/234), PR #289)
- A leftover build no longer hijacks "launch at login" from the installed app (macOS) (PR #295)

**Added**

- **Take a long break now** — menu-bar menu and Breaks tab, restarting the rotation from that moment ([#258](https://github.com/drmowinckels/entracte/issues/258))

Also merged since 0.0.10, but not user-facing: CI action bumps #300, #290, #291.

## Test Plan

Run locally on the release branch:

- `cargo test` — 1199 passed, 0 failed
- `npm run test` — 840 passed across 79 files
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo fmt --check` and `npm run format:check` — clean
- Version lockstep verified across all five version strings (three sources + two lockfiles)

No behaviour changes in this PR, so no new tests accompany it — the shipped behaviour was tested in #289 and #295.

## After merge

Tag and push `v0.0.11` to trigger the release build; the result lands as a **draft** for review before publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)