### PR TITLE
chore(deps): nightly security audit 2026-08-08

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7407,9 +7407,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
Automated nightly security audit for 2026-08-08.

## Advisory resolved

| Advisory | Package | Change | Severity | Notes |
| --- | --- | --- | --- | --- |
| [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8) | `nanoid` | 3.3.16 → 3.3.18 | high | Custom generators can loop indefinitely when size is zero (CWE-835). Dev-only, transitive via `postcss` → `stylelint`. Patch bump within the existing `^3.3.16` range; **lockfile-only**, `package.json` unchanged. |

## Scope

Only `package-lock.json` is touched — a single `nanoid` block (version + resolved + integrity). No source, workflow, config, or `package.json` changes.

## Verification (run on this branch head)

- `npm audit --audit-level=high` → **0 vulnerabilities** (advisory absent, none new)
- `npm run build` → pass
- `cargo build` (`src-tauri/`) → pass
- `cargo test --no-run` (`src-tauri/`) → pass

## Not fixed this run (MANUAL, left for human review — no action taken)

- **RUSTSEC-2026-0235** `rkyv` 0.7.46 — patched only in 0.8.x (major). Pulled optionally by `rust_decimal` (via `byte-unit` → `tauri-plugin-log`); the `rkyv` feature is **not enabled**, so it is not in the compiled build graph. Not auto-fixable (major transitive bump gated upstream).
- **RUSTSEC-2026-0222** `wasmtime` 43.0.2 — CVSS vector `AV:L/AC:H/PR:H/UI:R` (low). Fix needs wasmtime 46.0.2+ (major); pinned transitively by `extism`. Not auto-fixable.

This PR supersedes any prior `chore/sec-audit-*` PR (none were open this run) and is set to **auto-merge only after CI is fully green and the adversarial merge review passes 5/5**. On any red check, rejection, timeout, or uncertainty it will be left open for a human.

---
_Generated by [Claude Code](https://claude.ai/code/session_011AAwiJesBZ1YbYJZzeSQAx)_