### PR TITLE
chore(deps): nightly security audit 2026-08-07

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6657,9 +6657,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Nightly security audit — 2026-08-07

Automated dependency audit (`npm audit` + `cargo audit`). One SAFE Node upgrade applied.

### Applied (Node)

| Advisory | Package | Change | Severity |
| --- | --- | --- | --- |
| [GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj) (CVE-2026-59870) | `js-yaml` | `4.3.0` → `4.3.1` | High (CVSS 7.5) |

- **Nature:** quadratic (O(n²)) CPU consumption in `!!omap` resolution — a DoS on untrusted YAML. Fixed upstream by replacing the linear `indexOf` scan with a `Set` (O(n)). Pure security patch, no API change.
- **Scope:** transitive **dev** dependency via `@eslint/eslintrc` (`^4.1.1`) and `cosmiconfig` (`^4.1.0`); `4.3.1` is in-range for both, so this is a lockfile-only bump (`package-lock.json`). `package.json` is untouched.
- Post-bump `npm audit` reports **0 vulnerabilities**.

### Not actioned — MANUAL (recorded, no change)

Both Rust findings require **major-version bumps gated on upstream**, so they are out of scope for an automated safe upgrade and are **not** high enough to warrant a tracking issue:

| Advisory | Package | Why skipped |
| --- | --- | --- |
| [RUSTSEC-2026-0222](https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-hgjw-h833-99q9) | `wasmtime` 43.0.2 (via `extism`) | Fix needs 43 → 46/47 (major). CVSS `AV:L/AC:H/PR:H/UI:R` = **Low (~3.7)**. |
| RUSTSEC-2026-0235 | `rkyv` 0.7.46 | Fix needs 0.7 → 0.8 (major), driven by `rust_decimal`. **No CVSS assigned**; present only as an *unactivated optional feature* (not compiled into the build). |

Pre-existing unmaintained/unsound warnings (glib `RUSTSEC-2024-0429` etc.) are already tracked in #84.

### Supersession

No prior open `chore/sec-audit-*` PR existed, so nothing was superseded. This is the only open audit PR.

### Auto-merge

Per the nightly routine, this PR **auto-merges only after** CI is fully green **and** an adversarial 5/5 merge review clears it with no doubt. On any red check, any rejection, timeout, or uncertainty, it is left **open for a human** instead.

---

### Verification run
- `npm run build` (tsc + vite) ✅
- `npm audit` → 0 vulnerabilities ✅
- `cargo build` / `cargo test --no-run` — run as part of the adversarial gate on this head.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VkKTPMauc6xjZZZSDVj4HF)_