### PR TITLE
chore(deps): nightly security audit 2026-09-10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8542,9 +8542,9 @@
       }
     },
     "node_modules/smol-toml": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
-      "integrity": "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.8.0.tgz",
+      "integrity": "sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {


### PR DESCRIPTION
Automated nightly dependency/security audit for 2026-09-10.

## Node (npm audit) — 1 advisory resolved

| Advisory | Package | Change | Severity |
| --- | --- | --- | --- |
| [GHSA-7w5x-hrqm-74c2](https://github.com/advisories/GHSA-7w5x-hrqm-74c2) | `smol-toml` | `1.6.1` → `1.8.0` | High (DoS via malformed TOML) |

- Patched upstream in `1.7.1`; bumped to the current `1.8.0`.
- `smol-toml` is a **dev-only transitive** dependency (via `knip` and `cspell-config-lib`, both of which require `^1.6.1`), so this is a **minor, in-range, lockfile-only** change — `package-lock.json` is the only file touched.
- `npm audit` reports **0 vulnerabilities** after the bump.

## Rust (cargo audit) — nothing auto-fixable tonight

3 vulnerabilities were found; all require **major** bumps blocked behind upstream crates, so none are in the automated SAFE (patch/minor) tier. All are already tracked:

- RUSTSEC-2026-0269 / RUSTSEC-2026-0222 (`wasmtime` via `extism`) → tracked in #323
- RUSTSEC-2026-0235 (`rkyv` via `rust_decimal`) → tracked in #314

No new security issues were opened (both are duplicates of existing open issues).

## Merge policy

This PR supersedes any prior `chore/sec-audit-*` PR (none were open tonight). It is set to **auto-merge only after CI is fully green AND a 5/5 adversarial merge review passes with no doubt**. On any red check, any rejection, any timeout, or any uncertainty, it is left OPEN for a human instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SNpQYXwwXFeEjcgTYwrqg3

---
_Generated by [Claude Code](https://claude.ai/code/session_01SNpQYXwwXFeEjcgTYwrqg3)_