### PR TITLE
chore(deps): nightly security audit 2026-08-19

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2390,9 +2390,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",


### PR DESCRIPTION
## Nightly security audit — 2026-08-19

Automated dependency audit (`cargo audit` + `npm audit`). One SAFE transitive upgrade applied.

### Applied (SAFE)

| Advisory | Crate | From → To | Type | Note |
| --- | --- | --- | --- | --- |
| [RUSTSEC-2026-0258](https://rustsec.org/advisories/RUSTSEC-2026-0258) | `h2` | 0.4.14 → 0.4.16 | patch | h2 unbounded empty DATA frames (DoS). Patched `>=0.4.16`. Transitive via `reqwest`/`hyper`. |

The diff is a single 2-line change to `src-tauri/Cargo.lock` (version + checksum). `h2`'s dependency set is unchanged between 0.4.14 and 0.4.16, so no other lockfile entries move.

**Verified locally:**
- `cargo audit` on this branch head: RUSTSEC-2026-0258 is **resolved**, and **no new advisory** appeared (remaining findings are the pre-existing MANUAL ones below).
- `npm run build` (frontend): passes.
- `cargo build` / `cargo test` are validated by CI (Tauri system libs aren't available in the audit runner).

### Not actioned (MANUAL — tracked separately, not in this PR)

| Advisory | Crate | Why skipped |
| --- | --- | --- |
| RUSTSEC-2026-0235 | `rkyv` 0.7.46 | Needs major bump to 0.8.17 (0.7 has no patch). Tracked in #314. |
| RUSTSEC-2026-0222 | `wasmtime` 43.0.2 | Patch requires major bump to ≥46.0.2 via `extism`. CVSS Low (AV:L/AC:H/PR:H). Not auto-upgradable. |

`npm audit`: **0 vulnerabilities.**

---

This PR supersedes any prior open `chore/sec-audit-*` PR (none were open tonight). Per the nightly routine it will **auto-merge only if** CI is fully green **and** an adversarial merge review passes 5/5 with no doubt; otherwise it is left open for human review.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lt15UHwPaX8kT2AdXhYsmk)_