### PR TITLE
fix(cask): expose bundled entracte CLI on PATH

### DIFF
--- a/Casks/entracte.rb
+++ b/Casks/entracte.rb
@@ -20,6 +20,7 @@ cask "entracte" do
   depends_on macos: ">= :big_sur"
 
   app "Entracte.app"
+  binary "#{appdir}/Entracte.app/Contents/MacOS/entracte"
 
   zap trash: [
     "~/Library/Application Support/io.drmowinckels.entracte",


### PR DESCRIPTION
@drmowinckels — nightly triage fix for #320, left **open for your review** (not merged).

Closes #320

## Root cause
The Homebrew cask ([`Casks/entracte.rb`](../blob/main/Casks/entracte.rb)) declared only `app "Entracte.app"` and had **no `binary` stanza**. The `app` stanza links the bundle into `/Applications` but never exposes the CLI that ships inside it, so after `brew install --cask` there is no `entracte` in the Homebrew prefix and the documented `entracte help` / `entracte pause 30m` commands fail with `command not found`.

The reporter confirmed the CLI itself is fine — it lives at `Entracte.app/Contents/MacOS/entracte` and runs when invoked by full path — and that a manual symlink into `$(brew --prefix)/bin` resolves it.

## What changed
One line added to the cask, immediately after `app`:

```ruby
binary "#{appdir}/Entracte.app/Contents/MacOS/entracte"
```

This is the canonical Homebrew idiom for a CLI bundled inside a `.app`: it symlinks the in-bundle binary into the Homebrew bin dir (e.g. `/opt/homebrew/bin/entracte`), so it lands on PATH on install and is removed on uninstall. The symlink points at the exact same in-place binary the reporter already ran successfully, so `@executable_path`-relative bundle resources resolve identically.

## Verification
- This is a **packaging-only change to a Homebrew cask** (`Casks/entracte.rb`), a macOS-only distribution artifact. It touches no Rust or TypeScript, so per AGENTS.md it is repo-housekeeping/packaging and outside the code-test gate — there is no unit-test surface for a Ruby cask in this repo, and `cargo`/`npm`/`knip`/`cspell` do not cover `.rb`.
- The stanza and its placement follow the Homebrew Cask Cookbook `binary`-inside-`.app` convention, and the target path is confirmed by the reporter's own `find` output in #320.
- **Not verified with an actual `brew install`** — this nightly runs on Linux and cask installation is macOS-only. Please confirm on a real macOS box (`brew reinstall --cask drmowinckels/entracte/entracte` from this branch, then `which entracte`) before merging.

## Residual risk
Low. The change is a single declarative symlink of a binary that already works standalone. Only caveat: if a future release renames the bundled binary, this path must track it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LeomAj7P2cLXZzYmPhyZMA)_