### PR TITLE
fix(lint): ignore the root target/ tree in eslint

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -14,6 +14,7 @@ export default tseslint.config(
       "coverage",
       "node_modules",
       "src-tauri",
+      "target",
       "docs",
       "scripts",
       "*.config.{js,ts}",


### PR DESCRIPTION
## Summary

`npm run lint` fails with 361 errors for any contributor who has built the docs locally. [`eslint.config.js`](https://github.com/drmowinckels/entracte/blob/main/eslint.config.js) ignores `dist`, `coverage`, `node_modules`, `src-tauri`, `docs`, and `scripts` — but not the root `target/` tree.

`npm run doc` writes typedoc output to `target/typedoc` (both `docs.yml` and `docs-preview.yml` then `cp -r target/typedoc/.` into the VitePress dist). That tree is gitignored, so it never shows up in review, but `eslint .` walks it and lints the generated browser bundles:

```
target/typedoc/assets/icons.js
   4:13  error  'document' is not defined  no-undef
   8:13  error  'location' is not defined  no-undef
...
✖ 362 problems (361 errors, 1 warning)
```

CI stays green because the `frontend` job runs `npm run lint` without ever running `doc`, so `target/` doesn't exist on a fresh runner. The breakage is local-only, which is why it went unnoticed.

Adding `"target"` to the ignores list matches the existing intent stated in the comment right above it — *"Build output, vendored configs, and the Rust/docs trees are out of scope — the frontend lint surface is `src/`."*

## Test Plan

Verified with `target/typedoc` present locally (the reproducing condition):

- Before: `✖ 362 problems (361 errors, 1 warning)`
- After: `✖ 1 problem (0 errors, 1 warning)`

The remaining warning is pre-existing on `main` (`react-hooks/exhaustive-deps` in `src/lib/use-local-draft.ts`) and confirms `src/` is still being linted — the ignore narrows nothing in the real lint surface.

No tests accompany this: it changes a lint-tool ignore list, not runtime code, and a test asserting the entry exists would only restate the config. The behavioural check is `npm run lint` itself, which CI already runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)