### PR TITLE
fix(windows): stop a console window flashing on every probe tick (#303)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Versions on the `0.0.X` line are public beta releases; `0.1.X` and onwards will 
 
 ## [Unreleased]
 
+### Fixed
+
+- **No more command-prompt window flashing every few seconds (Windows).** Entracte checks a few times a minute whether something is holding the display awake, and that check runs a small built-in Windows tool. Windows gives such a tool its own console window even when nothing is meant to be shown — so a black `cmd` window blinked on screen roughly every ten seconds for as long as Entracte was running, stealing focus for a moment each time. The window is now suppressed, so the check runs invisibly as intended. This applied whether or not you had video detection switched on, and the same suppression now covers hook commands, which could flash a window each time a break started. ([#303](https://github.com/drmowinckels/entracte/issues/303))
+
 ## [0.0.11] — 2026-08-04
 
 ### Fixed

--- a/src-tauri/src/hooks.rs
+++ b/src-tauri/src/hooks.rs
@@ -237,6 +237,10 @@ fn spawn_hook_with_timeout(command: &str, env: &[(String, String)], timeout: Dur
     cmd.stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::null());
+    // Same reason the stdio above is nulled: a hook is background automation,
+    // not something the user is watching. On Windows a console-subsystem hook
+    // would otherwise flash its own window on every break (#303).
+    crate::proc::suppress_console(&mut cmd);
     for (k, v) in env {
         cmd.env(k, v);
     }

--- a/src-tauri/src/proc.rs
+++ b/src-tauri/src/proc.rs
@@ -88,6 +88,30 @@ fn read_capped(mut reader: impl Read, cap: Option<usize>) -> Vec<u8> {
 /// Scratch buffer size for the draining read loop.
 const READ_CHUNK: usize = 8 * 1024;
 
+/// Stop Windows from allocating a console window for a console-subsystem
+/// child.
+///
+/// Redirecting stdio is not enough: `powercfg.exe` and `cmd.exe` are console
+/// subsystem binaries, so Windows gives each spawn its own console, which
+/// flashes on screen and steals focus for a few frames. Entracte's detection
+/// probes run on a 10 s loop, so that surfaced as a `cmd` window blinking
+/// every ten seconds for the whole session (#303).
+///
+/// `CREATE_NO_WINDOW` suppresses the console while leaving the child attached
+/// to the pipes we hand it — unlike `DETACHED_PROCESS`, which would also
+/// suppress the window but break output capture. Non-Windows targets have no
+/// console to suppress, so this is a no-op there and callers stay
+/// platform-agnostic.
+pub fn suppress_console(cmd: &mut Command) -> &mut Command {
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+        cmd.creation_flags(CREATE_NO_WINDOW);
+    }
+    cmd
+}
+
 /// Spawn `cmd`, capture its output bounded by the wait `timeout` and an
 /// optional per-stream byte `cap`, killing and reaping the child on overrun.
 fn spawn_and_capture(
@@ -98,6 +122,7 @@ fn spawn_and_capture(
     cmd.stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
+    suppress_console(cmd);
     let mut child = cmd.spawn()?;
 
     let child_stdout = child.stdout.take().expect("stdout piped above");
@@ -274,6 +299,35 @@ mod tests {
             cmd.args(["/C", "ping", "-n", "6", "127.0.0.1"]);
             cmd
         }
+    }
+
+    #[test]
+    fn suppress_console_keeps_output_capture_working() {
+        // The probe path applies `suppress_console` before spawning, so the
+        // flag must hide the console *without* detaching the child from our
+        // pipes. `DETACHED_PROCESS` would also hide the window but silently
+        // break capture, so asserting stdout still arrives is what
+        // distinguishes the correct flag from the plausible wrong one.
+        let mut cmd = echo_hello();
+        suppress_console(&mut cmd);
+        let out = cmd.output_timeout(Duration::from_secs(5)).unwrap();
+        assert!(out.status.success());
+        assert!(
+            String::from_utf8_lossy(&out.stdout).contains("hello"),
+            "stdout was {:?}",
+            out.stdout
+        );
+    }
+
+    #[test]
+    fn suppress_console_returns_the_same_command_for_chaining() {
+        let mut cmd = echo_hello();
+        let ptr = &raw const cmd;
+        let returned = suppress_console(&mut cmd);
+        assert_eq!(
+            ptr, &raw const *returned,
+            "suppress_console must borrow through, not replace the command"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #303 — a `cmd` window flashing every ~10s on Windows for the whole session.

### Root cause

Three facts line up exactly with the report:

1. [`video.rs`](https://github.com/drmowinckels/entracte/blob/main/src-tauri/src/video.rs) polls on a `POLL_INTERVAL` of **10 s** — the reporter's "every ~10s".
2. The Windows leg of that poll shells out to `powercfg.exe /requests`.
3. `video::spawn_monitor` is called **unconditionally** from `scheduler/mod.rs`, so the poll runs even with `pause_during_video: false` — which is exactly what the reporter's diagnostics show.

`powercfg.exe` is a console-subsystem binary, so Windows allocates a console for every spawn. Redirecting stdio does not prevent that — the window still appears and takes focus for a few frames. There was no `creation_flags` call anywhere in the tree.

### Fix

A single `proc::suppress_console` helper applying `CREATE_NO_WINDOW`, called from:

- **`spawn_and_capture`** — covers every OS probe and the hook Test button in one place, matching that module's stated role as the funnel for OS-integration probes.
- **The fire-and-forget hook spawn** in `hooks.rs`, which spawns directly and bypasses that helper. It nulls its stdio for the same "background automation, not something the user watches" reason, so a console-subsystem hook flashing a window on every break is the same defect. Called out separately since it's beyond the literal report — easy to drop if you'd rather keep this to the probe path.

`CREATE_NO_WINDOW` rather than the `conhost --headless` workaround suggested on the issue: it's the documented flag for this, needs no wrapper process, and applies uniformly. Notably **not** `DETACHED_PROCESS`, which also hides the window but severs the pipes we capture through.

On non-Windows targets the helper is a no-op, so callers stay platform-agnostic and nothing changes for macOS/Linux.

### Audit

Every `spawn`/`output`/`output_timeout` site was checked against its platform gate. The only Windows-reachable ones are the `powercfg` probe and the two hook paths — all three now covered. The rest (`pmset`, `xprop`, `gsettings`, `gdbus`, `systemd-inhibit`, `loginctl`, macOS `log`) are macOS/Linux-gated.

## Test Plan

Two new tests in `proc::tests`, run on all three platforms in CI:

- `suppress_console_keeps_output_capture_working` — the load-bearing one. It asserts stdout still arrives after suppression, which is what distinguishes `CREATE_NO_WINDOW` from `DETACHED_PROCESS`; the wrong flag would hide the window just as well and silently break every probe. On the `rust (windows-latest)` job this exercises the real flag.
- `suppress_console_returns_the_same_command_for_chaining` — guards the borrow-through contract.

Local: `cargo test` 1201 passed (up from 1199), 0 failed; `cargo clippy --all-targets -- -D warnings` clean; `cargo fmt --check` and prettier clean.

The visible symptom itself — no window appearing — isn't assertable in a headless test; the Windows CI job verifies the flag doesn't break capture, which is the part that could regress silently.

## Note on release timing

`main` is already tagged `v0.0.11` with a built draft release. This entry sits under `[Unreleased]`, so it ships in 0.0.12 unless you'd rather re-cut 0.0.11 to include it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)