### PR TITLE
chore(release): 0.0.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Versions on the `0.0.X` line are public beta releases; `0.1.X` and onwards will 
 
 ## [Unreleased]
 
+## [0.0.12] — 2026-08-04
+
 ### Fixed
 
 - **No more command-prompt window flashing every few seconds (Windows).** Entracte checks a few times a minute whether something is holding the display awake, and that check runs a small built-in Windows tool. Windows gives such a tool its own console window even when nothing is meant to be shown — so a black `cmd` window blinked on screen roughly every ten seconds for as long as Entracte was running, stealing focus for a moment each time. The window is now suppressed, so the check runs invisibly as intended. This applied whether or not you had video detection switched on, and the same suppression now covers hook commands, which could flash a window each time a break started. ([#303](https://github.com/drmowinckels/entracte/issues/303))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "entracte-desktop",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "entracte-desktop",
-      "version": "0.0.11",
+      "version": "0.0.12",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-autostart": "^2.5.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "entracte-desktop",
   "private": true,
-  "version": "0.0.11",
+  "version": "0.0.12",
   "type": "module",
   "engines": {
     "node": "^20.19.0 || >=22.12.0"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1581,7 +1581,7 @@ checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
 
 [[package]]
 name = "entracte"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "base64 0.22.1",
  "block2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "entracte"
-version = "0.0.11"
+version = "0.0.12"
 description = "Cross-platform break reminder"
 authors = ["Athanasia Mowinckel"]
 license = "Apache-2.0"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Entracte",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "identifier": "io.drmowinckels.entracte",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary

Version bump for 0.0.12, shipping the Windows console-flash fix from #307.

Bumps `0.0.11` → `0.0.12` across the same six files as previous releases, keeping the three version sources in lockstep (`package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`) plus both lockfiles, and promotes `[Unreleased]` to `## [0.0.12] — 2026-08-04`.

### Shipping in this release

**Fixed**

- No more command-prompt window flashing every few seconds on Windows ([#303](https://github.com/drmowinckels/entracte/issues/303), PR #307)

Also merged since 0.0.11 but not user-facing: #306 (eslint ignores the root `target/` tree).

### Why a second release the same day

0.0.11 was already **published** and serving users by the time #303 was fixed — `releases/latest` resolved to it, every bundle had downloads, and `latest.json` had been fetched 9 times by update clients. Re-cutting the tag would have yanked artifacts people already had and invalidated a manifest clients had seen, so the fix ships forward as 0.0.12 instead.

## Test Plan

Run locally on the release branch:

- `cargo test` — 1201 passed, 0 failed
- `npm run test` — 840 passed across 79 files
- `npm run lint` — 0 errors (1 pre-existing warning), now clean with `target/typedoc` present thanks to #306
- `cargo fmt --check`, `npm run format:check`, prettier on CHANGELOG — all clean
- Version lockstep verified across all five version strings

No behaviour changes in this PR, so no new tests accompany it — the shipped fix was tested in #307, including on `rust (windows-latest)`.

## After merge

Tag and push `v0.0.12`; the result lands as a draft for review before publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)