### PR TITLE
Bump cask to 0.0.11

### DIFF
--- a/Casks/entracte.rb
+++ b/Casks/entracte.rb
@@ -1,9 +1,9 @@
 cask "entracte" do
   arch arm: "aarch64", intel: "x64"
 
-  version "0.0.10"
-  sha256 arm:   "4e6726a1f184152580ef78d709516a551bfce2268470f33d972719a14188548f",
-         intel: "858799d82261565028f8556005398520921f42a4405fb2fbfa839acd5051c948"
+  version "0.0.11"
+  sha256 arm:   "af2a34fce45b20579b0d5f4b9693573bf93d2de27eee0fbabbd3e9af7b56fdaf",
+         intel: "4b987b2d01de8a56dd76be313f2f284fda04af8c5617d3c735ad3258dc264349"
 
   url "https://github.com/drmowinckels/entracte/releases/download/v#{version}/Entracte_#{version}_#{arch}.dmg",
       verified: "github.com/drmowinckels/entracte/"


### PR DESCRIPTION
## Summary

Bumps the Homebrew cask to 0.0.11. Opened by hand because `bump-cask.yml` could not open it itself — see below.

```
version "0.0.10" → "0.0.11"
sha256 arm:   4e6726a1… → af2a34fc…
       intel: 858799d8… → 4b987b2d…
```

### Checksums verified

Both DMGs were downloaded from the published release and hashed independently, rather than trusting the workflow's values:

| Asset | SHA256 |
| --- | --- |
| `Entracte_0.0.11_aarch64.dmg` | `af2a34fce45b20579b0d5f4b9693573bf93d2de27eee0fbabbd3e9af7b56fdaf` |
| `Entracte_0.0.11_x64.dmg` | `4b987b2d01de8a56dd76be313f2f284fda04af8c5617d3c735ad3258dc264349` |

Both match the cask exactly.

### Why this was opened manually

The `bump-cask` run for `v0.0.11` ([run 30934186212](https://github.com/drmowinckels/entracte/actions/runs/30934186212)) pushed the branch and commit successfully, then failed on the final step:

```
pull request create failed: GraphQL: GitHub Actions is not permitted to
create or approve pull requests (createPullRequest)
```

This is the same failure as `v0.0.9` and `v0.0.10` — hence the orphaned `bump-cask/0.0.9` and `bump-cask/0.0.10` branches and the cask sitting at an old version. The fix is **Settings → Actions → General → "Allow GitHub Actions to create and approve pull requests"**; until that's enabled, every release will need this manual step.

### Rebased before opening

The workflow branches from the release tag, so `bump-cask/0.0.11` was cut from `88dae43` — before #306 and #307 merged. Against current `main` it therefore showed as *reverting* the eslint `target/` ignore and the whole `suppress_console` Windows fix. I rebased onto `main` first, so this PR now touches only `Casks/entracte.rb`.

Worth noting the same trap applies to any future manual bump-cask PR, and it gets worse the longer the gap between tagging and merging.

## Test Plan

- Both DMG checksums independently verified against the published release assets (table above)
- Diff confined to `Casks/entracte.rb`: `1 file changed, 3 insertions(+), 3 deletions(-)`
- `url` template resolves via `#{version}`/`#{arch}`, so no URL edit is needed
- After merge: `brew upgrade --cask entracte` should pick up 0.0.11

🤖 Generated with [Claude Code](https://claude.com/claude-code)