### PR TITLE
fix(overlay): read monitor geometry on the main thread (#333)

### DIFF
--- a/src-tauri/src/scheduler/overlay.rs
+++ b/src-tauri/src/scheduler/overlay.rs
@@ -276,6 +276,58 @@ fn monitor_rect(m: &tauri::Monitor) -> MonitorRect {
     }
 }
 
+/// How long to wait for the main thread to answer a geometry read before
+/// giving up. Generous enough to absorb a busy event loop, short enough
+/// that a wedged main thread degrades to "no overlay" rather than
+/// stalling the break loop indefinitely.
+#[cfg(not(test))]
+const GEOMETRY_READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
+
+/// Read the display layout **on the main thread** and hand back plain data.
+///
+/// `WryHandle::available_monitors` and `primary_monitor` reach straight into
+/// the event loop's `window_target` with no dispatch, and the `unsafe impl
+/// Send` that lets that type cross threads states its own precondition:
+/// "we ensure this type is only used on the main thread". Every caller of
+/// [`fire_break`] runs on a tokio worker (the scheduler run loop, the IPC
+/// handler, and the tray menu all go through `async_runtime::spawn`), so
+/// calling these directly races the GTK main loop on one X connection and
+/// aborts inside libxcb (#333).
+///
+/// Both reads share a single hop so the returned monitor list and primary
+/// come from one consistent snapshot.
+///
+/// Deliberately **not** extended to cover window creation: tauri-runtime-wry
+/// documents that `create_webview` "must be called from a separate thread,
+/// otherwise the channel will introduce a deadlock", so [`ensure_overlay`]
+/// must keep running on the caller's thread. `cursor_position` is left alone
+/// too — it already dispatches through the event loop.
+///
+/// Returns `None` if the main thread is unreachable or too slow, which
+/// degrades to "no overlay this time" rather than risking a hang.
+#[cfg(not(test))]
+fn read_display_geometry<R: Runtime>(
+    app: &AppHandle<R>,
+) -> Option<(Vec<tauri::Monitor>, Option<tauri::Monitor>)> {
+    let (tx, rx) = std::sync::mpsc::channel();
+    let handle = app.clone();
+    if let Err(e) = app.run_on_main_thread(move || {
+        let all = handle.available_monitors().unwrap_or_default();
+        let primary = handle.primary_monitor().ok().flatten();
+        let _ = tx.send((all, primary));
+    }) {
+        log::warn!("overlay: could not reach the main thread to read monitors: {e}");
+        return None;
+    }
+    match rx.recv_timeout(GEOMETRY_READ_TIMEOUT) {
+        Ok(snapshot) => Some(snapshot),
+        Err(e) => {
+            log::warn!("overlay: timed out reading monitors on the main thread: {e}");
+            None
+        }
+    }
+}
+
 fn select_overlay_monitors<R: Runtime>(
     app: &AppHandle<R>,
     placement: MonitorPlacement,
@@ -287,19 +339,15 @@ fn select_overlay_monitors<R: Runtime>(
     // exercised by unit tests — it relies on the e2e smoke run for coverage.
     // Treat edits below this line as unit-uncovered by design.
     #[cfg(test)]
-    let all: Vec<tauri::Monitor> = Vec::new();
+    let (all, primary_monitor): (Vec<tauri::Monitor>, Option<tauri::Monitor>) = (Vec::new(), None);
     #[cfg(not(test))]
-    let all = app.available_monitors().unwrap_or_default();
+    let (all, primary_monitor) = read_display_geometry(app).unwrap_or_default();
     if all.is_empty() {
         return Vec::new();
     }
     let rects: Vec<MonitorRect> = all.iter().map(monitor_rect).collect();
 
-    let primary = app
-        .primary_monitor()
-        .ok()
-        .flatten()
-        .and_then(|p| monitor_index_by_rect(&monitor_rect(&p), &rects));
+    let primary = primary_monitor.and_then(|p| monitor_index_by_rect(&monitor_rect(&p), &rects));
 
     let active = match placement {
         MonitorPlacement::Active => match app.cursor_position() {

--- a/src-tauri/src/scheduler/overlay.rs
+++ b/src-tauri/src/scheduler/overlay.rs
@@ -305,15 +305,22 @@ const GEOMETRY_READ_TIMEOUT: std::time::Duration = std::time::Duration::from_sec
 ///
 /// Returns `None` if the main thread is unreachable or too slow, which
 /// degrades to "no overlay this time" rather than risking a hang.
+/// Resolving the primary's *index* happens inside the hop too, so the
+/// caller receives only plain data and never re-touches a live handle.
 #[cfg(not(test))]
 fn read_display_geometry<R: Runtime>(
     app: &AppHandle<R>,
-) -> Option<(Vec<tauri::Monitor>, Option<tauri::Monitor>)> {
+) -> Option<(Vec<tauri::Monitor>, Option<usize>)> {
     let (tx, rx) = std::sync::mpsc::channel();
     let handle = app.clone();
     if let Err(e) = app.run_on_main_thread(move || {
         let all = handle.available_monitors().unwrap_or_default();
-        let primary = handle.primary_monitor().ok().flatten();
+        let rects: Vec<MonitorRect> = all.iter().map(monitor_rect).collect();
+        let primary = handle
+            .primary_monitor()
+            .ok()
+            .flatten()
+            .and_then(|p| monitor_index_by_rect(&monitor_rect(&p), &rects));
         let _ = tx.send((all, primary));
     }) {
         log::warn!("overlay: could not reach the main thread to read monitors: {e}");
@@ -335,19 +342,17 @@ fn select_overlay_monitors<R: Runtime>(
     // In unit tests the mock runtime's available_monitors() is unimplemented
     // and panics; return empty so fire_break can be called in tests without
     // opening windows. NOTE: under test `all` is always empty, so the
-    // monitor-selection logic below (rects/primary/active/pick) is not
-    // exercised by unit tests — it relies on the e2e smoke run for coverage.
+    // monitor-selection logic below (rects/active/pick) is not exercised by
+    // unit tests — it relies on the e2e smoke run for coverage.
     // Treat edits below this line as unit-uncovered by design.
     #[cfg(test)]
-    let (all, primary_monitor): (Vec<tauri::Monitor>, Option<tauri::Monitor>) = (Vec::new(), None);
+    let (all, primary): (Vec<tauri::Monitor>, Option<usize>) = (Vec::new(), None);
     #[cfg(not(test))]
-    let (all, primary_monitor) = read_display_geometry(app).unwrap_or_default();
+    let (all, primary) = read_display_geometry(app).unwrap_or_default();
     if all.is_empty() {
         return Vec::new();
     }
     let rects: Vec<MonitorRect> = all.iter().map(monitor_rect).collect();
-
-    let primary = primary_monitor.and_then(|p| monitor_index_by_rect(&monitor_rect(&p), &rects));
 
     let active = match placement {
         MonitorPlacement::Active => match app.cursor_position() {


### PR DESCRIPTION
Addresses #333. **Needs verification on a real Linux/X11 desktop before merging — see below.**

## Root cause

Read against the `tauri-runtime-wry 2.11.1` in our lockfile, in `impl<T: UserEvent> RuntimeHandle<T> for WryHandle<T>` — the impl an `AppHandle` dispatches to:

| Call | Implementation | Safe off-main-thread? |
| --- | --- | --- |
| `available_monitors()` | `self.context.main_thread.window_target.available_monitors()` | **No — direct, no dispatch** |
| `primary_monitor()` | `self.context.main_thread.window_target.primary_monitor()` | **No — direct, no dispatch** |
| `cursor_position()` | `event_loop_window_getter!(…)` | Yes |
| `create_webview()` | dispatches a message to the event loop | Yes |

The `unsafe impl Send` that lets that context cross threads carries its own precondition:

```rust
// SAFETY: we ensure this type is only used on the main thread.
unsafe impl<T: UserEvent> Send for DispatcherMainThreadContext<T> {}
```

We weren't upholding it. Every caller of `fire_break` runs on a tokio worker — the scheduler run loop (`scheduler/mod.rs:281`), the IPC handler (`ipc.rs:419`) and the tray menu (`tray.rs:262`) all go through `async_runtime::spawn` — so the two monitor reads raced the GTK main loop on a single X connection and aborted in libxcb. The `unsafe impl` is why this compiled silently rather than failing to build.

This is why it was never CI-only: `run_loop` is on a tokio worker too, so a real Linux user hit the same race on every scheduled break.

## The fix, and why it is scoped this narrowly

Both reads are marshalled through `run_on_main_thread` in a **single hop**, so the monitor list and the primary come from one consistent snapshot.

What is deliberately *not* changed:

- **Window creation stays on the calling thread.** `tauri-runtime-wry` documents directly above `create_webview` that it "must be called from a separate thread, otherwise the channel will introduce a deadlock". The intuitive fix — wrapping all of `fire_break` in `run_on_main_thread` — would trade an intermittent crash for a hard hang, with the failure signature of #196 / #226.
- **`cursor_position` is untouched** — already dispatched.

## Failure mode of the timeout

The read is bounded at 2s. On timeout it returns `None`, which lands in the **pre-existing** `shown == 0` branch that already logs `break … fired but NO overlay window could be shown — the break is invisible`. So a wedged main thread degrades to a loudly-logged missed break rather than stalling the break loop.

That bound is also the backstop against a future caller invoking this *from* the main thread: it would time out rather than deadlock. All current callers are tokio workers (verified above), so it should never fire in practice.

Trade-off worth stating plainly: this introduces a new (unlikely) missed-break path on **all** platforms in exchange for removing an unsound cross-thread read that was also present on all platforms — macOS's `NSScreen` is main-thread-only too, it just doesn't abort the way libxcb does. I judged upholding the documented API contract everywhere to be the right call over a `#[cfg(target_os = "linux")]` patch, but say the word if you'd rather confine it to Linux.

## Test plan — and its honest limits

- `cargo test --lib` — 1206 passed, 0 failed
- `cargo clippy --all-targets`, `cargo fmt --check` — clean

**No new unit test.** `read_display_geometry` is `#[cfg(not(test))]` and is a marshalling shim over `run_on_main_thread` + `available_monitors`, which are unimplemented/panicking under `MockRuntime` — there is no mockable surface. This is consistent with the pre-existing note at `overlay.rs:283` that `select_overlay_monitors` is unit-uncovered by design and relies on the e2e smoke run. Extracting the `Result → Option` mapping into a "testable" helper would be test theatre; it would prove nothing about the threading behaviour that is the entire point of the change.

**The real signal is the `smoke (ubuntu-22.04)` job.** It reproduced the abort three times running before this change. Several consecutive green runs here are the evidence that matters — and per #196 / #226, a `tauri dev` or packaged-`.app` run on an actual X11 desktop is the honest final confirmation, which I cannot do from macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0127sYVs4N6kKEnvoBRPHSKw
