### PR TITLE
fix(lint): use as_chunks for the tray glyph pixel scan

### DIFF
--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -918,11 +918,12 @@ mod tests {
         let img = Image::from_bytes(TRAY_ICON_BYTES).unwrap();
         let out = outline_glyph_for_panels(img.rgba(), img.width(), img.height());
         assert_eq!(out.len(), img.rgba().len(), "dimensions must be preserved");
-        let has_fill = out
-            .chunks_exact(4)
+        let pixels = out.as_chunks::<4>().0;
+        let has_fill = pixels
+            .iter()
             .any(|p| p[3] > 0 && p[0] > 0xE0 && p[1] > 0xE0 && p[2] > 0xE0);
-        let has_outline = out
-            .chunks_exact(4)
+        let has_outline = pixels
+            .iter()
             .any(|p| p[3] == 255 && p[0] < 0x30 && p[1] < 0x30 && p[2] < 0x30);
         assert!(
             has_fill,


### PR DESCRIPTION
## Summary

Rust 1.98 stable added `clippy::chunks_exact_to_as_chunks`, which fires on the two constant-size `chunks_exact(4)` calls in `outline_for_panels_gives_real_glyph_both_fill_and_outline`. Because CI runs `-D clippy::all`, this fails the `rust` job on **all three OS matrix legs of every open PR** — #330 and #321 are both red purely for this reason, not for anything in their diffs.

Replaced with the suggested `as_chunks::<4>().0`, hoisted into a single `pixels` binding shared by both scans.

## Test plan

- `cargo clippy --all-targets` — clean
- `cargo test --lib tray::` — 14 passed, 0 failed

Local toolchain here is 1.95, which does not have the lint; the fix compiles on both since `slice::as_chunks` is stable well before 1.95.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0127sYVs4N6kKEnvoBRPHSKw